### PR TITLE
feat(e2e): call the real server by canonical action ID on every surface

### DIFF
--- a/test/e2e/internal/harness/call.go
+++ b/test/e2e/internal/harness/call.go
@@ -1,0 +1,575 @@
+//go:build e2e
+
+// call.go is how a test asks a server to run an action.
+//
+// A test names a canonical action ID and the parameters; which tool that is,
+// and what the arguments look like around them, is the projection's business.
+// The verbs differ only in what they do with the answer: Do decodes it and
+// fails the test if anything went wrong, Try hands both back, Refused asserts
+// that a named class of refusal happened, and Eventually keeps asking until a
+// predicate holds.
+//
+// Three things are checked before a call is sent, because each of them
+// produces a failure that reads as something else once it has been sent. An ID
+// the catalog does not have looks like a tool error from the server. An action
+// above the tier the package declared looks like a permissions problem with
+// the instance. An action this session does not serve looks like the server
+// forgetting to register it, when the session was configured not to have it.
+
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil/e2ecalls"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Purpose says what a call was made for. A call made to build or tear down
+// fixture state is worth less as coverage than one a test asserted on, so it
+// is recorded rather than guessed at from the test name.
+type Purpose string
+
+// The four purposes, spelled as the shard record spells them.
+const (
+	// PurposeTest is a call the test body made and asserted on.
+	PurposeTest Purpose = e2ecalls.PurposeTest
+	// PurposeCleanup is a call made from a cleanup, after the test body.
+	PurposeCleanup Purpose = e2ecalls.PurposeCleanup
+	// PurposeSweep is a call made by a sweep over what a session serves.
+	PurposeSweep Purpose = e2ecalls.PurposeSweep
+	// PurposeRaw is a call made through Raw, where the protocol rather than
+	// the action is what the test is about.
+	PurposeRaw Purpose = e2ecalls.PurposeRaw
+)
+
+// String returns the purpose as a record spells it.
+func (p Purpose) String() string { return string(p) }
+
+// Failure is a class of unhappy answer a test can ask for by name.
+//
+// The classes are the server's own vocabulary wherever it has one: four of
+// them are the refusal reasons the dispatchers log, so a test asking for
+// FailureNeedsConfirmation is asking for exactly what the server counts under
+// that name rather than for a string that happens to appear in a message.
+type Failure string
+
+// The failure classes. Anything a test expects that is not plain success is
+// one of these, and the name is what the call record carries as its
+// expectation.
+const (
+	// FailureToolError is an error result the classes below do not name: the
+	// action ran and GitLab or the handler refused it.
+	FailureToolError Failure = "tool_error"
+	// FailureUnknownAction is a dispatcher told to run an action it has no
+	// route for, which is also what a withheld action answers.
+	FailureUnknownAction Failure = Failure(toolutil.RefusalUnknownAction)
+	// FailureInvalidParams is a call whose arguments the dispatcher rejected
+	// before any handler ran.
+	FailureInvalidParams Failure = Failure(toolutil.RefusalInvalidParams)
+	// FailureNeedsConfirmation is a destructive action refused for want of an
+	// explicit confirmation.
+	FailureNeedsConfirmation Failure = Failure(toolutil.RefusalNeedsConfirmation)
+	// FailureSafeMode is a mutating action answered with a preview of itself.
+	FailureSafeMode Failure = Failure(toolutil.RefusalSafeMode)
+	// FailureNotFound is GitLab answering 404 for the object named.
+	FailureNotFound Failure = "not_found"
+	// FailureForbidden is GitLab answering 401 or 403 for the credential used.
+	FailureForbidden Failure = "forbidden"
+	// FailureProtocolError is a JSON-RPC error rather than a tool result: the
+	// call never became a tool outcome at all.
+	FailureProtocolError Failure = "protocol_error"
+)
+
+// String returns the class as a record spells it.
+func (f Failure) String() string { return string(f) }
+
+// callOptions is what the options a caller passed add up to.
+type callOptions struct {
+	purpose Purpose
+	confirm bool
+	timeout time.Duration
+}
+
+// CallOption adjusts one call.
+type CallOption func(*callOptions)
+
+// For declares what a call was made for. Without it a call is PurposeTest.
+func For(purpose Purpose) CallOption {
+	return func(o *callOptions) { o.purpose = purpose }
+}
+
+// WithoutConfirmation sends a destructive action with no explicit approval,
+// which is how a test sees the refusal a client that cannot prompt is given.
+// It changes nothing for an action that is not destructive.
+func WithoutConfirmation() CallOption {
+	return func(o *callOptions) { o.confirm = false }
+}
+
+// Within bounds one call, for an action whose own timeout is longer than the
+// test is willing to wait.
+func Within(timeout time.Duration) CallOption {
+	return func(o *callOptions) { o.timeout = timeout }
+}
+
+// resolveCallOptions applies the caller's options over the defaults: a test
+// call, confirmed if destructive, bounded by the test's own context.
+func resolveCallOptions(opts []CallOption) callOptions {
+	resolved := callOptions{purpose: PurposeTest, confirm: true}
+	for _, opt := range opts {
+		opt(&resolved)
+	}
+	return resolved
+}
+
+// callResult is one answer, classified.
+type callResult struct {
+	// result is what the server returned, nil when nothing came back.
+	result *mcp.CallToolResult
+	// outcome is one of the e2ecalls Outcome constants, or a refusal spelled
+	// with its reason.
+	outcome string
+	// failure is the class an unhappy answer falls into, empty on success.
+	failure Failure
+	// text is the first text content block, which is where every refusal this
+	// server makes puts its reason.
+	text string
+	// duration is how long the call took.
+	duration time.Duration
+	// err is the transport or protocol error, nil when the server answered.
+	err error
+}
+
+// ok reports whether the server ran the action and reported no failure.
+func (r callResult) ok() bool { return r.err == nil && r.failure == "" }
+
+// describe is the one-line summary a failed assertion carries. The elapsed
+// time is part of it because the two failures that look alike in a log, a
+// refusal and a timeout, are told apart by it.
+func (r callResult) describe() string {
+	if r.err != nil {
+		return fmt.Sprintf("%s after %s: %v", r.outcome, r.duration.Round(time.Millisecond), r.err)
+	}
+	if r.text != "" {
+		return fmt.Sprintf("%s after %s: %s", r.outcome, r.duration.Round(time.Millisecond), firstLines(r.text, 6))
+	}
+	return fmt.Sprintf("%s after %s", r.outcome, r.duration.Round(time.Millisecond))
+}
+
+// callRetries is how many times a call that failed in transit is sent again.
+// A Docker GitLab under the load of a whole suite drops connections, and the
+// old suite retried four times for the same reason.
+const callRetries = 4
+
+// callRetryDelay is the step the delay between attempts grows by.
+const callRetryDelay = 500 * time.Millisecond
+
+// Do runs an action and decodes its answer, failing the test if the server did
+// not run it.
+func Do[O any](s *Session, id ActionID, params map[string]any, opts ...CallOption) O {
+	s.env.T.Helper()
+
+	var output O
+	resolved := resolveCallOptions(opts)
+	answer := s.invoke(id, params, resolved)
+	if !answer.ok() {
+		s.env.T.Fatalf("%s: %s%s", callLabel(id, resolved), answer.describe(), s.conn.failureContext())
+		return output
+	}
+	if err := decodeResult(answer.result, &output); err != nil {
+		s.env.T.Fatalf("%s: %v", callLabel(id, resolved), err)
+	}
+	return output
+}
+
+// DoVoid runs an action whose answer the test does not read, failing the test
+// if the server did not run it.
+func DoVoid(s *Session, id ActionID, params map[string]any, opts ...CallOption) {
+	s.env.T.Helper()
+
+	resolved := resolveCallOptions(opts)
+	answer := s.invoke(id, params, resolved)
+	if !answer.ok() {
+		s.env.T.Fatalf("%s: %s%s", callLabel(id, resolved), answer.describe(), s.conn.failureContext())
+	}
+}
+
+// Try runs an action and hands back both halves, for a test whose subject is
+// the failure itself rather than a named class of it.
+func Try[O any](s *Session, id ActionID, params map[string]any, opts ...CallOption) (O, error) {
+	s.env.T.Helper()
+
+	var output O
+	answer := s.invoke(id, params, resolveCallOptions(opts))
+	if !answer.ok() {
+		return output, errors.New(answer.describe())
+	}
+	if err := decodeResult(answer.result, &output); err != nil {
+		return output, err
+	}
+	return output, nil
+}
+
+// Refused asserts that the server declined the call in the named class, and
+// returns what it said so a test can assert on the wording it promises.
+func Refused(s *Session, id ActionID, params map[string]any, want Failure, opts ...CallOption) string {
+	s.env.T.Helper()
+
+	resolved := resolveCallOptions(opts)
+	answer := s.invoke(id, params, resolved)
+	if answer.failure == "" {
+		s.env.T.Fatalf("%s: the server ran the action, and the test expected it to be refused as %s",
+			callLabel(id, resolved), want)
+		return ""
+	}
+	if answer.failure != want {
+		s.env.T.Fatalf("%s: refused as %s, and the test expected %s: %s",
+			callLabel(id, resolved), answer.failure, want, firstLines(answer.text, 6))
+	}
+	return answer.text
+}
+
+// ExpectToolError asserts that the call came back as a tool error whose text
+// carries the given substring.
+//
+// It is separate from Refused because the class is the same for every one of
+// them: what distinguishes a GitLab refusal a test cares about is the message,
+// and asserting on that message is the whole point of the call.
+func ExpectToolError(s *Session, id ActionID, params map[string]any, contains string, opts ...CallOption) string {
+	s.env.T.Helper()
+
+	resolved := resolveCallOptions(opts)
+	answer := s.invoke(id, params, resolved)
+	if answer.failure == "" {
+		s.env.T.Fatalf("%s: the server ran the action, and the test expected an error mentioning %q",
+			callLabel(id, resolved), contains)
+		return ""
+	}
+	if !strings.Contains(strings.ToLower(answer.text), strings.ToLower(contains)) {
+		s.env.T.Fatalf("%s: the error does not mention %q: %s",
+			callLabel(id, resolved), contains, firstLines(answer.text, 6))
+	}
+	return answer.text
+}
+
+// Eventually runs an action until the predicate accepts its answer, or the
+// timeout runs out.
+//
+// GitLab makes a great deal of what this server asks for asynchronously: a
+// merge request becomes mergeable, a pipeline leaves created, a project finishes
+// importing. The predicate is what a test says it is waiting for, and the
+// failure names the last answer rather than only the timeout.
+func Eventually[O any](
+	s *Session,
+	id ActionID,
+	params map[string]any,
+	interval, timeout time.Duration,
+	until func(O) bool,
+	opts ...CallOption,
+) O {
+	s.env.T.Helper()
+
+	var output O
+	resolved := resolveCallOptions(opts)
+	err := Poll(s.env.Ctx, interval, timeout, func() (bool, string, error) {
+		answer := s.invoke(id, params, resolved)
+		if !answer.ok() {
+			// A failed read is worth waiting through: the object a test is
+			// waiting for often does not exist yet when the first call is made.
+			return false, answer.describe(), nil
+		}
+		var current O
+		if decodeErr := decodeResult(answer.result, &current); decodeErr != nil {
+			return false, "", decodeErr
+		}
+		if !until(current) {
+			return false, "the answer does not satisfy the condition yet", nil
+		}
+		output = current
+		return true, "", nil
+	})
+	if err != nil {
+		s.env.T.Fatalf("waiting for %s: %v%s", callLabel(id, resolved), err, s.conn.failureContext())
+	}
+	return output
+}
+
+// callLabel names a call in a failure message: the action, and the purpose
+// when it is not an ordinary test call. A failure inside a cleanup reads
+// differently from one in the test body, and the message should say which.
+func callLabel(id ActionID, opts callOptions) string {
+	if opts.purpose == PurposeTest || opts.purpose == "" {
+		return string(id)
+	}
+	return fmt.Sprintf("%s (%s)", id, opts.purpose)
+}
+
+// invoke resolves the action onto this session's surface and sends it.
+func (s *Session) invoke(id ActionID, params map[string]any, opts callOptions) callResult {
+	s.env.T.Helper()
+
+	call, err := s.resolve(id, params, opts.confirm)
+	if err != nil {
+		s.env.T.Fatalf("%v", err)
+		return callResult{}
+	}
+	return s.send(call, opts)
+}
+
+// resolve turns an action ID into the call this session takes, refusing the
+// three cases that would otherwise be sent and misread.
+func (s *Session) resolve(id ActionID, params map[string]any, confirm bool) (toolCall, error) {
+	inst := s.conn.inst
+	projected, err := newProjection(inst.facts.Tier, inst.client.IsGitLabDotCom())
+	if err != nil {
+		return toolCall{}, err
+	}
+	action, known := projected.lookup(id)
+	if !known {
+		return toolCall{}, fmt.Errorf("no action %s in the catalog this instance serves (tier %s)", id, inst.facts.Tier)
+	}
+	if ceiling := inst.actionTierCeiling(); !ceiling.AtLeast(action.minimumTier) {
+		return toolCall{}, fmt.Errorf("action %s needs %s, and the %s package runs on %s: move the scenario to a "+
+			"package whose requirement provides it", id, action.minimumTier, inst.pkg, ceiling)
+	}
+	// The projection first, because it knows the surface's own reason: an
+	// action whose individual tool name a sibling owns is unservable for that
+	// reason and not because a mode removed it, and the session's action set
+	// cannot tell the two apart.
+	call, err := action.callOn(s.Surface(), params, confirm)
+	if err != nil {
+		return toolCall{}, err
+	}
+	if !s.Serves(id) {
+		return toolCall{}, fmt.Errorf("the %s session does not serve %s: the %s mode, the credential's scopes or the "+
+			"operator's exclusions removed it", s.Surface(), id, s.Mode())
+	}
+	return call, nil
+}
+
+// send makes the call, retrying what failed in transit.
+func (s *Session) send(call toolCall, opts callOptions) callResult {
+	ctx := s.env.Ctx
+	if opts.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.timeout)
+		defer cancel()
+	}
+
+	var answer callResult
+	for attempt := range callRetries {
+		started := time.Now()
+		result, err := s.conn.client().CallTool(ctx, &mcp.CallToolParams{Name: call.tool, Arguments: call.arguments})
+		answer = classify(result, err)
+		answer.duration = time.Since(started)
+
+		if answer.err == nil || !retryable(answer, s.conn) || attempt == callRetries-1 {
+			return answer
+		}
+		// A child that died takes its pipe with it, so reconnecting is the
+		// only thing that can make the next attempt different.
+		if !s.conn.alive() {
+			if restartErr := s.conn.restart(); restartErr != nil {
+				return answer
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return answer
+		case <-time.After(time.Duration(attempt+1) * callRetryDelay):
+		}
+	}
+	return answer
+}
+
+// retryable reports whether an answer is worth sending again: a connection
+// GitLab or the child dropped, and nothing else. A tool error is an answer.
+func retryable(answer callResult, conn *sessionConn) bool {
+	if answer.err == nil {
+		return false
+	}
+	if !conn.alive() {
+		return true
+	}
+	message := answer.err.Error()
+	for _, transient := range []string{"EOF", "connection reset by peer", "broken pipe", "connection refused"} {
+		if strings.Contains(message, transient) {
+			return true
+		}
+	}
+	return false
+}
+
+// classify reads one answer into the vocabulary the record and the assertions
+// share.
+func classify(result *mcp.CallToolResult, err error) callResult {
+	if err != nil {
+		answer := callResult{err: err, failure: FailureProtocolError, outcome: e2ecalls.OutcomeProtocolError}
+		if isTransportError(err) {
+			answer.outcome = e2ecalls.OutcomeTransportError
+		}
+		return answer
+	}
+	if result == nil {
+		return callResult{
+			err:     errors.New("the server answered with no result and no error"),
+			failure: FailureProtocolError,
+			outcome: e2ecalls.OutcomeProtocolError,
+		}
+	}
+
+	answer := callResult{result: result, text: resultText(result), outcome: e2ecalls.OutcomeOK}
+	if preview, isPreview := safeModePreview(result, answer.text); isPreview {
+		answer.outcome = e2ecalls.OutcomePreview
+		answer.failure = FailureSafeMode
+		answer.text = preview
+		return answer
+	}
+	if !result.IsError {
+		return answer
+	}
+	answer.failure = classifyToolError(answer.text)
+	if answer.failure == FailureToolError {
+		answer.outcome = e2ecalls.OutcomeToolError
+		return answer
+	}
+	answer.outcome = e2ecalls.RefusedOutcome(string(answer.failure))
+	return answer
+}
+
+// isTransportError reports whether the call never reached a handler at all.
+func isTransportError(err error) bool {
+	message := err.Error()
+	for _, transient := range []string{"EOF", "connection reset by peer", "broken pipe", "connection refused", "file already closed"} {
+		if strings.Contains(message, transient) {
+			return true
+		}
+	}
+	return false
+}
+
+// safeModePreview reports whether a result is a safe-mode preview, and returns
+// the name of the action it previewed.
+//
+// Both shapes are read, because the surfaces answer differently: the
+// dispatchers return the preview as structured content, and the individual
+// surface returns the card. Reading only one of them would classify half the
+// previews as ordinary successes.
+func safeModePreview(result *mcp.CallToolResult, text string) (string, bool) {
+	if result.StructuredContent != nil {
+		encoded, err := json.Marshal(result.StructuredContent)
+		if err == nil {
+			var preview toolutil.SafeModePreview
+			if json.Unmarshal(encoded, &preview) == nil && preview.Status == "blocked" && preview.Mode == "safe" {
+				return "safe mode blocked " + preview.Tool, true
+			}
+		}
+	}
+	if preview, isPreview := toolutil.ParseSafeModePreview(text); isPreview {
+		return "safe mode blocked " + preview.Tool, true
+	}
+	return "", false
+}
+
+// classifyToolError names the class an error result falls into, from the text
+// the server put in it.
+//
+// The markers are the server's own wording. Reading them is a compromise the
+// alternative does not improve on: the refusal reason is on the span rather
+// than in the result, so the only thing a client holds at the moment it has to
+// classify is the message, and a test that named no class at all could not
+// tell a refused confirmation from a 404.
+func classifyToolError(text string) Failure {
+	lowered := strings.ToLower(text)
+	switch {
+	case strings.Contains(lowered, "re-send with confirm=true"):
+		return FailureNeedsConfirmation
+	case strings.Contains(lowered, "unknown action"):
+		return FailureUnknownAction
+	case strings.Contains(lowered, "is required for this action"),
+		strings.Contains(lowered, "missing required params"),
+		strings.Contains(lowered, "'action' is required"):
+		return FailureInvalidParams
+	case strings.Contains(lowered, "404"), strings.Contains(lowered, "not found"):
+		return FailureNotFound
+	case strings.Contains(lowered, "403"), strings.Contains(lowered, "401"),
+		strings.Contains(lowered, "forbidden"), strings.Contains(lowered, "unauthorized"):
+		return FailureForbidden
+	default:
+		return FailureToolError
+	}
+}
+
+// resultText returns the first text block of a result, which is where every
+// message this server writes for a person or a model ends up.
+func resultText(result *mcp.CallToolResult) string {
+	for _, content := range result.Content {
+		if text, isText := content.(*mcp.TextContent); isText {
+			return text.Text
+		}
+	}
+	return ""
+}
+
+// decodeResult reads a tool result into the output type, preferring the
+// structured content and falling back to the text block.
+//
+// The fallback is not theoretical: a tool whose output schema the SDK could
+// not derive answers with text alone, and a decoder that only read structured
+// content would report an empty object for it.
+func decodeResult(result *mcp.CallToolResult, output any) error {
+	if result == nil {
+		return errors.New("no result to decode")
+	}
+	if result.StructuredContent != nil {
+		encoded, err := json.Marshal(result.StructuredContent)
+		if err != nil {
+			return fmt.Errorf("re-encoding the structured content: %w", err)
+		}
+		if err = json.Unmarshal(encoded, output); err != nil {
+			return fmt.Errorf("decoding the structured content into %T: %w", output, err)
+		}
+		return nil
+	}
+	text := resultText(result)
+	if text == "" {
+		return fmt.Errorf("the result carries neither structured content nor text to decode into %T", output)
+	}
+	if err := json.Unmarshal([]byte(text), output); err != nil {
+		return fmt.Errorf("decoding the text result into %T: %w", output, err)
+	}
+	return nil
+}
+
+// actionTierCeiling is the highest tier an action may need for this package to
+// be allowed to call it.
+//
+// A package that declares no license runs Free actions only, whatever the
+// instance turns out to be. That is the runtime half of the rule the static
+// gate enforces: an action above Free named in the common or ce package would
+// pass on a licensed instance and fail on an unlicensed one, and a suite whose
+// result depends on which runtime happened to run it is not a gate.
+func (inst *instance) actionTierCeiling() edition.Tier {
+	if inst.requirement == Licensed {
+		return inst.facts.Tier
+	}
+	return edition.Free
+}
+
+// firstLines returns at most n lines of text, for a failure message that has
+// to carry a server's answer without burying its own first line.
+func firstLines(text string, n int) string {
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n")
+	}
+	return strings.Join(lines[:n], "\n") + fmt.Sprintf("\n... (%d more lines)", len(lines)-n)
+}

--- a/test/e2e/internal/harness/call_test.go
+++ b/test/e2e/internal/harness/call_test.go
@@ -1,0 +1,386 @@
+//go:build e2e
+
+// call_test.go covers what a test learns from an answer: which class of
+// failure it was, what the answer decodes into, and when a call is worth
+// sending again.
+//
+// The classification is the part worth pinning hardest. A refusal reaches the
+// client as text, so the only thing that separates a destructive call refused
+// for want of a confirmation from a plain 404 is what the server wrote, and a
+// harness that classified both as "tool error" would let a test assert the
+// wrong refusal and pass.
+
+package harness
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil/e2ecalls"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// errorResult builds the shape every refusal this server makes arrives in: an
+// error result whose first text block carries the reason.
+func errorResult(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: text}}}
+}
+
+// TestClassify_EveryRefusal_LandsInItsOwnClass pins how an answer is read.
+//
+// The markers are the server's own wording, so each case here is a sentence
+// the product writes: the confirmation guard's instruction, the dispatcher's
+// unknown-action message, its missing-parameter message, and GitLab's own
+// statuses.
+func TestClassify_EveryRefusal_LandsInItsOwnClass(t *testing.T) {
+	cases := []struct {
+		name        string
+		text        string
+		wantFailure Failure
+		wantOutcome string
+	}{
+		{
+			name:        "needs confirmation",
+			text:        "Confirm gitlab_project_delete? This action may be irreversible. The connected client cannot prompt for confirmation. Re-send with confirm=true only after the user explicitly approves this operation.",
+			wantFailure: FailureNeedsConfirmation,
+			wantOutcome: e2ecalls.RefusedOutcome(toolutil.RefusalNeedsConfirmation),
+		},
+		{
+			name:        "unknown action",
+			text:        `gitlab_issue: unknown action "explode". Valid actions: create, get, list`,
+			wantFailure: FailureUnknownAction,
+			wantOutcome: e2ecalls.RefusedOutcome(toolutil.RefusalUnknownAction),
+		},
+		{
+			name:        "missing params",
+			text:        "gitlab_issue/get: missing required params: project_id, issue_iid. Put action-specific fields under params.",
+			wantFailure: FailureInvalidParams,
+			wantOutcome: e2ecalls.RefusedOutcome(toolutil.RefusalInvalidParams),
+		},
+		{
+			name:        "params required",
+			text:        "gitlab_issue/get: 'params' is required for this action. Required params: project_id.",
+			wantFailure: FailureInvalidParams,
+			wantOutcome: e2ecalls.RefusedOutcome(toolutil.RefusalInvalidParams),
+		},
+		{
+			name:        "not found",
+			text:        "get issue: 404 Not Found",
+			wantFailure: FailureNotFound,
+			wantOutcome: e2ecalls.RefusedOutcome(string(FailureNotFound)),
+		},
+		{
+			name:        "forbidden",
+			text:        "delete project: 403 Forbidden",
+			wantFailure: FailureForbidden,
+			wantOutcome: e2ecalls.RefusedOutcome(string(FailureForbidden)),
+		},
+		{
+			name:        "anything else",
+			text:        "create branch: branch already exists",
+			wantFailure: FailureToolError,
+			wantOutcome: e2ecalls.OutcomeToolError,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			answer := classify(errorResult(testCase.text), nil)
+
+			if answer.failure != testCase.wantFailure {
+				t.Errorf("failure = %q, want %q", answer.failure, testCase.wantFailure)
+			}
+			if answer.outcome != testCase.wantOutcome {
+				t.Errorf("outcome = %q, want %q", answer.outcome, testCase.wantOutcome)
+			}
+			if answer.ok() {
+				t.Error("a refused call reports itself as having run")
+			}
+		})
+	}
+}
+
+// TestClassify_Success_IsOk checks that an ordinary answer is not classified
+// as anything.
+func TestClassify_Success_IsOk(t *testing.T) {
+	answer := classify(&mcp.CallToolResult{StructuredContent: map[string]any{"id": 1}}, nil)
+
+	if !answer.ok() {
+		t.Fatalf("a successful call was classified %q: %s", answer.outcome, answer.describe())
+	}
+	if answer.outcome != e2ecalls.OutcomeOK {
+		t.Errorf("outcome = %q, want %q", answer.outcome, e2ecalls.OutcomeOK)
+	}
+}
+
+// TestClassify_SafeModePreview_IsAPreviewOnBothSurfaceShapes checks that a
+// blocked mutation is recognized however the surface answered it.
+//
+// The dispatchers answer with the preview as structured content and the
+// individual surface answers with the card. A classifier that read one of them
+// would count half the previews as ordinary successes, which is the worst
+// possible answer: the test would believe the mutation happened.
+func TestClassify_SafeModePreview_IsAPreviewOnBothSurfaceShapes(t *testing.T) {
+	preview := toolutil.NewSafeModePreview("project.delete", map[string]any{"project_id": 7})
+	structured := map[string]any{}
+	encoded, err := json.Marshal(preview)
+	if err != nil {
+		t.Fatalf("encoding the preview: %v", err)
+	}
+	if err = json.Unmarshal(encoded, &structured); err != nil {
+		t.Fatalf("decoding the preview into a map: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		result *mcp.CallToolResult
+	}{
+		{
+			name:   "structured, as the dispatchers answer",
+			result: &mcp.CallToolResult{StructuredContent: structured},
+		},
+		{
+			name: "card, as the individual surface answers",
+			result: &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: toolutil.FormatSafeModePreviewMarkdown(preview)}},
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			answer := classify(testCase.result, nil)
+
+			if answer.failure != FailureSafeMode {
+				t.Errorf("failure = %q, want %q", answer.failure, FailureSafeMode)
+			}
+			if answer.outcome != e2ecalls.OutcomePreview {
+				t.Errorf("outcome = %q, want %q", answer.outcome, e2ecalls.OutcomePreview)
+			}
+			if !strings.Contains(answer.text, "project.delete") {
+				t.Errorf("the preview does not name the action it blocked: %q", answer.text)
+			}
+		})
+	}
+}
+
+// TestClassify_NoAnswer_IsAProtocolOrTransportFailure checks the two ways a
+// call comes back without being a tool outcome at all.
+//
+// They are kept apart because they mean different things: a JSON-RPC error is
+// the server answering, and a dropped connection is the server or GitLab
+// having gone away, which is the only one worth sending again.
+func TestClassify_NoAnswer_IsAProtocolOrTransportFailure(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		result      *mcp.CallToolResult
+		wantOutcome string
+	}{
+		{name: "json-rpc error", err: errors.New("method not found"), wantOutcome: e2ecalls.OutcomeProtocolError},
+		{name: "dropped connection", err: errors.New("write |1: broken pipe"), wantOutcome: e2ecalls.OutcomeTransportError},
+		{name: "nothing at all", wantOutcome: e2ecalls.OutcomeProtocolError},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			answer := classify(testCase.result, testCase.err)
+
+			if answer.outcome != testCase.wantOutcome {
+				t.Errorf("outcome = %q, want %q", answer.outcome, testCase.wantOutcome)
+			}
+			if answer.failure != FailureProtocolError {
+				t.Errorf("failure = %q, want %q", answer.failure, FailureProtocolError)
+			}
+			if answer.err == nil {
+				t.Error("an answer that never arrived carries no error")
+			}
+		})
+	}
+}
+
+// TestDecodeResult_StructuredFirstThenText pins the decoding order.
+//
+// The fallback is not theoretical: a tool whose output schema the SDK could
+// not derive answers with text alone, and a decoder that read only structured
+// content would hand the test an empty object and no error.
+func TestDecodeResult_StructuredFirstThenText(t *testing.T) {
+	type answer struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	cases := []struct {
+		name   string
+		result *mcp.CallToolResult
+		want   answer
+	}{
+		{
+			name:   "structured content",
+			result: &mcp.CallToolResult{StructuredContent: map[string]any{"id": 7, "name": "from structured"}},
+			want:   answer{ID: 7, Name: "from structured"},
+		},
+		{
+			name:   "text fallback",
+			result: &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: `{"id":9,"name":"from text"}`}}},
+			want:   answer{ID: 9, Name: "from text"},
+		},
+		{
+			name: "structured wins over text",
+			result: &mcp.CallToolResult{
+				StructuredContent: map[string]any{"id": 1, "name": "structured"},
+				Content:           []mcp.Content{&mcp.TextContent{Text: `{"id":2,"name":"text"}`}},
+			},
+			want: answer{ID: 1, Name: "structured"},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var decoded answer
+			if err := decodeResult(testCase.result, &decoded); err != nil {
+				t.Fatalf("decodeResult() error = %v", err)
+			}
+			if decoded != testCase.want {
+				t.Errorf("decoded %+v, want %+v", decoded, testCase.want)
+			}
+		})
+	}
+}
+
+// TestDecodeResult_NothingToDecode_IsReported checks that an answer carrying
+// neither shape fails rather than leaving the test with a zero value.
+func TestDecodeResult_NothingToDecode_IsReported(t *testing.T) {
+	cases := []struct {
+		name   string
+		result *mcp.CallToolResult
+	}{
+		{name: "no result", result: nil},
+		{name: "no content", result: &mcp.CallToolResult{}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var decoded map[string]any
+			if err := decodeResult(testCase.result, &decoded); err == nil {
+				t.Fatal("decodeResult() accepted a result with nothing in it")
+			}
+		})
+	}
+}
+
+// TestResolveCallOptions_DefaultsAndOverrides pins what a call is when nobody
+// says otherwise, and what each option changes.
+func TestResolveCallOptions_DefaultsAndOverrides(t *testing.T) {
+	defaults := resolveCallOptions(nil)
+	if defaults.purpose != PurposeTest {
+		t.Errorf("purpose = %q, want %q", defaults.purpose, PurposeTest)
+	}
+	if !defaults.confirm {
+		t.Error("a destructive call is unconfirmed by default, and the server then fails closed on every one of them")
+	}
+
+	overridden := resolveCallOptions([]CallOption{For(PurposeCleanup), WithoutConfirmation(), Within(time.Second)})
+	if overridden.purpose != PurposeCleanup {
+		t.Errorf("purpose = %q, want %q", overridden.purpose, PurposeCleanup)
+	}
+	if overridden.confirm {
+		t.Error("WithoutConfirmation() left the confirmation on")
+	}
+	if overridden.timeout != time.Second {
+		t.Errorf("timeout = %s, want 1s", overridden.timeout)
+	}
+}
+
+// TestCallLabel_NamesThePurposeWhenItIsNotATestCall checks that a failure
+// inside a cleanup says so, since a cleanup failing reads very differently
+// from the test body failing.
+func TestCallLabel_NamesThePurposeWhenItIsNotATestCall(t *testing.T) {
+	cases := []struct {
+		name    string
+		purpose Purpose
+		want    string
+	}{
+		{name: "test", purpose: PurposeTest, want: "issue.delete"},
+		{name: "cleanup", purpose: PurposeCleanup, want: "issue.delete (cleanup)"},
+		{name: "sweep", purpose: PurposeSweep, want: "issue.delete (sweep)"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			label := callLabel("issue.delete", callOptions{purpose: testCase.purpose})
+			if label != testCase.want {
+				t.Errorf("callLabel() = %q, want %q", label, testCase.want)
+			}
+		})
+	}
+}
+
+// TestActionTierCeiling_FollowsThePackagesRequirement pins the ceiling a call
+// is checked against.
+//
+// A package that declared no license runs Free actions only, whatever the
+// instance turns out to be; a licensed package runs up to whatever the
+// instance is licensed for.
+func TestActionTierCeiling_FollowsThePackagesRequirement(t *testing.T) {
+	cases := []struct {
+		name        string
+		requirement Requirement
+		tier        edition.Tier
+		want        edition.Tier
+	}{
+		{name: "any on a licensed instance", requirement: Any, tier: edition.Ultimate, want: edition.Free},
+		{name: "free", requirement: Free, tier: edition.Free, want: edition.Free},
+		{name: "licensed premium", requirement: Licensed, tier: edition.Premium, want: edition.Premium},
+		{name: "licensed ultimate", requirement: Licensed, tier: edition.Ultimate, want: edition.Ultimate},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			inst := &instance{requirement: testCase.requirement, facts: runtimeFacts{Tier: testCase.tier}}
+			if ceiling := inst.actionTierCeiling(); ceiling != testCase.want {
+				t.Errorf("actionTierCeiling() = %s, want %s", ceiling, testCase.want)
+			}
+		})
+	}
+}
+
+// TestFirstLines_TruncatesAndSaysSo checks that a server's answer can be
+// quoted in a failure without burying the assertion that failed.
+func TestFirstLines_TruncatesAndSaysSo(t *testing.T) {
+	short := firstLines("one\ntwo", 6)
+	if short != "one\ntwo" {
+		t.Errorf("firstLines() = %q, want the whole text", short)
+	}
+
+	long := firstLines(strings.Repeat("line\n", 20), 3)
+	if strings.Count(long, "\n") > 3 {
+		t.Errorf("firstLines() kept %d lines, want 3 plus the note", strings.Count(long, "\n"))
+	}
+	if !strings.Contains(long, "more lines") {
+		t.Errorf("firstLines() truncated without saying so: %q", long)
+	}
+}
+
+// TestIsTransportError_OnlyTheDroppedConnections checks which errors are read
+// as the connection having gone away.
+func TestIsTransportError_OnlyTheDroppedConnections(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "eof", err: errors.New("unexpected EOF"), want: true},
+		{name: "reset", err: errors.New("read tcp: connection reset by peer"), want: true},
+		{name: "broken pipe", err: errors.New("write: broken pipe"), want: true},
+		{name: "refused", err: errors.New("dial tcp: connection refused"), want: true},
+		{name: "closed file", err: errors.New("file already closed"), want: true},
+		{name: "method not found", err: errors.New("method not found"), want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := isTransportError(testCase.err); got != testCase.want {
+				t.Errorf("isTransportError(%v) = %t, want %t", testCase.err, got, testCase.want)
+			}
+		})
+	}
+}

--- a/test/e2e/internal/harness/env.go
+++ b/test/e2e/internal/harness/env.go
@@ -53,8 +53,18 @@ type Env struct {
 // changed anything.
 func New(t *testing.T, opts ...Option) *Env {
 	t.Helper()
+	return newEnv(t, bootstrap(t), opts...)
+}
 
-	inst := bootstrap(t)
+// newEnv prepares one test's Env against an instance the caller already
+// resolved.
+//
+// It is split from New so that the harness's own tests, which drive the real
+// binary against a stub GitLab, can build an Env without the package-wide
+// bootstrap a real run goes through. Everything a test observes is here; New
+// is the resolution of the instance and nothing else.
+func newEnv(t *testing.T, inst *instance, opts ...Option) *Env {
+	t.Helper()
 
 	var options envOptions
 	for _, opt := range opts {

--- a/test/e2e/internal/harness/main.go
+++ b/test/e2e/internal/harness/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,6 +125,10 @@ func Main(m *testing.M, req Requirement) int {
 
 	code := m.Run()
 
+	// Before the binary is removed, and in this order: on Windows a running
+	// executable cannot be deleted, so a child left alive would leave the
+	// build behind on every run.
+	closeSessions()
 	removeBuiltBinary()
 	return state.finish(code)
 }
@@ -257,6 +262,18 @@ type settings struct {
 
 // get returns one setting, or the empty string.
 func (s settings) get(key string) string { return s.values[key] }
+
+// with returns a copy of the settings carrying one different value.
+//
+// A copy rather than an assignment, because a session given its own credential
+// must not change the credential every other session inherits: the map is
+// shared by every reader of the run's configuration.
+func (s settings) with(key, value string) settings {
+	values := make(map[string]string, len(s.values)+1)
+	maps.Copy(values, s.values)
+	values[key] = value
+	return settings{values: values}
+}
 
 // loadSettings resolves the run's configuration, highest precedence first: the
 // process environment, the file E2E_ENV_FILE names, test/e2e/.env.docker in

--- a/test/e2e/internal/harness/project.go
+++ b/test/e2e/internal/harness/project.go
@@ -1,0 +1,267 @@
+//go:build e2e
+
+// project.go turns one canonical action ID into the call each surface spells
+// for it.
+//
+// A test names an action once, as the catalog names it, and the harness works
+// out what to send: gitlab_execute_action with the ID on the dynamic surface,
+// the domain tool with the operation in its action argument on meta, and the
+// declared tool name on individual. That last one is why this file reads the
+// catalog rather than a formula: an individual tool name is declared per
+// ActionSpec, a large legacy set is verb-first, and no string transformation
+// recovers one from an ID.
+//
+// It also answers which actions a surface cannot reach at all, which matters
+// more than it sounds. Several actions declare one individual tool name, and
+// registration binds that name to the first of them; the others are then
+// unservable on that surface, and a test that called the name anyway would
+// exercise a different action and pass. The same goes for an action declaring
+// no individual tool at all.
+
+package harness
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/config"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	gitlabtools "github.com/jmrplens/gitlab-mcp-server/v3/internal/tools"
+	dynamictools "github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/dynamic"
+)
+
+// ActionID is a canonical catalog action identifier, such as issue.list.
+//
+// It is a named type rather than a string so that the push-time static gate
+// can find every ID a test names, follow it through helper parameters, and
+// check it against the catalog. A bare string literal would be invisible to
+// that gate, which is the whole reason a test never writes a tool name.
+type ActionID string
+
+// String returns the identifier as the catalog spells it.
+func (id ActionID) String() string { return string(id) }
+
+// Surface is one of the three tool surfaces the binary can serve.
+type Surface string
+
+// The three surfaces, spelled as the binary's own GITLAB_MCP_TOOL_SURFACE
+// values so that a session's configuration is the variable it sets.
+const (
+	// SurfaceDynamic is the default two-tool find and execute surface.
+	SurfaceDynamic Surface = config.ToolSurfaceDynamic
+	// SurfaceMeta is the domain dispatcher surface.
+	SurfaceMeta Surface = config.ToolSurfaceMeta
+	// SurfaceIndividual is one registered tool per action.
+	SurfaceIndividual Surface = config.ToolSurfaceIndividual
+)
+
+// String returns the surface as the environment variable spells it.
+func (s Surface) String() string { return string(s) }
+
+// AllSurfaces lists the three surfaces in the order a subtest runs them:
+// dynamic first, because it is what a client gets by default and so the one a
+// failure matters most on.
+func AllSurfaces() []Surface {
+	return []Surface{SurfaceDynamic, SurfaceMeta, SurfaceIndividual}
+}
+
+// projectedAction is everything the harness needs to call one catalog action
+// on any surface, plus what it needs to refuse the call before sending it.
+type projectedAction struct {
+	// id is the canonical catalog identifier.
+	id ActionID
+	// domain is the catalog domain, the half of the ID before the dot.
+	domain string
+	// metaTool is the domain tool the meta surface registers.
+	metaTool string
+	// metaAction is the operation name that tool's action argument takes.
+	metaAction string
+	// individualTool is the declared individual tool name, empty when this
+	// action cannot be reached on that surface.
+	individualTool string
+	// individualOwner names the action the declared name is bound to when it
+	// is bound to another one, so a refusal can say who took it.
+	individualOwner string
+	// destructive says the action asks for a confirmation before it runs.
+	destructive bool
+	// readOnly is the action's own classification, before the individual
+	// surface's narrowing overrides.
+	readOnly bool
+	// minimumTier is the licensing tier the action needs, read from the
+	// catalog's Edition annotation.
+	minimumTier edition.Tier
+}
+
+// projection is one instance's reading of the catalog: every action it serves,
+// projected onto the three surfaces.
+type projection struct {
+	tier    edition.Tier
+	actions map[ActionID]projectedAction
+}
+
+// projectionKey names one built projection. The tier decides which actions
+// exist and how their schemas are pruned; the instance class decides whether
+// the GitLab.com-only actions are among them.
+type projectionKey struct {
+	tier   edition.Tier
+	dotcom bool
+}
+
+// projections holds one projection per key. Building it walks the whole
+// catalog, which is the expensive part of a session start, and every session
+// of one run asks for the same one.
+var projections sync.Map // projectionKey -> *projectionEntry
+
+// projectionEntry is one cached projection, built by the first caller while
+// every concurrent caller for the same key waits.
+type projectionEntry struct {
+	once sync.Once
+	made *projection
+	err  error
+}
+
+// newProjection returns the projection for a tier and instance class, building
+// it on first use from the same shared base catalog the binary registers from.
+func newProjection(tier edition.Tier, dotcom bool) (*projection, error) {
+	loaded, _ := projections.LoadOrStore(projectionKey{tier: tier, dotcom: dotcom}, &projectionEntry{})
+	entry, _ := loaded.(*projectionEntry)
+	entry.once.Do(func() {
+		entry.made, entry.err = buildProjection(tier, dotcom)
+	})
+	return entry.made, entry.err
+}
+
+// buildProjection reads the catalog once and records what each surface calls
+// every action.
+//
+// IncludeMCP is set because the binary sets it: without it the gitlab_server
+// diagnostics group is absent, and a test naming server.status would be told
+// the catalog has no such action when the server serves it.
+func buildProjection(tier edition.Tier, dotcom bool) (*projection, error) {
+	catalog, err := gitlabtools.SharedBaseCatalog(dotcom, gitlabtools.ActionCatalogOptions{Tier: tier, IncludeMCP: true})
+	if err != nil {
+		return nil, fmt.Errorf("build the base catalog at tier %s: %w", tier, err)
+	}
+
+	// The identifier is the one reader that knows which action a declared
+	// individual tool name is registered for. Asking it, rather than trusting
+	// the name on each action, is what makes a shadowed sibling unservable
+	// here instead of silently calling somebody else's handler.
+	identify := gitlabtools.NewCallIdentifier(catalog, config.ToolSurfaceIndividual)
+
+	made := &projection{tier: tier, actions: make(map[ActionID]projectedAction, catalog.CountActions())}
+	for _, action := range catalog.Actions() {
+		projected := projectedAction{
+			id:          ActionID(action.ID),
+			domain:      action.Domain,
+			metaTool:    action.ToolName,
+			metaAction:  action.Name,
+			destructive: action.Destructive,
+			readOnly:    action.ReadOnly,
+			minimumTier: edition.TierFromEdition(action.Edition),
+		}
+		if name := strings.TrimSpace(action.IndividualTool.Name); name != "" {
+			if identity, known := identify.Identify(name, nil); known && identity.ActionID == string(action.ID) {
+				projected.individualTool = name
+			} else if known {
+				projected.individualOwner = identity.ActionID
+			}
+		}
+		made.actions[projected.id] = projected
+	}
+	return made, nil
+}
+
+// lookup returns the projection of one action, and whether the catalog this
+// run serves has it at all.
+func (p *projection) lookup(id ActionID) (projectedAction, bool) {
+	action, found := p.actions[id]
+	return action, found
+}
+
+// toolCall is one tools/call: the tool to name and the arguments to send.
+type toolCall struct {
+	// tool is the registered tool name.
+	tool string
+	// arguments is the argument object, as the surface's own tool takes it.
+	arguments map[string]any
+	// argumentNames are the top-level argument names, for the record. The
+	// values are deliberately left out of it: a value is a fixture, a name is
+	// part of the call.
+	argumentNames []string
+}
+
+// confirmArgument is the field every surface reads an explicit approval of a
+// destructive action from. On dynamic it is top level, beside the action and
+// its params; on the other two it travels with the action's own parameters.
+const confirmArgument = "confirm"
+
+// callOn spells the call this action takes on one surface.
+//
+// A destructive action always carries the confirmation, because the harness is
+// not a person and the server fails closed without one: the alternative is
+// GITLAB_MCP_YOLO_MODE in the child, which the launcher refuses to pass for
+// the reason stated there. A test that wants to see the refusal asks for it
+// explicitly instead, through Refused.
+func (a projectedAction) callOn(surface Surface, params map[string]any, confirm bool) (toolCall, error) {
+	arguments := make(map[string]any, len(params)+1)
+	maps.Copy(arguments, params)
+	if confirm && a.destructive {
+		arguments[confirmArgument] = true
+	}
+
+	switch surface {
+	case SurfaceDynamic:
+		call := map[string]any{"action": string(a.id), "params": paramsObject(params)}
+		if confirm && a.destructive {
+			// Top level here, and only here: the execute tool's own schema
+			// says so, and a confirm inside params is read as a parameter of
+			// the action rather than as an approval.
+			call[confirmArgument] = true
+		}
+		return toolCall{tool: dynamictools.ExecuteActionToolName, arguments: call, argumentNames: argumentNames(call)}, nil
+	case SurfaceMeta:
+		if a.metaTool == "" || a.metaAction == "" {
+			return toolCall{}, fmt.Errorf("action %s declares no meta tool and action pair", a.id)
+		}
+		call := map[string]any{"action": a.metaAction}
+		if len(arguments) > 0 {
+			call["params"] = arguments
+		}
+		return toolCall{tool: a.metaTool, arguments: call, argumentNames: argumentNames(call)}, nil
+	case SurfaceIndividual:
+		if a.individualTool == "" {
+			return toolCall{}, a.unservableOnIndividual()
+		}
+		return toolCall{tool: a.individualTool, arguments: arguments, argumentNames: argumentNames(arguments)}, nil
+	default:
+		return toolCall{}, fmt.Errorf("unknown surface %q", surface)
+	}
+}
+
+// unservableOnIndividual says why this action cannot be called on the
+// individual surface, naming the sibling that took its tool name when one did.
+func (a projectedAction) unservableOnIndividual() error {
+	if a.individualOwner != "" {
+		return fmt.Errorf("action %s is not servable on the individual surface: the tool name it declares is "+
+			"registered for %s, which is the first action to declare it", a.id, a.individualOwner)
+	}
+	return fmt.Errorf("action %s is not servable on the individual surface: it declares no individual tool", a.id)
+}
+
+// paramsObject returns the params object the dynamic execute tool takes, which
+// is required and must be an object even when the action needs nothing.
+func paramsObject(params map[string]any) map[string]any {
+	if params == nil {
+		return map[string]any{}
+	}
+	return params
+}
+
+// argumentNames returns the sorted top-level argument names of a call.
+func argumentNames(arguments map[string]any) []string {
+	return slices.Sorted(maps.Keys(arguments))
+}

--- a/test/e2e/internal/harness/project_test.go
+++ b/test/e2e/internal/harness/project_test.go
@@ -1,0 +1,308 @@
+//go:build e2e
+
+// project_test.go covers the projection: what each surface calls an action,
+// and which actions a surface cannot reach at all.
+//
+// It runs against the real catalog rather than a fixture, because the thing
+// worth pinning is the relationship between a canonical ID and the three
+// spellings the product gives it, and a fixture would pin a relationship this
+// package invented.
+
+package harness
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	dynamictools "github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/dynamic"
+)
+
+// freeProjection returns the projection a Free self-managed instance serves,
+// which is the catalog every one of these assertions is about.
+func freeProjection(t *testing.T) *projection {
+	t.Helper()
+
+	made, err := newProjection(edition.Free, false)
+	if err != nil {
+		t.Fatalf("building the projection: %v", err)
+	}
+	return made
+}
+
+// TestProjection_OneActionOnEverySurface_SpellsTheSurfacesOwnCall pins what a
+// test naming one canonical ID actually sends on each of the three surfaces.
+//
+// The three spellings are genuinely different, and the individual one is
+// declared rather than derived: gitlab_issue_list is domain-first,
+// gitlab_server_status is a diagnostics tool outside the GitLab API, and a
+// large legacy set is verb-first. A projection that guessed would send a tool
+// name no surface registers and the failure would read as a missing tool.
+func TestProjection_OneActionOnEverySurface_SpellsTheSurfacesOwnCall(t *testing.T) {
+	made := freeProjection(t)
+
+	cases := []struct {
+		name           string
+		id             ActionID
+		metaTool       string
+		metaAction     string
+		individualTool string
+	}{
+		{name: "issue list", id: "issue.list", metaTool: "gitlab_issue", metaAction: "list", individualTool: "gitlab_issue_list"},
+		{name: "project get", id: "project.get", metaTool: "gitlab_project", metaAction: "get", individualTool: "gitlab_project_get"},
+		{name: "branch create", id: "branch.create", metaTool: "gitlab_branch", metaAction: "create", individualTool: "gitlab_branch_create"},
+		{name: "server status", id: "server.status", metaTool: "gitlab_server", metaAction: "status", individualTool: "gitlab_server_status"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			action, known := made.lookup(testCase.id)
+			if !known {
+				t.Fatalf("the Free catalog has no action %s", testCase.id)
+			}
+
+			assertDynamicCall(t, action)
+			assertMetaCall(t, action, testCase.metaTool, testCase.metaAction)
+			assertIndividualCall(t, action, testCase.individualTool)
+		})
+	}
+}
+
+// projectionParams are the parameters every projection assertion sends, so the
+// three checks below differ only in where they expect to find them.
+var projectionParams = map[string]any{"project_id": "group/project"}
+
+// assertDynamicCall checks the call the default surface spells: the execute
+// tool, the canonical ID in the action argument, and the parameters in an
+// object under params.
+func assertDynamicCall(t *testing.T, action projectedAction) {
+	t.Helper()
+
+	call, err := action.callOn(SurfaceDynamic, projectionParams, false)
+	if err != nil {
+		t.Fatalf("projecting %s onto the dynamic surface: %v", action.id, err)
+	}
+	if call.tool != dynamictools.ExecuteActionToolName {
+		t.Errorf("dynamic tool = %q, want %q", call.tool, dynamictools.ExecuteActionToolName)
+	}
+	if call.arguments["action"] != string(action.id) {
+		t.Errorf("dynamic action argument = %v, want %s", call.arguments["action"], action.id)
+	}
+	params, isObject := call.arguments["params"].(map[string]any)
+	if !isObject || params["project_id"] != "group/project" {
+		t.Errorf("dynamic params = %v, want the caller's parameters in an object", call.arguments["params"])
+	}
+}
+
+// assertMetaCall checks the call the meta surface spells: the domain tool,
+// with the operation in its action argument.
+func assertMetaCall(t *testing.T, action projectedAction, wantTool, wantAction string) {
+	t.Helper()
+
+	call, err := action.callOn(SurfaceMeta, projectionParams, false)
+	if err != nil {
+		t.Fatalf("projecting %s onto the meta surface: %v", action.id, err)
+	}
+	if call.tool != wantTool || call.arguments["action"] != wantAction {
+		t.Errorf("meta call = %s/%v, want %s/%s", call.tool, call.arguments["action"], wantTool, wantAction)
+	}
+}
+
+// assertIndividualCall checks the call the individual surface spells: the
+// declared tool name, with the parameters at the top level.
+func assertIndividualCall(t *testing.T, action projectedAction, wantTool string) {
+	t.Helper()
+
+	call, err := action.callOn(SurfaceIndividual, projectionParams, false)
+	if err != nil {
+		t.Fatalf("projecting %s onto the individual surface: %v", action.id, err)
+	}
+	if call.tool != wantTool {
+		t.Errorf("individual tool = %q, want %q", call.tool, wantTool)
+	}
+	if call.arguments["project_id"] != "group/project" {
+		t.Errorf("individual arguments = %v, want the parameters at the top level", call.arguments)
+	}
+}
+
+// TestProjection_ShadowedIndividualName_IsUnservableAndNamesTheOwner is the
+// case the projection exists for.
+//
+// repository.file_history and repository.commit_list both declare
+// gitlab_commit_list, and registration binds the name to whichever comes
+// first. A harness that sent the name for either would run one action while
+// claiming to have run the other, and the test would pass. So the second one
+// is unservable here, and the refusal says who owns the name.
+func TestProjection_ShadowedIndividualName_IsUnservableAndNamesTheOwner(t *testing.T) {
+	made := freeProjection(t)
+
+	action, known := made.lookup("repository.file_history")
+	if !known {
+		t.Fatal("the Free catalog has no repository.file_history")
+	}
+
+	_, err := action.callOn(SurfaceIndividual, nil, false)
+	if err == nil {
+		t.Fatal("repository.file_history projected onto an individual tool, and gitlab_commit_list belongs to another action")
+	}
+	if !strings.Contains(err.Error(), "repository.commit_list") {
+		t.Errorf("the refusal does not name the action that owns the tool name: %v", err)
+	}
+
+	// The other two surfaces reach it, which is what makes the individual one
+	// a gap rather than the action being unreachable.
+	for _, surface := range []Surface{SurfaceDynamic, SurfaceMeta} {
+		t.Run(string(surface), func(t *testing.T) {
+			if _, projectErr := action.callOn(surface, nil, false); projectErr != nil {
+				t.Errorf("repository.file_history does not project onto %s: %v", surface, projectErr)
+			}
+		})
+	}
+}
+
+// TestProjection_ActionWithNoIndividualTool_IsUnservableThere covers the other
+// half of the same rule.
+//
+// server.health_check declares no individual tool name at all, so the
+// individual surface registers nothing for it. Saying so here is what keeps a
+// coverage report from counting it as reached on a surface that never served
+// it.
+func TestProjection_ActionWithNoIndividualTool_IsUnservableThere(t *testing.T) {
+	made := freeProjection(t)
+
+	action, known := made.lookup("server.health_check")
+	if !known {
+		t.Fatal("the Free catalog has no server.health_check; the projection is built without IncludeMCP")
+	}
+
+	_, err := action.callOn(SurfaceIndividual, nil, false)
+	if err == nil {
+		t.Fatal("server.health_check projected onto an individual tool, and it declares none")
+	}
+	if !strings.Contains(err.Error(), "declares no individual tool") {
+		t.Errorf("the refusal does not say why: %v", err)
+	}
+}
+
+// TestProjection_DestructiveAction_CarriesConfirmWhereItsSurfaceReadsIt pins
+// where each surface reads an explicit approval from.
+//
+// The dynamic execute tool reads it at the top level and says so in its own
+// schema; the other two read it from the action's parameters. A confirmation
+// put in the wrong place is not an error anywhere, it is simply not seen, and
+// the destructive call is then refused for want of one.
+func TestProjection_DestructiveAction_CarriesConfirmWhereItsSurfaceReadsIt(t *testing.T) {
+	made := freeProjection(t)
+
+	action, known := made.lookup("project.delete")
+	if !known {
+		t.Fatal("the Free catalog has no project.delete")
+	}
+	if !action.destructive {
+		t.Fatal("project.delete is not classified destructive, so this test is asserting nothing")
+	}
+
+	dynamic, err := action.callOn(SurfaceDynamic, map[string]any{"project_id": "group/project"}, true)
+	if err != nil {
+		t.Fatalf("projecting project.delete onto the dynamic surface: %v", err)
+	}
+	if dynamic.arguments[confirmArgument] != true {
+		t.Errorf("the dynamic call carries no top-level confirm: %v", dynamic.arguments)
+	}
+	if params, isObject := dynamic.arguments["params"].(map[string]any); isObject {
+		if _, inParams := params[confirmArgument]; inParams {
+			t.Errorf("the dynamic call also put confirm inside params, where the action reads it as a parameter: %v", params)
+		}
+	}
+
+	for _, surface := range []Surface{SurfaceMeta, SurfaceIndividual} {
+		t.Run(string(surface), func(t *testing.T) {
+			call, projectErr := action.callOn(surface, map[string]any{"project_id": "group/project"}, true)
+			if projectErr != nil {
+				t.Fatalf("projecting project.delete onto %s: %v", surface, projectErr)
+			}
+			params := call.arguments
+			if surface == SurfaceMeta {
+				nested, isObject := call.arguments["params"].(map[string]any)
+				if !isObject {
+					t.Fatalf("the meta call carries no params object: %v", call.arguments)
+				}
+				params = nested
+			}
+			if params[confirmArgument] != true {
+				t.Errorf("the %s call carries no confirm: %v", surface, params)
+			}
+		})
+	}
+}
+
+// TestProjection_WithoutConfirmation_SendsNone checks that an unconfirmed call
+// really is unconfirmed, which is what a test of the server's fail-closed
+// behavior stands on.
+func TestProjection_WithoutConfirmation_SendsNone(t *testing.T) {
+	made := freeProjection(t)
+
+	action, known := made.lookup("project.delete")
+	if !known {
+		t.Fatal("the Free catalog has no project.delete")
+	}
+
+	for _, surface := range AllSurfaces() {
+		t.Run(string(surface), func(t *testing.T) {
+			call, err := action.callOn(surface, map[string]any{"project_id": "group/project"}, false)
+			if err != nil {
+				t.Fatalf("projecting project.delete onto %s: %v", surface, err)
+			}
+			if slices.Contains(call.argumentNames, confirmArgument) {
+				t.Errorf("an unconfirmed %s call carries confirm: %v", surface, call.arguments)
+			}
+		})
+	}
+}
+
+// TestProjection_UnknownSurface_IsRefused checks that a surface nothing serves
+// is reported rather than treated as one of the three.
+func TestProjection_UnknownSurface_IsRefused(t *testing.T) {
+	made := freeProjection(t)
+
+	action, known := made.lookup("issue.list")
+	if !known {
+		t.Fatal("the Free catalog has no issue.list")
+	}
+
+	if _, err := action.callOn(Surface("http"), nil, false); err == nil {
+		t.Fatal("callOn accepted a surface the binary does not serve")
+	}
+}
+
+// TestProjection_TierDecidesWhatExists checks that the projection is built for
+// the tier it was asked for.
+//
+// An Ultimate-only action is absent from the Free catalog, which is how a call
+// to it from a package that declared no license fails with a message about the
+// catalog rather than with a 403 from GitLab twenty lines later.
+func TestProjection_TierDecidesWhatExists(t *testing.T) {
+	free := freeProjection(t)
+	ultimate, err := newProjection(edition.Ultimate, false)
+	if err != nil {
+		t.Fatalf("building the Ultimate projection: %v", err)
+	}
+
+	licensed := 0
+	for id, action := range ultimate.actions {
+		if action.minimumTier == edition.Free {
+			continue
+		}
+		licensed++
+		if _, known := free.lookup(id); known {
+			t.Errorf("%s needs %s and is in the Free catalog", id, action.minimumTier)
+		}
+	}
+	if licensed == 0 {
+		t.Fatal("the Ultimate catalog carries no action above Free, so this test asserts nothing")
+	}
+	if len(free.actions) >= len(ultimate.actions) {
+		t.Errorf("the Free catalog has %d actions and the Ultimate one %d, and Free is a subset",
+			len(free.actions), len(ultimate.actions))
+	}
+}

--- a/test/e2e/internal/harness/served.go
+++ b/test/e2e/internal/harness/served.go
@@ -1,0 +1,340 @@
+//go:build e2e
+
+// served.go asks, once per session, whether the server serves what the
+// server's own assemblers say it should.
+//
+// It is not a second implementation of the catalog. The expectation comes from
+// calling tools.SharedMetaCatalog, tools.SharedIndividualCatalog and
+// dynamiccatalog.Build with the config.ServerConfig the binary built for
+// itself: the probed tier, the credential's scopes after NarrowToTokenScope,
+// the protective mode and the operator's exclusions. What is reimplemented
+// here is only the last step each surface takes after the catalog is built,
+// which is registration, and each of those is a handful of lines.
+//
+// Why it exists: the thing a test cannot see is a tool that was never
+// registered. A suite whose sessions were assembled in-process was served five
+// catalog groups its own binary withholds for want of a scope, and every test
+// of those groups passed. Checking the set once, when a session starts, turns
+// that class into one failure that names the difference.
+
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	gitlabtools "github.com/jmrplens/gitlab-mcp-server/v3/internal/tools"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/actioncatalog"
+	dynamictools "github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/dynamic"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/dynamiccatalog"
+)
+
+// servedSets is what one session listed when it started.
+type servedSets struct {
+	// tools are the registered tool names.
+	tools []string
+	// resources are the static resource URIs.
+	resources []string
+	// templates are the resource URI templates.
+	templates []string
+	// prompts are the prompt names.
+	prompts []string
+	// actions are the catalog actions this session can reach, which is not a
+	// listing: it comes from the catalog the assemblers built.
+	actions map[ActionID]struct{}
+}
+
+// listServed reads the four listings a session publishes.
+//
+// The iterators are used rather than one call each, because a listing may be
+// paginated and a first page read as the whole set would make the served-set
+// check report every tool after it as missing.
+func listServed(ctx context.Context, session *mcp.ClientSession) (servedSets, error) {
+	var served servedSets
+
+	for tool, err := range session.Tools(ctx, nil) {
+		if err != nil {
+			return served, fmt.Errorf("tools/list: %w", err)
+		}
+		served.tools = append(served.tools, tool.Name)
+	}
+	for resource, err := range session.Resources(ctx, nil) {
+		if err != nil {
+			return served, fmt.Errorf("resources/list: %w", err)
+		}
+		served.resources = append(served.resources, resource.URI)
+	}
+	for template, err := range session.ResourceTemplates(ctx, nil) {
+		if err != nil {
+			return served, fmt.Errorf("resources/templates/list: %w", err)
+		}
+		served.templates = append(served.templates, template.URITemplate)
+	}
+	for prompt, err := range session.Prompts(ctx, nil) {
+		if err != nil {
+			return served, fmt.Errorf("prompts/list: %w", err)
+		}
+		served.prompts = append(served.prompts, prompt.Name)
+	}
+
+	slices.Sort(served.tools)
+	slices.Sort(served.resources)
+	slices.Sort(served.templates)
+	slices.Sort(served.prompts)
+	return served, nil
+}
+
+// surfaceExpectation is what one configuration should serve: the catalog-backed
+// tool names, and the actions those tools can reach.
+type surfaceExpectation struct {
+	// tools are the registered names the catalog accounts for, sorted.
+	tools []string
+	// actions are the catalog actions the surface can reach.
+	actions map[ActionID]struct{}
+	// standalone are the tool names registered outside the catalog, which the
+	// comparison ignores: they are pinned by behavior tests instead.
+	standalone []string
+}
+
+// expectedSurface asks the server's own assemblers what this configuration
+// serves.
+//
+// The client it builds the catalogs with is the harness's own. Binding rebuilds
+// the handlers for that client and touches nothing this reads, so the names and
+// the action IDs are the ones the binary's own catalog carries.
+func expectedSurface(inst *instance, cfg ServerConfig, scopes []string) (surfaceExpectation, error) {
+	serverCfg := serverConfigFor(inst, cfg, scopes)
+	client := inst.client
+	standalone := standaloneToolNames(client)
+
+	switch cfg.Surface {
+	case SurfaceDynamic:
+		catalog, _, err := dynamiccatalog.Build(client, serverCfg)
+		if err != nil {
+			return surfaceExpectation{}, fmt.Errorf("assemble the dynamic catalog: %w", err)
+		}
+		// The dynamic surface registers two tools whatever the catalog holds;
+		// the catalog decides which actions they reach, which is what the
+		// action set carries.
+		return surfaceExpectation{
+			tools:      []string{dynamictools.ExecuteActionToolName, dynamictools.FindActionToolName},
+			actions:    catalogActionIDs(catalog),
+			standalone: standalone,
+		}, nil
+	case SurfaceMeta:
+		catalog, _, err := gitlabtools.SharedMetaCatalog(client, serverCfg)
+		if err != nil {
+			return surfaceExpectation{}, fmt.Errorf("assemble the meta catalog: %w", err)
+		}
+		names := make([]string, 0, catalog.CountGroups())
+		for _, group := range catalog.Groups() {
+			names = append(names, group.ToolName)
+		}
+		slices.Sort(names)
+		return surfaceExpectation{tools: names, actions: catalogActionIDs(catalog), standalone: standalone}, nil
+	case SurfaceIndividual:
+		catalog, _, err := gitlabtools.SharedIndividualCatalog(client, serverCfg)
+		if err != nil {
+			return surfaceExpectation{}, fmt.Errorf("assemble the individual catalog: %w", err)
+		}
+		names, actions := individualRegistrations(catalog, serverCfg.ReadOnly)
+		return surfaceExpectation{tools: names, actions: actions, standalone: standalone}, nil
+	default:
+		return surfaceExpectation{}, fmt.Errorf("unknown tool surface %q", cfg.Surface)
+	}
+}
+
+// serverConfigFor builds the configuration the binary builds for itself from
+// the same inputs: what the environment said, what the probe found, and what
+// the credential can do.
+func serverConfigFor(inst *instance, cfg ServerConfig, scopes []string) *config.ServerConfig {
+	serverCfg := &config.ServerConfig{
+		GitLabURL:         inst.facts.URL,
+		ToolSurface:       string(cfg.Surface),
+		CapabilitySurface: string(cfg.Capabilities),
+		Tier:              inst.facts.Tier,
+		ReadOnly:          cfg.Mode == ModeReadOnly,
+		SafeMode:          cfg.Mode == ModeSafe,
+		ExcludeTools:      slices.Clone(cfg.ExcludeTools),
+		TokenScopes:       scopes,
+		MetaParamSchema:   config.DefaultMetaParamSchema,
+	}
+	// The same call the binary makes, in the same place: a credential that
+	// cannot write is served a read-only surface whatever the deployment
+	// asked for, and an expectation built without it would name write tools
+	// the server never registered.
+	gitlabclient.NarrowToTokenScope(serverCfg)
+	return serverCfg
+}
+
+// standaloneToolNames lists the tools registered outside the action catalog:
+// gitlab_discover_project and the gitlab_interactive_* flows.
+//
+// They are left out of the comparison rather than checked here because nothing
+// in the catalog accounts for them, so a comparison would be this file
+// restating the spec list to itself. Their presence is pinned by the behavior
+// tests that call them.
+func standaloneToolNames(client *gitlabclient.Client) []string {
+	specs := gitlabtools.StandaloneSurfaceToolSpecs(client)
+	names := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		names = append(names, spec.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// catalogActionIDs returns every action a catalog holds.
+func catalogActionIDs(catalog *actioncatalog.Catalog) map[ActionID]struct{} {
+	actions := make(map[ActionID]struct{}, catalog.CountActions())
+	for _, action := range catalog.Actions() {
+		actions[ActionID(action.ID)] = struct{}{}
+	}
+	return actions
+}
+
+// individualRegistrations replays what the individual surface registers from a
+// catalog: one tool per action that declares a name, the first declarer of a
+// name keeping it, and, in read-only mode, only the ones whose annotation says
+// they read.
+//
+// The read-only step is here rather than in the catalog because that is where
+// the binary does it: SharedIndividualCatalog applies the exclusions and the
+// credential's scopes, and read-only mode is applied afterwards, over the
+// registered tools, by the visibility pass.
+func individualRegistrations(catalog *actioncatalog.Catalog, readOnly bool) (names []string, actions map[ActionID]struct{}) {
+	names = make([]string, 0, catalog.CountActions())
+	actions = make(map[ActionID]struct{}, catalog.CountActions())
+	taken := make(map[string]struct{}, catalog.CountActions())
+
+	for _, group := range catalog.Groups() {
+		if !individualGroupRegistered(group) {
+			continue
+		}
+		for _, action := range group.ActionsInOrder() {
+			name := strings.TrimSpace(action.IndividualTool.Name)
+			if name == "" {
+				continue
+			}
+			if _, already := taken[name]; already {
+				continue
+			}
+			taken[name] = struct{}{}
+			if readOnly && !individualActionReadOnly(action) {
+				continue
+			}
+			names = append(names, name)
+			actions[ActionID(action.ID)] = struct{}{}
+		}
+	}
+	slices.Sort(names)
+	return names, actions
+}
+
+// individualGroupRegistered mirrors the group gate the individual surface
+// applies with standalone utilities included, which is how the binary calls it.
+// Only the dynamic controller group has no individual projection.
+func individualGroupRegistered(group actioncatalog.Group) bool {
+	switch group.SurfaceKind {
+	case actioncatalog.SurfaceKindGitLabAction, actioncatalog.SurfaceKindMetaGroup,
+		actioncatalog.SurfaceKindRuntimeUtility, actioncatalog.SurfaceKindInteractiveUtility:
+		return true
+	default:
+		return false
+	}
+}
+
+// individualActionReadOnly is the read-only bit the individual surface serves
+// as a tool's annotation: the action's own classification, narrowed by an
+// override that can only ever narrow it.
+func individualActionReadOnly(action actioncatalog.Action) bool {
+	readOnly := action.ReadOnly
+	overrides := action.IndividualTool.AnnotationOverrides.NarrowingOnly(action.ReadOnly, action.Idempotent)
+	if overrides.ReadOnly != nil {
+		readOnly = *overrides.ReadOnly
+	}
+	return readOnly
+}
+
+// missingDiffLimit is how many names each half of a difference report carries.
+// A surface can differ by a thousand names when something is wrong at the
+// catalog level, and a thousand-line failure hides the count that says so.
+const missingDiffLimit = 20
+
+// checkServedTools compares what a session listed with what the assemblers say
+// it should serve, ignoring the tools registered outside the catalog.
+func checkServedTools(surface Surface, served []string, expected surfaceExpectation) error {
+	standalone := make(map[string]struct{}, len(expected.standalone))
+	for _, name := range expected.standalone {
+		standalone[name] = struct{}{}
+	}
+
+	// Dropped from both sides, not only from what was served: the individual
+	// surface projects the standalone groups into tools of its own as well as
+	// registering them separately, so a name removed from one side and kept on
+	// the other would be reported as a difference by the filtering itself.
+	catalogBacked := withoutNames(served, standalone)
+	wanted := withoutNames(expected.tools, standalone)
+
+	missing := difference(wanted, catalogBacked)
+	unexpected := difference(catalogBacked, wanted)
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+
+	var report strings.Builder
+	fmt.Fprintf(&report, "the %s session does not serve what the catalog assemblers say it should:\n", surface)
+	fmt.Fprintf(&report, "  served %d catalog-backed tools, expected %d\n", len(catalogBacked), len(wanted))
+	writeNameList(&report, "expected and not served", missing)
+	writeNameList(&report, "served and not expected", unexpected)
+	report.WriteString("  standalone tools are excluded from this comparison: " + strings.Join(expected.standalone, ", "))
+	return errors.New(report.String())
+}
+
+// writeNameList adds one half of a difference to the report, truncated.
+func writeNameList(report *strings.Builder, heading string, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	shown := names
+	suffix := ""
+	if len(shown) > missingDiffLimit {
+		shown = shown[:missingDiffLimit]
+		suffix = fmt.Sprintf(" (and %d more)", len(names)-missingDiffLimit)
+	}
+	fmt.Fprintf(report, "  %s (%d): %s%s\n", heading, len(names), strings.Join(shown, ", "), suffix)
+}
+
+// withoutNames returns the names that are not in the given set.
+func withoutNames(names []string, excluded map[string]struct{}) []string {
+	kept := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, found := excluded[name]; !found {
+			kept = append(kept, name)
+		}
+	}
+	return kept
+}
+
+// difference returns the sorted names in a that are not in b.
+func difference(a, b []string) []string {
+	present := make(map[string]struct{}, len(b))
+	for _, name := range b {
+		present[name] = struct{}{}
+	}
+	var only []string
+	for _, name := range a {
+		if _, found := present[name]; !found {
+			only = append(only, name)
+		}
+	}
+	slices.Sort(only)
+	return slices.Compact(only)
+}

--- a/test/e2e/internal/harness/served_test.go
+++ b/test/e2e/internal/harness/served_test.go
@@ -1,0 +1,306 @@
+//go:build e2e
+
+// served_test.go covers the check that runs once when a session starts.
+//
+// Two halves. The comparison itself is pure and is tested with lists: what it
+// reports, what it ignores, and what it says when the two sides differ. The
+// expectation it compares against is built from the real assemblers, so the
+// assertions about it are about the rules registration applies after a catalog
+// is built rather than about a fixture.
+
+package harness
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	gitlabtools "github.com/jmrplens/gitlab-mcp-server/v3/internal/tools"
+)
+
+// TestCheckServedTools_TheSameSet_Passes checks the ordinary case: a session
+// serving what the assemblers say it should is accepted.
+func TestCheckServedTools_TheSameSet_Passes(t *testing.T) {
+	expected := surfaceExpectation{
+		tools:      []string{"gitlab_issue", "gitlab_project"},
+		standalone: []string{"gitlab_discover_project"},
+	}
+
+	err := checkServedTools(SurfaceMeta, []string{"gitlab_discover_project", "gitlab_issue", "gitlab_project"}, expected)
+	if err != nil {
+		t.Fatalf("checkServedTools() = %v, want nil", err)
+	}
+}
+
+// TestCheckServedTools_Differences_AreReportedBothWays checks that the report
+// names what is missing and what is extra.
+//
+// Both halves matter and they mean different things: a tool the assemblers
+// expect and the server did not register is a tool no test can reach, and one
+// the server registered that the assemblers do not know about is a tool
+// nothing in the catalog accounts for.
+func TestCheckServedTools_Differences_AreReportedBothWays(t *testing.T) {
+	expected := surfaceExpectation{tools: []string{"gitlab_issue", "gitlab_admin"}}
+
+	err := checkServedTools(SurfaceMeta, []string{"gitlab_issue", "gitlab_surprise"}, expected)
+
+	if err == nil {
+		t.Fatal("checkServedTools() accepted two different sets")
+	}
+	for _, want := range []string{"gitlab_admin", "gitlab_surprise", "expected and not served", "served and not expected"} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("the report does not mention %q:\n%v", want, err)
+			}
+		})
+	}
+}
+
+// TestCheckServedTools_StandaloneNames_AreIgnoredOnBothSides checks that the
+// tools registered outside the catalog are left out of the comparison whether
+// they were served, expected, or both.
+//
+// Both sides, because the individual surface projects the standalone groups
+// into tools of its own as well as registering them separately: removing them
+// from one side alone would make the filtering itself the difference.
+func TestCheckServedTools_StandaloneNames_AreIgnoredOnBothSides(t *testing.T) {
+	expected := surfaceExpectation{
+		tools:      []string{"gitlab_issue", "gitlab_discover_project"},
+		standalone: []string{"gitlab_discover_project", "gitlab_interactive_issue_create"},
+	}
+
+	err := checkServedTools(SurfaceIndividual, []string{"gitlab_issue", "gitlab_interactive_issue_create"}, expected)
+	if err != nil {
+		t.Fatalf("checkServedTools() = %v, want the standalone names ignored on both sides", err)
+	}
+}
+
+// TestCheckServedTools_ManyDifferences_AreTruncated checks that a session
+// differing wholesale reports a count rather than a thousand names.
+func TestCheckServedTools_ManyDifferences_AreTruncated(t *testing.T) {
+	expected := surfaceExpectation{}
+	served := make([]string, 0, missingDiffLimit*3)
+	for i := range missingDiffLimit * 3 {
+		served = append(served, "gitlab_tool_"+string(rune('a'+i%26))+string(rune('a'+i/26)))
+	}
+
+	err := checkServedTools(SurfaceIndividual, served, expected)
+
+	if err == nil {
+		t.Fatal("checkServedTools() accepted a session serving tools nothing expected")
+	}
+	if !strings.Contains(err.Error(), "more)") {
+		t.Errorf("a difference of %d names was not truncated:\n%v", len(served), err)
+	}
+}
+
+// TestDifference_ReportsOnlyWhatIsMissingAndDeduplicates pins the set helper
+// the report is built on.
+func TestDifference_ReportsOnlyWhatIsMissingAndDeduplicates(t *testing.T) {
+	cases := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{name: "nothing missing", a: []string{"one", "two"}, b: []string{"two", "one"}, want: nil},
+		{name: "one missing", a: []string{"one", "two"}, b: []string{"one"}, want: []string{"two"}},
+		{name: "duplicates collapse", a: []string{"two", "two"}, b: []string{"one"}, want: []string{"two"}},
+		{name: "empty b", a: []string{"one"}, b: nil, want: []string{"one"}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := difference(testCase.a, testCase.b); !slices.Equal(got, testCase.want) {
+				t.Errorf("difference(%v, %v) = %v, want %v", testCase.a, testCase.b, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestExpectedSurface_EachSurface_NamesWhatItRegisters checks the three
+// assembler calls against what each surface actually registers.
+//
+// The dynamic surface registers two tools whatever the catalog holds, the meta
+// surface one per group, and the individual surface one per action that
+// declares a name. Getting any of those wrong would make every session of that
+// surface abort with a difference that is the harness's own.
+func TestExpectedSurface_EachSurface_NamesWhatItRegisters(t *testing.T) {
+	inst := stubInstance(t)
+
+	cases := []struct {
+		name    string
+		surface Surface
+		check   func(*testing.T, surfaceExpectation)
+	}{
+		{
+			name:    "dynamic",
+			surface: SurfaceDynamic,
+			check: func(t *testing.T, expected surfaceExpectation) {
+				t.Helper()
+				if len(expected.tools) != 2 {
+					t.Errorf("the dynamic surface expects %v, want the two find and execute tools", expected.tools)
+				}
+				if _, found := expected.actions["issue.list"]; !found {
+					t.Error("the dynamic catalog does not carry issue.list")
+				}
+			},
+		},
+		{
+			name:    "meta",
+			surface: SurfaceMeta,
+			check: func(t *testing.T, expected surfaceExpectation) {
+				t.Helper()
+				if !slices.Contains(expected.tools, "gitlab_issue") {
+					t.Errorf("the meta surface does not expect gitlab_issue: %v", expected.tools)
+				}
+				if slices.Contains(expected.tools, "gitlab_issue_list") {
+					t.Error("the meta surface expects an individual tool name")
+				}
+			},
+		},
+		{
+			name:    "individual",
+			surface: SurfaceIndividual,
+			check: func(t *testing.T, expected surfaceExpectation) {
+				t.Helper()
+				if !slices.Contains(expected.tools, "gitlab_issue_list") {
+					t.Error("the individual surface does not expect gitlab_issue_list")
+				}
+				if _, found := expected.actions["server.health_check"]; found {
+					t.Error("the individual surface expects server.health_check, which declares no individual tool")
+				}
+				if _, found := expected.actions["repository.file_history"]; found {
+					t.Error("the individual surface expects repository.file_history, whose tool name repository.commit_list owns")
+				}
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			expected, err := expectedSurface(inst, ServerConfig{Surface: testCase.surface}.normalized(), nil)
+			if err != nil {
+				t.Fatalf("expectedSurface(%s): %v", testCase.surface, err)
+			}
+			testCase.check(t, expected)
+		})
+	}
+}
+
+// TestIndividualRegistrations_ReadOnlyMode_KeepsOnlyTheReads checks the step
+// the individual surface takes after its catalog is built.
+//
+// Read-only mode is applied there by removing registered tools whose
+// annotation says they write, rather than by filtering the catalog as the
+// other two surfaces do. An expectation that skipped it would name every write
+// tool the server removed, and every read-only session would abort.
+func TestIndividualRegistrations_ReadOnlyMode_KeepsOnlyTheReads(t *testing.T) {
+	inst := stubInstance(t)
+	serverCfg := serverConfigFor(inst, ServerConfig{Surface: SurfaceIndividual, Mode: ModeReadOnly}.normalized(), nil)
+	catalog, _, err := gitlabtools.SharedIndividualCatalog(inst.client, serverCfg)
+	if err != nil {
+		t.Fatalf("assembling the individual catalog: %v", err)
+	}
+
+	all, _ := individualRegistrations(catalog, false)
+	reads, readActions := individualRegistrations(catalog, true)
+
+	if len(reads) >= len(all) {
+		t.Fatalf("read-only mode kept %d of %d individual tools, want fewer", len(reads), len(all))
+	}
+	if !slices.Contains(reads, "gitlab_issue_list") {
+		t.Error("read-only mode removed gitlab_issue_list, which reads")
+	}
+	if slices.Contains(reads, "gitlab_project_delete") {
+		t.Error("read-only mode kept gitlab_project_delete, which writes")
+	}
+	if _, found := readActions["project.delete"]; found {
+		t.Error("the read-only action set carries project.delete")
+	}
+}
+
+// TestServerConfigFor_ReadOnlyCredential_NarrowsTheSurface checks that the
+// expectation is built through the same narrowing the binary applies.
+//
+// A token that cannot write is served a read-only surface whatever the
+// deployment asked for. An expectation built without that call would name
+// every write tool, and every session using such a credential would abort with
+// a difference that is not the server's.
+func TestServerConfigFor_ReadOnlyCredential_NarrowsTheSurface(t *testing.T) {
+	inst := stubInstance(t)
+
+	cases := []struct {
+		name         string
+		scopes       []string
+		wantReadOnly bool
+	}{
+		{name: "read_api only", scopes: []string{"read_api"}, wantReadOnly: true},
+		{name: "api", scopes: []string{"api"}, wantReadOnly: false},
+		{name: "undetected", scopes: nil, wantReadOnly: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			serverCfg := serverConfigFor(inst, ServerConfig{}.normalized(), testCase.scopes)
+			if serverCfg.ReadOnly != testCase.wantReadOnly {
+				t.Errorf("ReadOnly = %t, want %t for scopes %v", serverCfg.ReadOnly, testCase.wantReadOnly, testCase.scopes)
+			}
+			if testCase.wantReadOnly && !serverCfg.ReadOnlyFromTokenScope {
+				t.Error("the narrowing did not record that the credential caused it")
+			}
+		})
+	}
+}
+
+// TestServerConfigFor_CarriesTheShapeTheBinaryBuilt checks the mapping from a
+// harness configuration to the server configuration the assemblers take.
+func TestServerConfigFor_CarriesTheShapeTheBinaryBuilt(t *testing.T) {
+	inst := stubInstance(t)
+
+	serverCfg := serverConfigFor(inst, ServerConfig{
+		Surface:      SurfaceMeta,
+		Mode:         ModeSafe,
+		Capabilities: CapabilitiesMinimal,
+		ExcludeTools: []string{"gitlab_issue"},
+	}.normalized(), []string{"api"})
+
+	cases := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{name: "surface", got: serverCfg.ToolSurface, want: config.ToolSurfaceMeta},
+		{name: "capabilities", got: serverCfg.CapabilitySurface, want: config.CapabilitySurfaceMinimal},
+		{name: "safe mode", got: serverCfg.SafeMode, want: true},
+		{name: "read-only", got: serverCfg.ReadOnly, want: false},
+		{name: "tier", got: serverCfg.Tier, want: inst.facts.Tier},
+		{name: "instance", got: serverCfg.GitLabURL, want: inst.facts.URL},
+		{name: "exclusions", got: strings.Join(serverCfg.ExcludeTools, ","), want: "gitlab_issue"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.got != testCase.want {
+				t.Errorf("%s = %v, want %v", testCase.name, testCase.got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestStandaloneToolNames_AreTheOnesRegisteredOutsideTheCatalog pins the list
+// the comparison ignores, so a tool moving into the catalog is noticed here
+// rather than as an unexplained difference in every session.
+func TestStandaloneToolNames_AreTheOnesRegisteredOutsideTheCatalog(t *testing.T) {
+	client := gitlabclient.NewUnboundClient("https://gitlab.invalid")
+
+	names := standaloneToolNames(client)
+
+	if len(names) == 0 {
+		t.Fatal("no standalone tools were named, and the binary registers several")
+	}
+	if !slices.Contains(names, "gitlab_discover_project") {
+		t.Errorf("gitlab_discover_project is not among the standalone tools: %v", names)
+	}
+	if !slices.IsSorted(names) {
+		t.Errorf("the standalone names are not sorted: %v", names)
+	}
+}

--- a/test/e2e/internal/harness/session.go
+++ b/test/e2e/internal/harness/session.go
@@ -1,0 +1,628 @@
+//go:build e2e
+
+// session.go starts one server per configuration and hands every test that
+// asks for that configuration the same one.
+//
+// A configuration here is only what the released binary reads: a tool surface,
+// a protective mode, a capability surface, a credential, an exclusion list, a
+// transport. There is no hook that registers something extra and no way to
+// hand the server a catalog of the test's own, because the suite this replaces
+// had both and consequently tested an assembly no deployment runs.
+//
+// Sessions are shared because starting a server costs a process and a catalog
+// build, and because nothing about one test's calls changes what the next test
+// is served. A test that needs a server nobody else touches asks for a private
+// one, which is the same shape with a key nothing else can name.
+
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+)
+
+// Mode is the protective mode a server runs in.
+type Mode string
+
+// The three protective modes, named as the reader of a report would name them
+// rather than as the two booleans that produce them.
+const (
+	// ModeDefault runs the server with neither protection on.
+	ModeDefault Mode = "default"
+	// ModeReadOnly removes every mutating operation.
+	ModeReadOnly Mode = "read-only"
+	// ModeSafe answers a mutating operation with a preview of it.
+	ModeSafe Mode = "safe"
+)
+
+// String returns the mode as a report names it.
+func (m Mode) String() string { return string(m) }
+
+// CapabilitySurface is the resource and prompt catalog a server serves.
+type CapabilitySurface string
+
+// The two capability surfaces, spelled as GITLAB_MCP_CAPABILITY_SURFACE takes
+// them.
+const (
+	// CapabilitiesFull serves every resource and prompt.
+	CapabilitiesFull CapabilitySurface = config.CapabilitySurfaceFull
+	// CapabilitiesMinimal serves only what dynamic use needs.
+	CapabilitiesMinimal CapabilitySurface = config.CapabilitySurfaceMinimal
+)
+
+// String returns the capability surface as the environment variable spells it.
+func (c CapabilitySurface) String() string { return string(c) }
+
+// Elicitation is what the harness's client does with an elicitation request.
+type Elicitation string
+
+// The three elicitation policies. The default is None, and deliberately: a
+// client that advertises no elicitation makes the server fail closed on an
+// unconfirmed destructive call, which is the behavior a test asserting that
+// refusal needs. A flow that exists to be elicited asks for one of the others.
+const (
+	// ElicitationNone advertises no elicitation capability at all.
+	ElicitationNone Elicitation = "none"
+	// ElicitationAutoAccept accepts every request with an empty answer, which
+	// is what a confirmation prompt needs and nothing more.
+	ElicitationAutoAccept Elicitation = "auto-accept"
+	// ElicitationScripted answers with the responder the configuration
+	// carries. A scripted session is always private, since its answers belong
+	// to one test.
+	ElicitationScripted Elicitation = "scripted"
+)
+
+// String returns the policy's name.
+func (e Elicitation) String() string { return string(e) }
+
+// TransportKind is how the harness reaches the server.
+type TransportKind string
+
+// The two transports a deployment can use. Only stdio is wired here; see
+// [ServerConfig.Transport].
+const (
+	// TransportStdio drives the binary over its standard streams, the way
+	// every MCP client that launches a local server does.
+	TransportStdio TransportKind = "stdio"
+	// TransportHTTP drives it over a loopback HTTP listener.
+	TransportHTTP TransportKind = "http"
+)
+
+// String returns the transport's name.
+func (t TransportKind) String() string { return string(t) }
+
+// ServerConfig is one shape of server, in the terms the released binary reads.
+//
+// Every field maps onto a variable or a flag cmd/server itself consults. There
+// is deliberately no field for anything else: a configuration that could only
+// be produced by assembling a server in this process would describe a program
+// nobody deploys.
+type ServerConfig struct {
+	// Surface selects the tool catalog: dynamic, meta or individual. Empty is
+	// dynamic, which is what the binary serves with nothing set.
+	Surface Surface
+	// Mode selects the protective mode. Empty is ModeDefault.
+	Mode Mode
+	// Capabilities selects the resource and prompt catalog. Empty is
+	// CapabilitiesFull, the binary's own default.
+	Capabilities CapabilitySurface
+	// Token is the credential the server runs with. Empty is the run's own
+	// token; a fixture-minted one here is how a narrowed surface is tested.
+	Token string
+	// ExcludeTools is the operator's removal list, as --exclude-tools takes it.
+	ExcludeTools []string
+	// Elicitation is what this session's client does with an elicitation
+	// request. Empty is ElicitationNone.
+	Elicitation Elicitation
+	// Responder answers an elicitation request under ElicitationScripted, and
+	// is ignored under the other two policies.
+	Responder func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)
+	// Private asks for a server no other test shares, for a test that will
+	// leave the process in a state the next one should not inherit.
+	Private bool
+	// Transport is how the harness reaches the server. Empty is
+	// TransportStdio. TransportHTTP is refused today: the launcher starts the
+	// binary over its standard streams only, and giving it a listener belongs
+	// with the transport scenarios that will want one.
+	Transport TransportKind
+}
+
+// normalized returns the configuration with every empty field replaced by the
+// default the binary itself applies, so a key and a child environment are
+// built from what the server will actually be rather than from what was
+// written down.
+func (c ServerConfig) normalized() ServerConfig {
+	if c.Surface == "" {
+		c.Surface = SurfaceDynamic
+	}
+	if c.Mode == "" {
+		c.Mode = ModeDefault
+	}
+	if c.Capabilities == "" {
+		c.Capabilities = CapabilitiesFull
+	}
+	if c.Elicitation == "" {
+		c.Elicitation = ElicitationNone
+	}
+	if c.Transport == "" {
+		c.Transport = TransportStdio
+	}
+	c.ExcludeTools = slices.Clone(c.ExcludeTools)
+	slices.Sort(c.ExcludeTools)
+	return c
+}
+
+// validate reports a configuration the harness cannot start.
+func (c ServerConfig) validate() error {
+	if !slices.Contains(AllSurfaces(), c.Surface) {
+		return fmt.Errorf("unknown tool surface %q", c.Surface)
+	}
+	if c.Mode != ModeDefault && c.Mode != ModeReadOnly && c.Mode != ModeSafe {
+		return fmt.Errorf("unknown protective mode %q", c.Mode)
+	}
+	if c.Capabilities != CapabilitiesFull && c.Capabilities != CapabilitiesMinimal {
+		return fmt.Errorf("unknown capability surface %q", c.Capabilities)
+	}
+	if c.Elicitation == ElicitationScripted && c.Responder == nil {
+		return errors.New("an elicitation policy of scripted needs a Responder to answer with")
+	}
+	if c.Transport == TransportHTTP {
+		return errors.New("the HTTP transport is not wired yet: the launcher starts the binary over its " +
+			"standard streams, and a loopback listener arrives with the transport scenarios that need one")
+	}
+	if c.Transport != TransportStdio {
+		return fmt.Errorf("unknown transport %q", c.Transport)
+	}
+	return nil
+}
+
+// privateSessions numbers the private sessions one process hands out, so each
+// gets a key nothing else can name.
+var privateSessions atomic.Int64
+
+// key names one server shape. Two tests naming the same key share a process;
+// two naming different keys get one each.
+//
+// The instance is part of it because the same shape against another GitLab is
+// another server, and the token because the credential decides the catalog:
+// the scopes it carries narrow the surface before anything is registered. The
+// token is hashed rather than carried, since the key is printed.
+func (c ServerConfig) key(instance, token string) string {
+	parts := []string{
+		string(c.Surface), string(c.Mode), string(c.Capabilities), string(c.Elicitation), string(c.Transport),
+		"exclude=" + strings.Join(c.ExcludeTools, ","),
+		"instance=" + shortStableHash(instance),
+		"token=" + shortStableHash(token),
+	}
+	if c.Private || c.Elicitation == ElicitationScripted {
+		parts = append(parts, "private="+strconv.FormatInt(privateSessions.Add(1), 10))
+	}
+	return strings.Join(parts, "|")
+}
+
+// label names a session in a record and in a log file. It is the key without
+// the hashes, which are noise to a reader and identical across one run.
+func (c ServerConfig) label(private int64) string {
+	label := strings.Join([]string{string(c.Surface), string(c.Mode), string(c.Capabilities)}, "-")
+	if len(c.ExcludeTools) > 0 {
+		label += "-excluded"
+	}
+	if c.Elicitation != ElicitationNone {
+		label += "-" + string(c.Elicitation)
+	}
+	if private > 0 {
+		label += "-private" + strconv.FormatInt(private, 10)
+	}
+	return label
+}
+
+// childVariables returns the environment variables this configuration sets on
+// the server child, which is the whole of what it configures.
+func (c ServerConfig) childVariables() map[string]string {
+	vars := map[string]string{
+		"GITLAB_MCP_TOOL_SURFACE":       string(c.Surface),
+		"GITLAB_MCP_CAPABILITY_SURFACE": string(c.Capabilities),
+		"GITLAB_MCP_READ_ONLY":          strconv.FormatBool(c.Mode == ModeReadOnly),
+		"GITLAB_MCP_SAFE_MODE":          strconv.FormatBool(c.Mode == ModeSafe),
+		"GITLAB_MCP_LOG_LEVEL":          serverLogLevel,
+	}
+	if len(c.ExcludeTools) > 0 {
+		vars["GITLAB_MCP_EXCLUDE_TOOLS"] = strings.Join(c.ExcludeTools, ",")
+	}
+	return vars
+}
+
+// serverLogLevel is what every child logs at. Info rather than the default, so
+// a child's log says which catalog it registered and what it refused, which is
+// the first thing a failed call wants to quote.
+const serverLogLevel = "info"
+
+// sessionStartTimeout bounds starting one child and listing what it serves.
+// The individual surface builds roughly a thousand tools and marshals several
+// megabytes into its first tools/list, and does it slower under the race
+// detector.
+const sessionStartTimeout = 3 * time.Minute
+
+// Session is one test's handle on a server.
+//
+// The server behind it may be shared with other tests; the handle is not, and
+// carries the Env whose test the calls made through it are attributed to.
+type Session struct {
+	env  *Env
+	conn *sessionConn
+}
+
+// Label returns the name this session is recorded under.
+func (s *Session) Label() string { return s.conn.label }
+
+// Surface returns the tool surface this session serves.
+func (s *Session) Surface() Surface { return s.conn.cfg.Surface }
+
+// Mode returns the protective mode this session runs in.
+func (s *Session) Mode() Mode { return s.conn.cfg.Mode }
+
+// Capabilities returns the resource and prompt surface this session serves.
+func (s *Session) Capabilities() CapabilitySurface { return s.conn.cfg.Capabilities }
+
+// Transport returns how the harness reaches this session's server.
+func (s *Session) Transport() TransportKind { return s.conn.cfg.Transport }
+
+// Tools returns the tool names the session listed when it started.
+func (s *Session) Tools() []string { return slices.Clone(s.conn.served.tools) }
+
+// Resources returns the static resource URIs the session listed.
+func (s *Session) Resources() []string { return slices.Clone(s.conn.served.resources) }
+
+// ResourceTemplates returns the resource URI templates the session listed.
+func (s *Session) ResourceTemplates() []string { return slices.Clone(s.conn.served.templates) }
+
+// Prompts returns the prompt names the session listed.
+func (s *Session) Prompts() []string { return slices.Clone(s.conn.served.prompts) }
+
+// Serves reports whether this session can reach the given action at all.
+//
+// It answers from the catalog the server built rather than from the base
+// catalog, so an action removed by read-only mode, by the credential's scopes
+// or by the operator's exclusions is not served, and neither is one whose
+// individual tool name another action owns.
+func (s *Session) Serves(id ActionID) bool {
+	_, ok := s.conn.served.actions[id]
+	return ok
+}
+
+// sessionConn is one running server and the client speaking to it.
+type sessionConn struct {
+	label string
+	cfg   ServerConfig
+	proc  *serverProcess
+	inst  *instance
+
+	// served is what the session listed when it started, and what the
+	// served-set check was run against.
+	served servedSets
+
+	mu      sync.Mutex
+	session *mcp.ClientSession
+	// notifier fans resource-updated notifications out to the subscriptions
+	// tests opened on this session.
+	notifier *updateNotifier
+}
+
+// sessionEntry is one pooled session, started by the first test that asks for
+// its key while every concurrent asker waits.
+type sessionEntry struct {
+	once sync.Once
+	conn *sessionConn
+	err  error
+}
+
+// sessions holds one entry per server shape for the life of the test binary.
+var sessions sync.Map // string -> *sessionEntry
+
+// sessionContext is what every pooled child's life is bounded by, and
+// sessionCancel is what [closeSessions] ends the run's servers with.
+//
+// It belongs to the package rather than to the first caller because the
+// children outlive whichever test started them: a context created inside one
+// test's call would end with that test and take every later test's server with
+// it.
+var sessionContext, sessionCancel = context.WithCancel(context.Background())
+
+// sessionLifetime returns the context every child of this run is started
+// under.
+func sessionLifetime() context.Context { return sessionContext }
+
+// sessionRoot is the one directory every child calls home, and the only
+// directory any of them may read a local file from or write a download into.
+var (
+	sessionRootOnce sync.Once
+	sessionRootDir  string
+	errSessionRoot  error
+)
+
+// harnessRoot returns the directory the children run in, creating it once.
+//
+// Not a t.TempDir: children outlive the test that started them, and a
+// directory removed when that test ended would take the home of every later
+// test's server with it.
+func harnessRoot() (string, error) {
+	sessionRootOnce.Do(func() {
+		sessionRootDir, errSessionRoot = os.MkdirTemp("", "gitlab-mcp-e2e-root")
+	})
+	return sessionRootDir, errSessionRoot
+}
+
+// closeSessions stops every server this process started and removes what they
+// ran in.
+//
+// Main calls it before it deletes the binary it built, and the order matters
+// on Windows, where an executable that is still running cannot be removed.
+func closeSessions() {
+	sessionCancel()
+	sessions.Range(func(_, value any) bool {
+		if entry, ok := value.(*sessionEntry); ok && entry.conn != nil {
+			entry.conn.close()
+		}
+		return true
+	})
+	if sessionRootDir != "" {
+		_ = os.RemoveAll(sessionRootDir)
+	}
+}
+
+// Session returns this test's handle on the server for cfg, starting it if no
+// test has asked for that shape yet.
+//
+// A configuration that cannot be started, or a server whose served set does
+// not match what the shared assemblers say it should be, fails the test that
+// asked for it. Every later test asking for the same shape fails the same way,
+// with the same message: a session that started wrong is wrong for everybody,
+// and letting the second test through would report the difference as a
+// scattering of unrelated failures.
+func (e *Env) Session(cfg ServerConfig) *Session {
+	e.T.Helper()
+
+	conn, err := e.session(cfg)
+	if err != nil {
+		e.T.Fatalf("starting the %s session: %v", cfg.normalized().Surface, err)
+	}
+	if conn.cfg.Private {
+		e.T.Cleanup(conn.close)
+	}
+	return &Session{env: e, conn: conn}
+}
+
+// On returns this test's handle on the default session for one surface: no
+// protective mode, the full capability surface, the run's own credential.
+func (e *Env) On(surface Surface) *Session {
+	e.T.Helper()
+	return e.Session(ServerConfig{Surface: surface})
+}
+
+// session resolves the pooled connection for cfg, starting it once.
+func (e *Env) session(cfg ServerConfig) (*sessionConn, error) {
+	normalized := cfg.normalized()
+	if err := normalized.validate(); err != nil {
+		return nil, err
+	}
+	token := normalized.Token
+	if token == "" {
+		token = e.inst.settings.get(envGitLabToken)
+	}
+
+	key := normalized.key(e.inst.facts.URL, token)
+	loaded, _ := sessions.LoadOrStore(key, &sessionEntry{})
+	entry, _ := loaded.(*sessionEntry)
+	entry.once.Do(func() {
+		entry.conn, entry.err = startSession(e.inst, normalized, token, key)
+	})
+	return entry.conn, entry.err
+}
+
+// startSession launches one server and checks what it serves.
+func startSession(inst *instance, cfg ServerConfig, token, key string) (*sessionConn, error) {
+	lifetime := sessionLifetime()
+
+	root, err := harnessRoot()
+	if err != nil {
+		return nil, fmt.Errorf("creating the directory the server runs in: %w", err)
+	}
+	bin, err := serverBinary(inst.settings.get(binaryEnv))
+	if err != nil {
+		return nil, err
+	}
+
+	label := cfg.label(privateSessionNumber(key))
+	dir := filepath.Join(root, sanitizeNamePart(label, 60))
+	if err = os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("creating the session directory %s: %w", dir, err)
+	}
+
+	settingsForChild := inst.settings
+	if token != inst.settings.get(envGitLabToken) {
+		settingsForChild = inst.settings.with(envGitLabToken, token)
+	}
+
+	conn := &sessionConn{
+		label:    label,
+		cfg:      cfg,
+		inst:     inst,
+		proc:     newServerProcess(label, bin, newChildEnv(settingsForChild, dir, cfg.childVariables())),
+		notifier: newUpdateNotifier(),
+	}
+	if connectErr := conn.connect(); connectErr != nil {
+		return nil, connectErr
+	}
+
+	ctx, cancel := context.WithTimeout(lifetime, sessionStartTimeout)
+	defer cancel()
+	if conn.served, err = listServed(ctx, conn.client()); err != nil {
+		conn.close()
+		return nil, fmt.Errorf("listing what the %s session serves: %w\nserver stderr:\n%s", label, err, conn.proc.stderrTail())
+	}
+
+	scopes, err := sessionScopes(ctx, inst, token)
+	if err != nil {
+		conn.close()
+		return nil, err
+	}
+	expectation, err := expectedSurface(inst, cfg, scopes)
+	if err != nil {
+		conn.close()
+		return nil, err
+	}
+	if err = checkServedTools(cfg.Surface, conn.served.tools, expectation); err != nil {
+		conn.close()
+		return nil, err
+	}
+	conn.served.actions = expectation.actions
+	return conn, nil
+}
+
+// privateSessionNumber reads back the number a private key carries, so the
+// label a reader sees matches the key the pool holds. It returns zero for a
+// shared session, which carries no number.
+func privateSessionNumber(key string) int64 {
+	_, suffix, found := strings.Cut(key, "private=")
+	if !found {
+		return 0
+	}
+	number, err := strconv.ParseInt(suffix, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return number
+}
+
+// sessionScopes returns the scopes of the credential a session runs with.
+//
+// The run's own token was probed at bootstrap; a session given another one is
+// probed here, because the scopes decide which catalog groups the server
+// registers at all and a served-set check against the wrong list would fail
+// every session using that credential.
+func sessionScopes(ctx context.Context, inst *instance, token string) ([]string, error) {
+	if token == inst.settings.get(envGitLabToken) {
+		return inst.facts.Scopes, nil
+	}
+	client, err := gitlabclient.NewClientWithToken(inst.facts.URL, token,
+		strings.EqualFold(inst.settings.get(envSkipTLSVerify), "true"))
+	if err != nil {
+		return nil, fmt.Errorf("building a client for the session's own credential: %w", err)
+	}
+	return gitlabclient.DetectScopes(ctx, client.GL()), nil
+}
+
+// connect starts the child and opens an MCP session to it.
+func (c *sessionConn) connect() error {
+	lifetime := sessionLifetime()
+	ctx, cancel := context.WithTimeout(lifetime, sessionStartTimeout)
+	defer cancel()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "gitlab-mcp-e2e-harness", Version: "1"}, c.clientOptions())
+	session, err := client.Connect(ctx, c.proc.transport(lifetime), nil)
+	if err != nil {
+		return fmt.Errorf("connecting to the %s server: %w\nserver stderr:\n%s", c.label, err, c.proc.stderrTail())
+	}
+
+	c.mu.Lock()
+	c.session = session
+	c.mu.Unlock()
+	return nil
+}
+
+// clientOptions builds the client for this session: what it answers an
+// elicitation request with, and where a resource-updated notification goes.
+func (c *sessionConn) clientOptions() *mcp.ClientOptions {
+	options := &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(_ context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			if req != nil && req.Params != nil {
+				c.notifier.deliver(req.Params.URI)
+			}
+		},
+	}
+	switch c.cfg.Elicitation {
+	case ElicitationAutoAccept:
+		options.ElicitationHandler = acceptElicitation
+	case ElicitationScripted:
+		options.ElicitationHandler = c.cfg.Responder
+	default:
+		// ElicitationNone: no handler, so the client advertises no elicitation
+		// capability and the server fails closed rather than prompting.
+	}
+	return options
+}
+
+// acceptElicitation answers every request with an empty acceptance.
+//
+// Empty content is the right answer for what this policy is for: the
+// confirmation prompt a destructive action raises asks for approval and reads
+// no field back. A flow that needs values scripts them instead.
+func acceptElicitation(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+	return &mcp.ElicitResult{Action: "accept", Content: map[string]any{}}, nil
+}
+
+// client returns the live MCP session.
+func (c *sessionConn) client() *mcp.ClientSession {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.session
+}
+
+// restart replaces a child that has died with a fresh one of the same shape.
+//
+// It is what keeps one panicking handler from failing every later test of the
+// run: the process is gone, the session with it, and the next call would
+// otherwise find a closed pipe forever. The served set is not re-checked,
+// because it was checked when this shape first started and the child is
+// started from the same environment.
+func (c *sessionConn) restart() error {
+	c.mu.Lock()
+	if c.session != nil {
+		_ = c.session.Close()
+		c.session = nil
+	}
+	c.mu.Unlock()
+	return c.connect()
+}
+
+// close ends the session and the child behind it.
+//
+// The SDK's Close reports the error the reaper already collected, since both
+// wait on the same process; it is discarded for that reason and not out of
+// indifference.
+func (c *sessionConn) close() {
+	c.mu.Lock()
+	session := c.session
+	c.session = nil
+	c.mu.Unlock()
+
+	if session != nil {
+		_ = session.Close()
+	}
+}
+
+// alive reports whether the child behind this session is still running.
+func (c *sessionConn) alive() bool { return c.proc.alive() }
+
+// failureContext describes a dead child, for a call that failed because of it.
+func (c *sessionConn) failureContext() string {
+	if c.alive() {
+		return ""
+	}
+	return fmt.Sprintf("\nthe %s server is no longer running (%s)\nserver stderr:\n%s",
+		c.label, c.proc.exitStatus(), c.proc.stderrTail())
+}

--- a/test/e2e/internal/harness/session_test.go
+++ b/test/e2e/internal/harness/session_test.go
@@ -1,0 +1,524 @@
+//go:build e2e
+
+// session_test.go covers what a server shape is and what starting one proves.
+//
+// The configuration half is offline: a shape is a key, a label and a set of
+// environment variables, and each of those is what decides whether two tests
+// share a process. The last test is the whole thing: the real binary, started
+// on each of the three surfaces against a stub GitLab, serving exactly what
+// the shared assemblers say it should and answering a call made by canonical
+// action ID.
+
+package harness
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+)
+
+// stubToken is the credential the harness's own tests run with. It reaches
+// only the stub GitLab, which authenticates nobody.
+const stubToken = "glpat-harness-stub"
+
+// stubInstance builds the instance a harness test drives: a stub GitLab, a
+// client for it, and the facts a probe of it reports.
+//
+// It exists because the package-wide bootstrap needs a real GitLab and these
+// tests must not. Everything below the bootstrap is the same code a real run
+// uses, including the probe.
+func stubInstance(t *testing.T) *instance {
+	t.Helper()
+
+	stub := startStubGitLab(t)
+	client, err := gitlabclient.NewClientWithToken(stub.URL, stubToken, false)
+	if err != nil {
+		t.Fatalf("building a client for the stub: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	facts, err := probe(ctx, client, stub.URL, false, stubToken)
+	if err != nil {
+		t.Fatalf("probing the stub: %v", err)
+	}
+
+	return &instance{
+		settings:    testSettings(map[string]string{envGitLabURL: stub.URL, envGitLabToken: stubToken}),
+		requirement: Any,
+		pkg:         "harness",
+		runID:       configuredRunID(time.Now(), "", "harness"),
+		facts:       facts,
+		client:      client,
+	}
+}
+
+// TestServerConfig_EmptyFields_TakeTheBinarysOwnDefaults checks that a
+// configuration nobody filled in describes the server a client gets with
+// nothing set.
+//
+// It matters because the default surface is the one a deployment serves and
+// the one the suite should exercise most: a harness whose empty configuration
+// meant meta would have every unqualified test running on a surface almost
+// nobody uses.
+func TestServerConfig_EmptyFields_TakeTheBinarysOwnDefaults(t *testing.T) {
+	normalized := ServerConfig{}.normalized()
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "surface", got: normalized.Surface.String(), want: SurfaceDynamic.String()},
+		{name: "mode", got: normalized.Mode.String(), want: ModeDefault.String()},
+		{name: "capabilities", got: normalized.Capabilities.String(), want: CapabilitiesFull.String()},
+		{name: "elicitation", got: normalized.Elicitation.String(), want: ElicitationNone.String()},
+		{name: "transport", got: normalized.Transport.String(), want: TransportStdio.String()},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.got != testCase.want {
+				t.Errorf("%s = %q, want %q", testCase.name, testCase.got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestServerConfig_Invalid_IsRefusedWithAReason checks that a configuration
+// the harness cannot start says so rather than starting something else.
+func TestServerConfig_Invalid_IsRefusedWithAReason(t *testing.T) {
+	cases := []struct {
+		name   string
+		config ServerConfig
+		want   string
+	}{
+		{name: "unknown surface", config: ServerConfig{Surface: Surface("everything")}, want: "unknown tool surface"},
+		{name: "unknown mode", config: ServerConfig{Mode: Mode("paranoid")}, want: "unknown protective mode"},
+		{name: "unknown capability surface", config: ServerConfig{Capabilities: CapabilitySurface("some")}, want: "unknown capability surface"},
+		{name: "scripted with no responder", config: ServerConfig{Elicitation: ElicitationScripted}, want: "needs a Responder"},
+		{name: "http transport", config: ServerConfig{Transport: TransportHTTP}, want: "not wired yet"},
+		{name: "unknown transport", config: ServerConfig{Transport: TransportKind("carrier pigeon")}, want: "unknown transport"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.config.normalized().validate()
+			if err == nil {
+				t.Fatalf("%#v was accepted", testCase.config)
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Errorf("the refusal is %q, want it to mention %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+// TestServerConfig_Key_SeparatesWhatMakesADifferentServer pins which
+// differences get a process of their own.
+//
+// The credential is in the key because the scopes it carries narrow the
+// catalog before anything is registered, and the instance because the same
+// shape against another GitLab is another server. A key that ignored either
+// would hand a test a session serving a catalog built for somebody else.
+func TestServerConfig_Key_SeparatesWhatMakesADifferentServer(t *testing.T) {
+	base := ServerConfig{}.normalized()
+	baseKey := base.key("https://gitlab.test", "token-a")
+
+	cases := []struct {
+		name   string
+		config ServerConfig
+		url    string
+		token  string
+	}{
+		{name: "surface", config: ServerConfig{Surface: SurfaceMeta}, url: "https://gitlab.test", token: "token-a"},
+		{name: "mode", config: ServerConfig{Mode: ModeReadOnly}, url: "https://gitlab.test", token: "token-a"},
+		{name: "capabilities", config: ServerConfig{Capabilities: CapabilitiesMinimal}, url: "https://gitlab.test", token: "token-a"},
+		{name: "exclusions", config: ServerConfig{ExcludeTools: []string{"gitlab_issue"}}, url: "https://gitlab.test", token: "token-a"},
+		{name: "elicitation", config: ServerConfig{Elicitation: ElicitationAutoAccept}, url: "https://gitlab.test", token: "token-a"},
+		{name: "instance", config: ServerConfig{}, url: "https://other.test", token: "token-a"},
+		{name: "credential", config: ServerConfig{}, url: "https://gitlab.test", token: "token-b"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			key := testCase.config.normalized().key(testCase.url, testCase.token)
+			if key == baseKey {
+				t.Errorf("%s does not change the session key: both are %q", testCase.name, key)
+			}
+		})
+	}
+
+	if again := base.key("https://gitlab.test", "token-a"); again != baseKey {
+		t.Errorf("the same configuration produced two keys: %q and %q", baseKey, again)
+	}
+}
+
+// TestServerConfig_Key_CarriesNoCredential checks that the key a failure
+// message and a log line carry does not carry the token.
+func TestServerConfig_Key_CarriesNoCredential(t *testing.T) {
+	key := ServerConfig{}.normalized().key("https://gitlab.test", "glpat-secret-value")
+
+	if strings.Contains(key, "glpat-secret-value") {
+		t.Errorf("the session key carries the credential: %q", key)
+	}
+}
+
+// TestServerConfig_Private_GetsAServerOfItsOwn checks that two private
+// sessions of one shape never share a process.
+func TestServerConfig_Private_GetsAServerOfItsOwn(t *testing.T) {
+	private := ServerConfig{Private: true}.normalized()
+
+	first := private.key("https://gitlab.test", "token")
+	second := private.key("https://gitlab.test", "token")
+
+	if first == second {
+		t.Fatalf("two private sessions share the key %q", first)
+	}
+}
+
+// TestServerConfig_ChildVariables_AreTheOnesTheBinaryReads pins the mapping
+// from a shape to the environment the server is started with.
+//
+// Every entry here is a variable cmd/server itself consults. That is the whole
+// contract of this type: a field with no variable behind it would describe a
+// server the harness could produce and a deployment could not.
+func TestServerConfig_ChildVariables_AreTheOnesTheBinaryReads(t *testing.T) {
+	cases := []struct {
+		name   string
+		config ServerConfig
+		want   map[string]string
+	}{
+		{
+			name:   "default",
+			config: ServerConfig{},
+			want: map[string]string{
+				"GITLAB_MCP_TOOL_SURFACE":       "dynamic",
+				"GITLAB_MCP_CAPABILITY_SURFACE": "full",
+				"GITLAB_MCP_READ_ONLY":          "false",
+				"GITLAB_MCP_SAFE_MODE":          "false",
+			},
+		},
+		{
+			name:   "read-only meta",
+			config: ServerConfig{Surface: SurfaceMeta, Mode: ModeReadOnly},
+			want: map[string]string{
+				"GITLAB_MCP_TOOL_SURFACE": "meta",
+				"GITLAB_MCP_READ_ONLY":    "true",
+				"GITLAB_MCP_SAFE_MODE":    "false",
+			},
+		},
+		{
+			name:   "safe individual with exclusions",
+			config: ServerConfig{Surface: SurfaceIndividual, Mode: ModeSafe, ExcludeTools: []string{"gitlab_project_delete", "gitlab_issue"}},
+			want: map[string]string{
+				"GITLAB_MCP_TOOL_SURFACE":  "individual",
+				"GITLAB_MCP_READ_ONLY":     "false",
+				"GITLAB_MCP_SAFE_MODE":     "true",
+				"GITLAB_MCP_EXCLUDE_TOOLS": "gitlab_issue,gitlab_project_delete",
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			vars := testCase.config.normalized().childVariables()
+			for key, want := range testCase.want {
+				if vars[key] != want {
+					t.Errorf("%s = %q, want %q", key, vars[key], want)
+				}
+			}
+		})
+	}
+}
+
+// TestServerConfig_Label_NamesTheShapeWithoutHashes checks that the name a
+// record and a server log carry reads as the configuration it describes.
+func TestServerConfig_Label_NamesTheShapeWithoutHashes(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  ServerConfig
+		private int64
+		want    string
+	}{
+		{name: "default", config: ServerConfig{}, want: "dynamic-default-full"},
+		{name: "read-only meta", config: ServerConfig{Surface: SurfaceMeta, Mode: ModeReadOnly}, want: "meta-read-only-full"},
+		{name: "excluded", config: ServerConfig{ExcludeTools: []string{"gitlab_issue"}}, want: "dynamic-default-full-excluded"},
+		{name: "auto-accepting", config: ServerConfig{Elicitation: ElicitationAutoAccept}, want: "dynamic-default-full-auto-accept"},
+		{name: "private", config: ServerConfig{Private: true}, private: 3, want: "dynamic-default-full-private3"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if label := testCase.config.normalized().label(testCase.private); label != testCase.want {
+				t.Errorf("label = %q, want %q", label, testCase.want)
+			}
+		})
+	}
+}
+
+// TestPrivateSessionNumber_ReadsTheNumberOffTheKey checks that a private
+// session's label and its key agree, so a reader holding one can find the
+// other.
+func TestPrivateSessionNumber_ReadsTheNumberOffTheKey(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want int64
+	}{
+		{name: "shared", key: "dynamic|default|full|none|stdio|exclude=", want: 0},
+		{name: "private", key: "dynamic|default|full|none|stdio|exclude=|private=7", want: 7},
+		{name: "unparseable", key: "dynamic|default|full|none|stdio|exclude=|private=many", want: 0},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if number := privateSessionNumber(testCase.key); number != testCase.want {
+				t.Errorf("privateSessionNumber(%q) = %d, want %d", testCase.key, number, testCase.want)
+			}
+		})
+	}
+}
+
+// TestAcceptElicitation_AnswersWithAnEmptyAcceptance pins what the
+// auto-accepting policy sends back.
+//
+// Empty content is deliberate: the only request this policy exists for is the
+// confirmation a destructive action raises, which reads no field back. A flow
+// that needs values gets a scripted responder instead, and a policy that
+// invented values here would answer it with the wrong ones silently.
+func TestAcceptElicitation_AnswersWithAnEmptyAcceptance(t *testing.T) {
+	result, err := acceptElicitation(context.Background(), &mcp.ElicitRequest{})
+	if err != nil {
+		t.Fatalf("acceptElicitation() error = %v, want nil", err)
+	}
+	if result.Action != "accept" {
+		t.Errorf("action = %q, want accept", result.Action)
+	}
+	if len(result.Content) != 0 {
+		t.Errorf("content = %v, want it empty", result.Content)
+	}
+}
+
+// TestSettingsWith_ChangesOneValueAndLeavesTheOriginal checks that a session
+// given its own credential does not change the credential every other session
+// inherits.
+func TestSettingsWith_ChangesOneValueAndLeavesTheOriginal(t *testing.T) {
+	original := testSettings(map[string]string{envGitLabURL: "https://gitlab.test", envGitLabToken: "first"})
+
+	changed := original.with(envGitLabToken, "second")
+
+	if original.get(envGitLabToken) != "first" {
+		t.Errorf("the original settings now carry %q", original.get(envGitLabToken))
+	}
+	if changed.get(envGitLabToken) != "second" {
+		t.Errorf("the copy carries %q, want second", changed.get(envGitLabToken))
+	}
+	if changed.get(envGitLabURL) != "https://gitlab.test" {
+		t.Errorf("the copy lost the instance: %q", changed.get(envGitLabURL))
+	}
+}
+
+// TestSession_UnsupportedTransport_FailsTheTestThatAskedForIt checks that a
+// configuration the harness cannot start stops one test rather than being
+// silently downgraded to the one it can.
+func TestSession_UnsupportedTransport_FailsTheTestThatAskedForIt(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+
+	_, err := env.session(ServerConfig{Transport: TransportHTTP})
+
+	if err == nil {
+		t.Fatal("an HTTP session was started, and the launcher serves stdio only")
+	}
+	if !strings.Contains(err.Error(), "not wired yet") {
+		t.Errorf("the refusal is %q, want it to say the transport is not wired", err)
+	}
+}
+
+// statusAnswer is the part of the server.status answer these tests read.
+type statusAnswer struct {
+	// Status is the diagnostic verdict.
+	Status string `json:"status"`
+	// GitLabURL is the instance the server was configured with.
+	GitLabURL string `json:"gitlab_url"`
+	// Authenticated says the server reached GitLab with its credential.
+	Authenticated bool `json:"authenticated"`
+}
+
+// TestSession_RealBinaryOnEverySurface_ServesTheAssemblersCatalogAndAnswers is
+// the whole of what this step delivers, exercised end to end.
+//
+// For each of the three surfaces it starts the real binary, compares what the
+// session serves with what tools.SharedMetaCatalog, tools.SharedIndividualCatalog
+// and dynamiccatalog.Build say it should, and then makes one call by canonical
+// action ID. The call goes through the projection, so each surface sends its
+// own spelling: gitlab_execute_action with server.status, gitlab_server with
+// status, and gitlab_server_status with nothing.
+//
+// The GitLab behind it is the stub, which answers only what the server asks at
+// startup and what the status action reads, so the test needs no instance and
+// no credential.
+func TestSession_RealBinaryOnEverySurface_ServesTheAssemblersCatalogAndAnswers(t *testing.T) {
+	inst := stubInstance(t)
+
+	for _, surface := range AllSurfaces() {
+		t.Run(string(surface), func(t *testing.T) {
+			env := newEnv(t, inst)
+			// Private, because the stub GitLab behind this instance is closed
+			// when the test ends and a pooled session would outlive it.
+			session := env.Session(ServerConfig{Surface: surface, Private: true})
+
+			if len(session.Tools()) == 0 {
+				t.Fatal("the session lists no tools at all")
+			}
+			if !session.Serves("server.status") {
+				t.Fatalf("the %s session does not serve server.status", surface)
+			}
+
+			answer := Do[statusAnswer](session, "server.status", nil)
+			if !answer.Authenticated {
+				t.Errorf("the server reports it is not authenticated: %+v", answer)
+			}
+			// A prefix, because the server reports the API base it built from
+			// the instance rather than the instance itself.
+			if !strings.HasPrefix(answer.GitLabURL, inst.facts.URL) {
+				t.Errorf("gitlab_url = %q, want it to name the instance the harness pointed it at, %q", answer.GitLabURL, inst.facts.URL)
+			}
+			if answer.Status == "" {
+				t.Errorf("the status answer carries no status: %+v", answer)
+			}
+		})
+	}
+}
+
+// TestSession_UnservableAction_IsRefusedBeforeItIsSent checks the three
+// pre-flight refusals, which exist because each of them produces a failure
+// that reads as something else once the call has gone out.
+func TestSession_UnservableAction_IsRefusedBeforeItIsSent(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Surface: SurfaceIndividual, Private: true})
+
+	cases := []struct {
+		name string
+		id   ActionID
+		want string
+	}{
+		{name: "not in the catalog", id: "not_a_domain.not_an_action", want: "no action"},
+		{name: "shadowed individual name", id: "repository.file_history", want: "not servable on the individual surface"},
+		{name: "no individual tool", id: "server.health_check", want: "not servable on the individual surface"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := session.resolve(testCase.id, nil, false)
+			if err == nil {
+				t.Fatalf("%s resolved to a call on the individual surface", testCase.id)
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Errorf("the refusal is %q, want it to mention %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+// TestSession_ReadOnlyMode_WithholdsTheWritesAndSaysSo checks a protective
+// mode end to end: the server registers a narrowed surface, the session's
+// served-set check accepts it, and a call to something the mode removed is
+// refused before it is sent, naming the mode.
+func TestSession_ReadOnlyMode_WithholdsTheWritesAndSaysSo(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Surface: SurfaceIndividual, Mode: ModeReadOnly, Private: true})
+
+	if !session.Serves("project.get") {
+		t.Error("the read-only session does not serve project.get, which reads")
+	}
+	if session.Serves("project.delete") {
+		t.Fatal("the read-only session serves project.delete")
+	}
+	if slices.Contains(session.Tools(), "gitlab_project_delete") {
+		t.Error("the read-only session lists gitlab_project_delete")
+	}
+
+	_, err := session.resolve("project.delete", map[string]any{"project_id": "group/project"}, true)
+	if err == nil {
+		t.Fatal("project.delete resolved on a read-only session")
+	}
+	if !strings.Contains(err.Error(), "read-only mode") {
+		t.Errorf("the refusal is %q, want it to name the mode that removed the action", err)
+	}
+}
+
+// TestSession_DestructiveWithoutConfirmation_IsRefusedByTheServer checks the
+// refusal verb against the real binary.
+//
+// The confirmation guard runs before the handler, so the call never reaches
+// GitLab and the stub behind this test is never asked to delete anything. That
+// is also why this is the one end-to-end assertion about a mutating action
+// that a test with no GitLab can make.
+func TestSession_DestructiveWithoutConfirmation_IsRefusedByTheServer(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	// ElicitationNone, so the client advertises no way to prompt and the
+	// server fails closed rather than asking.
+	session := env.Session(ServerConfig{Surface: SurfaceIndividual, Elicitation: ElicitationNone, Private: true})
+
+	text := Refused(session, "project.delete", map[string]any{"project_id": "group/project"},
+		FailureNeedsConfirmation, WithoutConfirmation())
+
+	if !strings.Contains(text, "confirm=true") {
+		t.Errorf("the refusal does not tell the caller how to proceed: %q", text)
+	}
+}
+
+// TestSession_ActionAboveThePackagesRequirement_IsRefused checks the tier
+// ceiling, which is the runtime half of the rule the static gate enforces.
+//
+// A package that declared no license may call Free actions only. Without this
+// the same test would pass on a licensed runtime and fail on an unlicensed
+// one, and a suite whose verdict depends on which runtime ran it is not a
+// gate.
+func TestSession_ActionAboveThePackagesRequirement_IsRefused(t *testing.T) {
+	inst := stubInstance(t)
+	// Pretend the instance is licensed while the package still is not: that is
+	// exactly the case the ceiling exists for, and the one a Docker run on an
+	// EE image produces.
+	inst.facts.Tier = edition.Ultimate
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Private: true})
+
+	licensed := licensedActionFor(t, inst)
+	if _, err := session.resolve(licensed, nil, false); err == nil {
+		t.Fatalf("%s resolved for a package that declared no license", licensed)
+	} else if !strings.Contains(err.Error(), "runs on free") {
+		t.Errorf("the refusal is %q, want it to name the ceiling the package runs under", err)
+	}
+}
+
+// licensedActionFor returns one action the Ultimate catalog has and the Free
+// one does not, so the ceiling test names a real action rather than a made-up
+// one.
+func licensedActionFor(t *testing.T, inst *instance) ActionID {
+	t.Helper()
+
+	ultimate, err := newProjection(edition.Ultimate, inst.client.IsGitLabDotCom())
+	if err != nil {
+		t.Fatalf("building the Ultimate projection: %v", err)
+	}
+	free, err := newProjection(edition.Free, inst.client.IsGitLabDotCom())
+	if err != nil {
+		t.Fatalf("building the Free projection: %v", err)
+	}
+	for id, action := range ultimate.actions {
+		if action.minimumTier == edition.Free {
+			continue
+		}
+		if _, inFree := free.lookup(id); !inFree {
+			return id
+		}
+	}
+	t.Fatal("the Ultimate catalog carries no action the Free one lacks")
+	return ""
+}

--- a/test/e2e/internal/harness/surfaces.go
+++ b/test/e2e/internal/harness/surfaces.go
@@ -1,0 +1,109 @@
+//go:build e2e
+
+// surfaces.go runs one scenario on more than one surface.
+//
+// The same action reached through gitlab_execute_action, through a domain
+// dispatcher and through a declared individual tool is three different code
+// paths in the server: three schemas, three argument shapes, three sets of
+// rewrites on the way to the handler. A scenario written once and run on all
+// three is the only way the suite says anything about the other two, and the
+// suite this replaces had a separate hand-written copy per surface, which is
+// why its coverage of the individual surface was the deepest and its coverage
+// of the default one the shallowest.
+//
+// Each surface runs as a subtest with an Env of its own, because an Env is one
+// test's handle: its context ends with that subtest, its cleanups run when
+// that subtest ends, and its names carry that subtest's name. The parent's Env
+// stays the owner of anything built before the split.
+
+package harness
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// EachSurface runs fn once per surface, as a subtest named after it.
+//
+// The Env fn is given belongs to the subtest, so what it creates is cleaned up
+// when that surface's run ends rather than at the end of the parent.
+func EachSurface(e *Env, fn func(*Env, Surface)) {
+	e.T.Helper()
+	SurfacesWith(e, func(*Env) struct{} { return struct{}{} }, func(env *Env, surface Surface, _ struct{}) {
+		fn(env, surface)
+	})
+}
+
+// OnSurfaces runs fn on the named surfaces only, and says in the test log why
+// the others were left out.
+//
+// The reason is required rather than optional: a scenario that runs on one
+// surface is a hole in the other two, and the coverage report should be able
+// to say whether the hole is deliberate. The usual cause is a fixture that
+// cannot be multiplied, such as a seed the setup script creates exactly once.
+func OnSurfaces(e *Env, reason string, surfaces []Surface, fn func(*Env, Surface)) {
+	e.T.Helper()
+
+	if reason == "" {
+		e.T.Fatal("OnSurfaces needs a reason: a scenario that skips a surface has to say why")
+	}
+	if len(surfaces) == 0 {
+		e.T.Fatal("OnSurfaces was given no surface to run on")
+	}
+	for _, surface := range surfaces {
+		if !slices.Contains(AllSurfaces(), surface) {
+			e.T.Fatalf("OnSurfaces was given an unknown surface %q", surface)
+		}
+	}
+
+	if skipped := missingSurfaces(surfaces); len(skipped) > 0 {
+		e.T.Logf("not run on %s: %s", joinSurfaces(skipped), reason)
+	}
+	runSurfaces(e, surfaces, func(env *Env, surface Surface, _ struct{}) { fn(env, surface) }, struct{}{})
+}
+
+// SurfacesWith builds one fixture on the parent's Env and runs fn on every
+// surface against it.
+//
+// The fixture is built once, on purpose: a project, a merge request or a
+// pipeline costs seconds of a GitLab's time, and three copies of one would
+// treble the suite for nothing. What each surface then does to that fixture is
+// its own, and anything it creates hangs off its own Env.
+func SurfacesWith[F any](e *Env, build func(*Env) F, fn func(*Env, Surface, F)) {
+	e.T.Helper()
+
+	fixture := build(e)
+	runSurfaces(e, AllSurfaces(), fn, fixture)
+}
+
+// runSurfaces opens one subtest per surface, each with an Env of its own.
+func runSurfaces[F any](e *Env, surfaces []Surface, fn func(*Env, Surface, F), fixture F) {
+	e.T.Helper()
+
+	for _, surface := range surfaces {
+		e.T.Run(string(surface), func(t *testing.T) {
+			fn(newEnv(t, e.inst), surface, fixture)
+		})
+	}
+}
+
+// missingSurfaces returns the surfaces not in the given list.
+func missingSurfaces(surfaces []Surface) []Surface {
+	var missing []Surface
+	for _, surface := range AllSurfaces() {
+		if !slices.Contains(surfaces, surface) {
+			missing = append(missing, surface)
+		}
+	}
+	return missing
+}
+
+// joinSurfaces names a set of surfaces in a log line.
+func joinSurfaces(surfaces []Surface) string {
+	names := make([]string, 0, len(surfaces))
+	for _, surface := range surfaces {
+		names = append(names, string(surface))
+	}
+	return fmt.Sprintf("%v", names)
+}

--- a/test/e2e/internal/harness/surfaces_test.go
+++ b/test/e2e/internal/harness/surfaces_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+
+// surfaces_test.go covers the three ways a scenario is run on more than one
+// surface: on all of them, on a stated subset, and on all of them against one
+// fixture built by the parent.
+
+package harness
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestEachSurface_RunsOneSubtestPerSurface checks that a scenario written once
+// reaches all three surfaces, each in a subtest named after it.
+func TestEachSurface_RunsOneSubtestPerSurface(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+
+	var ran []Surface
+	EachSurface(env, func(child *Env, surface Surface) {
+		ran = append(ran, surface)
+		if child.T.Name() != t.Name()+"/"+string(surface) {
+			t.Errorf("the subtest is named %q, want it named after the surface", child.T.Name())
+		}
+		if child.T == env.T {
+			t.Error("the surface was given the parent's own test rather than its subtest")
+		}
+	})
+
+	if !slices.Equal(ran, AllSurfaces()) {
+		t.Errorf("ran on %v, want %v", ran, AllSurfaces())
+	}
+}
+
+// TestEachSurface_ChildEnv_IsItsOwn checks that each surface's Env belongs to
+// its own subtest, so what it creates is undone when that surface ends rather
+// than at the end of the parent.
+func TestEachSurface_ChildEnv_IsItsOwn(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+
+	names := map[string]bool{}
+	EachSurface(env, func(child *Env, _ Surface) {
+		name := child.Name("project")
+		if names[name] {
+			t.Errorf("two surfaces were handed the same name %q", name)
+		}
+		names[name] = true
+		if child.RunID() != env.RunID() {
+			t.Errorf("the child run ID is %q, want the parent's %q", child.RunID(), env.RunID())
+		}
+	})
+
+	if len(names) != len(AllSurfaces()) {
+		t.Errorf("%d surfaces handed out names, want %d", len(names), len(AllSurfaces()))
+	}
+}
+
+// TestOnSurfaces_NamedSurfacesOnly_AndSaysWhyTheRestAreSkipped checks the
+// declared subset.
+//
+// The reason is required because a scenario that runs on one surface is a hole
+// in the other two, and a coverage report should be able to say whether the
+// hole was chosen.
+func TestOnSurfaces_NamedSurfacesOnly_AndSaysWhyTheRestAreSkipped(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+
+	var ran []Surface
+	OnSurfaces(env, "the pending schema migration seed cannot be multiplied",
+		[]Surface{SurfaceDynamic}, func(_ *Env, surface Surface) {
+			ran = append(ran, surface)
+		})
+
+	if !slices.Equal(ran, []Surface{SurfaceDynamic}) {
+		t.Errorf("ran on %v, want only the dynamic surface", ran)
+	}
+}
+
+// TestOnSurfaces_MissingSurfaces_AreNamed checks the helper the log line is
+// built from.
+func TestOnSurfaces_MissingSurfaces_AreNamed(t *testing.T) {
+	cases := []struct {
+		name  string
+		given []Surface
+		want  []Surface
+	}{
+		{name: "one given", given: []Surface{SurfaceDynamic}, want: []Surface{SurfaceMeta, SurfaceIndividual}},
+		{name: "two given", given: []Surface{SurfaceDynamic, SurfaceMeta}, want: []Surface{SurfaceIndividual}},
+		{name: "all given", given: AllSurfaces(), want: nil},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := missingSurfaces(testCase.given); !slices.Equal(got, testCase.want) {
+				t.Errorf("missingSurfaces(%v) = %v, want %v", testCase.given, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestJoinSurfaces_NamesThemForALogLine checks the wording of the line that
+// records a deliberate hole.
+func TestJoinSurfaces_NamesThemForALogLine(t *testing.T) {
+	joined := joinSurfaces([]Surface{SurfaceMeta, SurfaceIndividual})
+
+	for _, want := range []string{"meta", "individual"} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(joined, want) {
+				t.Errorf("joinSurfaces() = %q, want it to name %q", joined, want)
+			}
+		})
+	}
+}
+
+// TestSurfacesWith_BuildsTheFixtureOnceForAllThree checks that one parent
+// fixture serves the three subtests.
+//
+// Building it once is the point: a project, a merge request or a pipeline
+// costs seconds of a GitLab's time, and three copies of one would treble the
+// suite for nothing.
+func TestSurfacesWith_BuildsTheFixtureOnceForAllThree(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+
+	built := 0
+	var seen []string
+	SurfacesWith(env, func(parent *Env) string {
+		built++
+		return parent.Name("fixture")
+	}, func(_ *Env, _ Surface, fixture string) {
+		seen = append(seen, fixture)
+	})
+
+	if built != 1 {
+		t.Errorf("the fixture was built %d times, want once", built)
+	}
+	if len(seen) != len(AllSurfaces()) {
+		t.Fatalf("%d surfaces saw the fixture, want %d", len(seen), len(AllSurfaces()))
+	}
+	for _, fixture := range seen {
+		if fixture != seen[0] {
+			t.Errorf("the surfaces were given different fixtures: %v", seen)
+			break
+		}
+	}
+}

--- a/test/e2e/internal/harness/verbs.go
+++ b/test/e2e/internal/harness/verbs.go
@@ -1,0 +1,247 @@
+//go:build e2e
+
+// verbs.go is everything a client can ask of a server that is not a tool call.
+//
+// They are here rather than beside the tool verbs because they are a different
+// kind of question. A tool call is about an action, which the projection knows
+// how to spell on three surfaces; a resource read, a prompt, a completion and a
+// subscription each address the server directly, by a URI or a name, and are
+// the same on every surface.
+//
+// Raw is the escape hatch, and the only way a test reaches tools/call without
+// naming an action. It exists for the protocol tests, where the subject is the
+// envelope rather than what is inside it: a malformed argument, a tool name no
+// surface registers, a call made to see how the server refuses it.
+
+package harness
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ReadResource reads one resource, failing the test when the server refuses.
+func (s *Session) ReadResource(uri string) *mcp.ReadResourceResult {
+	s.env.T.Helper()
+
+	result, err := s.conn.client().ReadResource(s.env.Ctx, &mcp.ReadResourceParams{URI: uri})
+	if err != nil {
+		s.env.T.Fatalf("resources/read %s: %v%s", uri, err, s.conn.failureContext())
+	}
+	return result
+}
+
+// TryReadResource reads one resource and hands both halves back, for a test
+// whose subject is the refusal.
+func (s *Session) TryReadResource(uri string) (*mcp.ReadResourceResult, error) {
+	s.env.T.Helper()
+	return s.conn.client().ReadResource(s.env.Ctx, &mcp.ReadResourceParams{URI: uri})
+}
+
+// GetPrompt renders one prompt, failing the test when the server refuses.
+func (s *Session) GetPrompt(name string, arguments map[string]string) *mcp.GetPromptResult {
+	s.env.T.Helper()
+
+	result, err := s.conn.client().GetPrompt(s.env.Ctx, &mcp.GetPromptParams{Name: name, Arguments: arguments})
+	if err != nil {
+		s.env.T.Fatalf("prompts/get %s: %v%s", name, err, s.conn.failureContext())
+	}
+	return result
+}
+
+// TryGetPrompt renders one prompt and hands both halves back.
+func (s *Session) TryGetPrompt(name string, arguments map[string]string) (*mcp.GetPromptResult, error) {
+	s.env.T.Helper()
+	return s.conn.client().GetPrompt(s.env.Ctx, &mcp.GetPromptParams{Name: name, Arguments: arguments})
+}
+
+// CompletePrompt asks for the values one prompt argument offers.
+func (s *Session) CompletePrompt(prompt, argument, value string) []string {
+	s.env.T.Helper()
+	return s.complete(&mcp.CompleteReference{Type: "ref/prompt", Name: prompt}, argument, value)
+}
+
+// CompleteResource asks for the values one resource template variable offers.
+func (s *Session) CompleteResource(uriTemplate, argument, value string) []string {
+	s.env.T.Helper()
+	return s.complete(&mcp.CompleteReference{Type: "ref/resource", URI: uriTemplate}, argument, value)
+}
+
+// complete sends one completion request and returns the values it answered.
+func (s *Session) complete(ref *mcp.CompleteReference, argument, value string) []string {
+	s.env.T.Helper()
+
+	result, err := s.conn.client().Complete(s.env.Ctx, &mcp.CompleteParams{
+		Ref:      ref,
+		Argument: mcp.CompleteParamsArgument{Name: argument, Value: value},
+	})
+	if err != nil {
+		s.env.T.Fatalf("completion/complete %s %s: %v%s", completionTarget(ref), argument, err, s.conn.failureContext())
+		return nil
+	}
+	return result.Completion.Values
+}
+
+// completionTarget names what a completion reference addressed, for a message.
+func completionTarget(ref *mcp.CompleteReference) string {
+	if ref.Name != "" {
+		return ref.Name
+	}
+	return ref.URI
+}
+
+// Raw sends one tools/call exactly as given, naming no action.
+//
+// Every other verb goes through the projection, which is what keeps a test
+// from hard-coding a tool name that the surface it runs on does not register.
+// This one deliberately does not, because the protocol tests need to send what
+// no projection would produce.
+func (s *Session) Raw(params *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+	s.env.T.Helper()
+	return s.conn.client().CallTool(s.env.Ctx, params)
+}
+
+// Subscription is one resource this test is watching.
+type Subscription struct {
+	session *Session
+	uri     string
+	updates <-chan struct{}
+}
+
+// URI returns the resource this subscription watches.
+func (s *Subscription) URI() string { return s.uri }
+
+// Subscribe asks the server to notify this session when a resource changes,
+// and unsubscribes when the test ends.
+//
+// The first read the server makes is its authorization check, so a subscribe
+// that is accepted means the credential could read the resource; one it
+// refuses fails the test here rather than at the first update that never
+// arrives.
+func (s *Session) Subscribe(uri string) *Subscription {
+	s.env.T.Helper()
+
+	updates := s.conn.notifier.watch(uri)
+	if err := s.conn.client().Subscribe(s.env.Ctx, &mcp.SubscribeParams{URI: uri}); err != nil {
+		s.conn.notifier.forget(uri, updates)
+		s.env.T.Fatalf("resources/subscribe %s: %v%s", uri, err, s.conn.failureContext())
+		return nil
+	}
+	s.env.T.Cleanup(func() {
+		// A background context, because the test's own is cancelled by the
+		// time cleanups run and an unsubscribe that never reached the server
+		// would leave it polling GitLab for the rest of the run.
+		ctx, cancel := context.WithTimeout(context.Background(), unsubscribeTimeout)
+		defer cancel()
+		_ = s.conn.client().Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: uri})
+		s.conn.notifier.forget(uri, updates)
+	})
+	return &Subscription{session: s, uri: uri, updates: updates}
+}
+
+// unsubscribeTimeout bounds the unsubscribe a subscription's cleanup sends.
+const unsubscribeTimeout = 30 * time.Second
+
+// Next waits for the next update notification for this resource, and fails the
+// test when none arrives in time.
+func (s *Subscription) Next(timeout time.Duration) {
+	s.session.env.T.Helper()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-s.updates:
+	case <-timer.C:
+		s.session.env.T.Fatalf("no resources/updated notification for %s within %s", s.uri, timeout)
+	case <-s.session.env.Ctx.Done():
+		s.session.env.T.Fatalf("waiting for an update to %s: %v", s.uri, s.session.env.Ctx.Err())
+	}
+}
+
+// TryNext waits for the next update and reports whether one arrived, for a
+// test whose subject is that no notification should come.
+func (s *Subscription) TryNext(timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-s.updates:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+// updateNotifier fans a session's resource-updated notifications out to the
+// subscriptions its tests opened.
+//
+// One session is shared by many tests, and the SDK delivers a notification to
+// the client rather than to whoever subscribed, so the fan-out has to happen
+// here. Each watcher gets a buffered channel of its own and a delivery that
+// would block is dropped: a test waiting for the next change is not made more
+// correct by a queue of changes it never read.
+type updateNotifier struct {
+	mu       sync.Mutex
+	watchers map[string][]chan struct{}
+}
+
+// updateBuffer is how many notifications one watcher may fall behind by.
+const updateBuffer = 8
+
+// newUpdateNotifier returns a notifier watching nothing.
+func newUpdateNotifier() *updateNotifier {
+	return &updateNotifier{watchers: map[string][]chan struct{}{}}
+}
+
+// watch registers a channel for one URI.
+func (n *updateNotifier) watch(uri string) chan struct{} {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	updates := make(chan struct{}, updateBuffer)
+	n.watchers[uri] = append(n.watchers[uri], updates)
+	return updates
+}
+
+// forget drops one watcher.
+func (n *updateNotifier) forget(uri string, updates chan struct{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	remaining := n.watchers[uri][:0]
+	for _, watcher := range n.watchers[uri] {
+		if watcher != updates {
+			remaining = append(remaining, watcher)
+		}
+	}
+	if len(remaining) == 0 {
+		delete(n.watchers, uri)
+		return
+	}
+	n.watchers[uri] = remaining
+}
+
+// deliver hands one notification to every watcher of a URI.
+func (n *updateNotifier) deliver(uri string) {
+	n.mu.Lock()
+	watchers := make([]chan struct{}, len(n.watchers[uri]))
+	copy(watchers, n.watchers[uri])
+	n.mu.Unlock()
+
+	for _, watcher := range watchers {
+		select {
+		case watcher <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// watching reports how many watchers one URI has, which is what a test of the
+// fan-out asserts on.
+func (n *updateNotifier) watching(uri string) int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.watchers[uri])
+}

--- a/test/e2e/internal/harness/verbs_test.go
+++ b/test/e2e/internal/harness/verbs_test.go
@@ -1,0 +1,191 @@
+//go:build e2e
+
+// verbs_test.go covers the parts of the non-tool verbs that can be tested
+// without a GitLab: the fan-out that decides which test a resource-updated
+// notification reaches, and the resource reads a stub instance can answer.
+//
+// The fan-out is the piece worth testing on its own. One session is shared by
+// many tests and the SDK delivers a notification to the client rather than to
+// whoever subscribed, so a test waiting for its own resource to change is
+// waiting on a channel this code chose.
+
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestUpdateNotifier_OneResource_ReachesEveryWatcher checks that two tests
+// watching one resource are both told when it changes.
+func TestUpdateNotifier_OneResource_ReachesEveryWatcher(t *testing.T) {
+	notifier := newUpdateNotifier()
+	first := notifier.watch("gitlab://project/7")
+	second := notifier.watch("gitlab://project/7")
+
+	notifier.deliver("gitlab://project/7")
+
+	watchers := map[string]chan struct{}{"first": first, "second": second}
+	for name, updates := range watchers {
+		t.Run(name, func(t *testing.T) {
+			select {
+			case <-updates:
+			default:
+				t.Error("a watcher of the changed resource was not told")
+			}
+		})
+	}
+}
+
+// TestUpdateNotifier_AnotherResource_ReachesNobody checks that a watcher is
+// only told about the resource it asked for, which is what lets one session
+// carry several tests' subscriptions.
+func TestUpdateNotifier_AnotherResource_ReachesNobody(t *testing.T) {
+	notifier := newUpdateNotifier()
+	updates := notifier.watch("gitlab://project/7")
+
+	notifier.deliver("gitlab://project/8")
+
+	select {
+	case <-updates:
+		t.Error("a watcher of project 7 was told about project 8")
+	default:
+	}
+}
+
+// TestUpdateNotifier_Forget_StopsDelivery checks that a subscription's cleanup
+// really unhooks it, so a test that has ended cannot be handed a notification
+// for a resource it no longer cares about.
+func TestUpdateNotifier_Forget_StopsDelivery(t *testing.T) {
+	notifier := newUpdateNotifier()
+	kept := notifier.watch("gitlab://project/7")
+	dropped := notifier.watch("gitlab://project/7")
+
+	notifier.forget("gitlab://project/7", dropped)
+	if watching := notifier.watching("gitlab://project/7"); watching != 1 {
+		t.Fatalf("the resource has %d watchers after one was dropped, want 1", watching)
+	}
+	notifier.deliver("gitlab://project/7")
+
+	select {
+	case <-dropped:
+		t.Error("a dropped watcher was still delivered to")
+	default:
+	}
+	select {
+	case <-kept:
+	default:
+		t.Error("the remaining watcher was not delivered to")
+	}
+}
+
+// TestUpdateNotifier_LastWatcherForgotten_LeavesNoEntry checks that a resource
+// nobody watches any more is dropped rather than accumulating for the life of
+// the run.
+func TestUpdateNotifier_LastWatcherForgotten_LeavesNoEntry(t *testing.T) {
+	notifier := newUpdateNotifier()
+	updates := notifier.watch("gitlab://project/7")
+
+	notifier.forget("gitlab://project/7", updates)
+
+	if watching := notifier.watching("gitlab://project/7"); watching != 0 {
+		t.Errorf("the resource still has %d watchers", watching)
+	}
+	// Delivering to nobody must not panic: a notification can arrive after the
+	// test that subscribed has ended and its cleanup has run.
+	notifier.deliver("gitlab://project/7")
+}
+
+// TestUpdateNotifier_SlowWatcher_IsNotBlockedOn checks that a test that never
+// read its updates cannot stop the session's notification handler.
+//
+// The handler runs on the client's own goroutine, so a blocking send there
+// would stall every other notification the session delivers, including those
+// other tests are waiting for.
+func TestUpdateNotifier_SlowWatcher_IsNotBlockedOn(t *testing.T) {
+	notifier := newUpdateNotifier()
+	notifier.watch("gitlab://project/7")
+
+	for range updateBuffer * 3 {
+		notifier.deliver("gitlab://project/7")
+	}
+}
+
+// TestSession_ReadResource_ReadsThroughTheRealBinary checks the resource verb
+// end to end against a session of the real server.
+//
+// gitlab://tools is the one resource every surface serves and that needs
+// nothing of GitLab, so it is what this can assert on with a stub behind it.
+func TestSession_ReadResource_ReadsThroughTheRealBinary(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Private: true})
+
+	result := session.ReadResource("gitlab://tools")
+
+	if len(result.Contents) == 0 {
+		t.Fatal("gitlab://tools answered with no content")
+	}
+	if !strings.Contains(result.Contents[0].Text, "gitlab_execute_action") {
+		t.Errorf("the tool manifest does not mention the dynamic execute tool: %.200s", result.Contents[0].Text)
+	}
+}
+
+// TestSession_TryReadResource_UnknownURI_ReportsInsteadOfFailing checks the
+// escape hatch a test of a refusal needs.
+func TestSession_TryReadResource_UnknownURI_ReportsInsteadOfFailing(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Private: true})
+
+	_, err := session.TryReadResource("gitlab://not-a-resource")
+
+	if err == nil {
+		t.Fatal("a resource the server does not serve was read without an error")
+	}
+}
+
+// TestSession_Raw_SendsExactlyWhatItIsGiven checks that the protocol escape
+// hatch names no action and applies no projection.
+//
+// It is what the protocol tests need: a tool name no surface registers, sent
+// as written, so the refusal the server makes is the subject.
+func TestSession_Raw_SendsExactlyWhatItIsGiven(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Private: true})
+
+	result, err := session.Raw(&mcp.CallToolParams{Name: "gitlab_not_a_tool", Arguments: map[string]any{}})
+
+	if err == nil && (result == nil || !result.IsError) {
+		t.Fatal("a tool nothing registers was accepted")
+	}
+}
+
+// TestSession_Prompts_AreListedOnTheFullCapabilitySurface checks the listings
+// a session records when it starts, which the coverage record's session line
+// is built from.
+func TestSession_Prompts_AreListedOnTheFullCapabilitySurface(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Private: true})
+
+	cases := []struct {
+		name string
+		got  int
+	}{
+		{name: "tools", got: len(session.Tools())},
+		{name: "resources", got: len(session.Resources())},
+		{name: "resource templates", got: len(session.ResourceTemplates())},
+		{name: "prompts", got: len(session.Prompts())},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.got == 0 {
+				t.Errorf("the session listed no %s, and the full capability surface serves several", testCase.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Step S05 of the e2e rebuild (issue 704): the layer between a test and a tool call.

Sessions start lazily, one per `ServerConfig` key: surface, mode, capabilities, credential (hashed, never printed), exclusions, elicitation policy and transport, with `Private` and a scripted responder taking a number nothing else can name. Every field maps onto a variable the binary reads; there is no configure hook, because the point of the rebuild is that the binary configures itself the way a client configures it.

A session's first act is the served-set check: it lists tools, resources, templates and prompts once and compares the catalog-backed tool names with what `tools.SharedMetaCatalog`, `tools.SharedIndividualCatalog` and `dynamiccatalog.Build` say for the `config.ServerConfig` the binary built for itself, tier probed, scopes narrowed, read-only and safe mode applied. Registration's last step is replayed where the catalog does not carry it: one tool per group on meta, the two find/execute tools on dynamic, one tool per declared name on individual with the first declarer keeping it. A surface serving more or less than that fails before any test runs.

`Do`, `DoVoid`, `Try`, `Refused` and `Eventually` project a canonical action id onto whichever surface the session serves, decode `StructuredContent` first, and classify the outcome the same way for the assertion and for the record. The non-tool verbs read resources, templates, prompts and completions through the same session. The HTTP transport is declared and refused with a stated error: the launcher starts the binary over its standard streams, and a loopback listener is a later step.
