### PR TITLE
feat(e2e): record what the server dispatched, not what the test asked for

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.22.0
 	go.opentelemetry.io/otel/sdk/metric v1.46.0
 	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/proto/otlp v1.11.0
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.56.0
 	golang.org/x/image v0.45.0
@@ -35,6 +36,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.49.0
+	google.golang.org/protobuf v1.36.12
 )
 
 require (
@@ -65,7 +67,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 // indirect
@@ -75,7 +76,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/grpc v1.83.1 // indirect
-	google.golang.org/protobuf v1.36.12 // indirect
 	gotest.tools/gotestsum v1.13.0 // indirect
 )
 

--- a/test/e2e/internal/harness/call.go
+++ b/test/e2e/internal/harness/call.go
@@ -33,6 +33,15 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
+// Expectation classes a call record can carry beside a [Failure], spelled as
+// the record spells them.
+const (
+	// ExpectationOK is a call the test expected to succeed.
+	ExpectationOK = e2ecalls.ExpectationOK
+	// ExpectationAny is a call whose outcome the test did not constrain.
+	ExpectationAny = e2ecalls.ExpectationAny
+)
+
 // Purpose says what a call was made for. A call made to build or tear down
 // fixture state is worth less as coverage than one a test asserted on, so it
 // is recorded rather than guessed at from the test name.
@@ -97,6 +106,13 @@ type callOptions struct {
 	purpose Purpose
 	confirm bool
 	timeout time.Duration
+	// expectation is what the caller asked to happen, in the record's
+	// vocabulary. Each verb sets it rather than the caller, because the verb
+	// is the assertion: Do expects success, Refused expects a class.
+	expectation string
+	// dispatch is the route the caller declared this call would run, when the
+	// server rewrites what was asked for.
+	dispatch ActionID
 }
 
 // CallOption adjusts one call.
@@ -105,6 +121,18 @@ type CallOption func(*callOptions)
 // For declares what a call was made for. Without it a call is PurposeTest.
 func For(purpose Purpose) CallOption {
 	return func(o *callOptions) { o.purpose = purpose }
+}
+
+// ExpectDispatch declares the route this call will actually run, for the cases
+// where the server rewrites what it was asked for.
+//
+// Without it, a call whose span names another route fails its test, which is
+// the assertion the whole recorder exists to make: a call that named issue.list
+// and ran issue.get proves nothing about issue.list. The rewrites are real and
+// deliberate, though: gitlab_environment get with an environment name runs
+// protected_get, so a test of that behavior says so here and is held to it.
+func ExpectDispatch(route ActionID) CallOption {
+	return func(o *callOptions) { o.dispatch = route }
 }
 
 // WithoutConfirmation sends a destructive action with no explicit approval,
@@ -121,13 +149,21 @@ func Within(timeout time.Duration) CallOption {
 }
 
 // resolveCallOptions applies the caller's options over the defaults: a test
-// call, confirmed if destructive, bounded by the test's own context.
+// call, confirmed if destructive, bounded by the test's own context, expected
+// to succeed.
 func resolveCallOptions(opts []CallOption) callOptions {
-	resolved := callOptions{purpose: PurposeTest, confirm: true}
+	resolved := callOptions{purpose: PurposeTest, confirm: true, expectation: e2ecalls.ExpectationOK}
 	for _, opt := range opts {
 		opt(&resolved)
 	}
 	return resolved
+}
+
+// expecting returns the options with the expectation a verb makes of its call,
+// which is the verb's own and not the caller's to override.
+func (o callOptions) expecting(expectation string) callOptions {
+	o.expectation = expectation
+	return o
 }
 
 // callResult is one answer, classified.
@@ -208,7 +244,7 @@ func Try[O any](s *Session, id ActionID, params map[string]any, opts ...CallOpti
 	s.env.T.Helper()
 
 	var output O
-	answer := s.invoke(id, params, resolveCallOptions(opts))
+	answer := s.invoke(id, params, resolveCallOptions(opts).expecting(e2ecalls.ExpectationAny))
 	if !answer.ok() {
 		return output, errors.New(answer.describe())
 	}
@@ -223,7 +259,7 @@ func Try[O any](s *Session, id ActionID, params map[string]any, opts ...CallOpti
 func Refused(s *Session, id ActionID, params map[string]any, want Failure, opts ...CallOption) string {
 	s.env.T.Helper()
 
-	resolved := resolveCallOptions(opts)
+	resolved := resolveCallOptions(opts).expecting(string(want))
 	answer := s.invoke(id, params, resolved)
 	if answer.failure == "" {
 		s.env.T.Fatalf("%s: the server ran the action, and the test expected it to be refused as %s",
@@ -246,7 +282,7 @@ func Refused(s *Session, id ActionID, params map[string]any, want Failure, opts 
 func ExpectToolError(s *Session, id ActionID, params map[string]any, contains string, opts ...CallOption) string {
 	s.env.T.Helper()
 
-	resolved := resolveCallOptions(opts)
+	resolved := resolveCallOptions(opts).expecting(string(FailureToolError))
 	answer := s.invoke(id, params, resolved)
 	if answer.failure == "" {
 		s.env.T.Fatalf("%s: the server ran the action, and the test expected an error mentioning %q",
@@ -321,7 +357,7 @@ func (s *Session) invoke(id ActionID, params map[string]any, opts callOptions) c
 		s.env.T.Fatalf("%v", err)
 		return callResult{}
 	}
-	return s.send(call, opts)
+	return s.send(id, call, opts)
 }
 
 // resolve turns an action ID into the call this session takes, refusing the
@@ -356,8 +392,18 @@ func (s *Session) resolve(id ActionID, params map[string]any, confirm bool) (too
 }
 
 // send makes the call, retrying what failed in transit.
-func (s *Session) send(call toolCall, opts callOptions) callResult {
-	ctx := s.env.Ctx
+//
+// The context carries who is making it, which is what the recorder reads on
+// the way out: the middleware sits on a client many tests share, and only the
+// caller knows whose call this is, what it is for and what it expects. Each
+// attempt passes through that middleware and so gets a trace and a record of
+// its own, which is right: a retry is another call, and two identical lines
+// would be one line in a record deduplicated by content.
+func (s *Session) send(id ActionID, call toolCall, opts callOptions) callResult {
+	ctx := s.attribute(opts.purpose, opts.expectation, callAttribution{
+		action:       id,
+		wantDispatch: opts.dispatch,
+	})
 	if opts.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, opts.timeout)

--- a/test/e2e/internal/harness/env.go
+++ b/test/e2e/internal/harness/env.go
@@ -40,9 +40,10 @@ type Env struct {
 	// with it.
 	Ctx context.Context
 
-	runID  string
-	ledger *ledger
-	inst   *instance
+	runID    string
+	ledger   *ledger
+	inst     *instance
+	recorder *envRecorder
 }
 
 // New prepares the harness for one test and returns its Env.
@@ -70,7 +71,18 @@ func newEnv(t *testing.T, inst *instance, opts ...Option) *Env {
 	for _, opt := range opts {
 		opt(&options)
 	}
-	requireNeeds(t, inst, options.needs)
+
+	env := &Env{T: t, runID: inst.runID, ledger: &ledger{}, inst: inst}
+	env.recorder = newEnvRecorder(env)
+	// Registered before anything else, and therefore run after everything
+	// else: t.Cleanup is last-in-first-out, so by the time the record is
+	// written the ledger has undone what the test created and the calls that
+	// undoing made are in the buffer too. It is also registered before the
+	// needs are checked, so a test skipped for want of a runner still writes
+	// the skip line that says so.
+	t.Cleanup(env.recorder.flush)
+
+	requireNeeds(t, inst, options.needs, env.recorder)
 
 	// Registered in this order on purpose: t.Cleanup runs last-in-first-out,
 	// so the ledger's undo work still holds every lock the test declared, and
@@ -82,14 +94,27 @@ func newEnv(t *testing.T, inst *instance, opts ...Option) *Env {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
+	env.Ctx = ctx
 
-	env := &Env{T: t, Ctx: ctx, runID: inst.runID, ledger: &ledger{}, inst: inst}
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), inst.cleanupBudget())
 		defer cleanupCancel()
 		env.ledger.cleanupAll(cleanupCtx, t)
 	})
 	return env
+}
+
+// Skipf ends this test with a reason the record carries.
+//
+// The testing package keeps a skip's reason to itself, so a test that calls
+// t.Skip directly is written down as skipped with no reason. This is how a
+// test says why, and the coverage report then reads "absent because there was
+// no runner" rather than an empty cell.
+func (e *Env) Skipf(format string, args ...any) {
+	e.T.Helper()
+	reason := fmt.Sprintf(format, args...)
+	e.recorder.noteSkip(reason)
+	e.T.Skip(reason)
 }
 
 // RunID returns the identifier every name this test hands out carries.

--- a/test/e2e/internal/harness/main.go
+++ b/test/e2e/internal/harness/main.go
@@ -48,6 +48,13 @@ const (
 	envRuntimeMismatch = "E2E_RUNTIME_MISMATCH"
 	envExternalNetwork = "E2E_EXTERNAL_NETWORK"
 	envFixtureURL      = "E2E_FIXTURE_URL"
+	// envCommit is the revision under test, recorded on the run line so a
+	// coverage report can be tied to the tree that produced it.
+	envCommit = "E2E_COMMIT"
+	// envSeeds is the comma-separated list of per-consumer seeds the
+	// provisioning script created. A scenario whose seed was not provisioned
+	// is absent rather than failing, and the run line is where that shows.
+	envSeeds = "E2E_SEEDS"
 
 	envBitbucketServerURL = "BITBUCKET_SERVER_URL"
 	envGitHubToken        = "GH_TOKEN"
@@ -125,10 +132,15 @@ func Main(m *testing.M, req Requirement) int {
 
 	code := m.Run()
 
+	// While the sessions are still alive, so a session line can say what it
+	// served and whether its dispatch was ever observed.
+	flushRunRecords()
+
 	// Before the binary is removed, and in this order: on Windows a running
 	// executable cannot be deleted, so a child left alive would leave the
 	// build behind on every run.
 	closeSessions()
+	closeSpanReceiver()
 	removeBuiltBinary()
 	return state.finish(code)
 }

--- a/test/e2e/internal/harness/needs.go
+++ b/test/e2e/internal/harness/needs.go
@@ -18,6 +18,7 @@ package harness
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -197,11 +198,18 @@ func (inst *instance) hasRunner() bool {
 
 // requireNeeds skips the test, naming the first requirement this run does not
 // provide.
-func requireNeeds(t *testing.T, inst *instance, needs []Need) {
+//
+// The reason goes to the recorder before the skip, because the testing package
+// keeps a skip message to itself: a coverage report that could not say why a
+// scenario was absent would read the same whether the fixture stack was
+// incomplete or the scenario was never written.
+func requireNeeds(t *testing.T, inst *instance, needs []Need, rec *envRecorder) {
 	t.Helper()
 	for _, need := range needs {
 		if ok, reason := need.available(inst); !ok {
-			t.Skipf("%s unavailable: %s", need.name, reason)
+			message := fmt.Sprintf("%s unavailable: %s", need.name, reason)
+			rec.noteSkip(message)
+			t.Skip(message)
 		}
 	}
 }

--- a/test/e2e/internal/harness/otlp.go
+++ b/test/e2e/internal/harness/otlp.go
@@ -1,0 +1,378 @@
+//go:build e2e
+
+// otlp.go is the half of the record that comes from the server rather than
+// from the client.
+//
+// A client knows what it asked for. It does not know what ran, and the two
+// differ on purpose: a meta or dynamic call naming an environment by name
+// dispatches protected_get rather than get, and an individual safe-mode call
+// answers with a preview of a mutation nobody made. Crediting the requested
+// action would credit an action that never ran, which is the defect the suite
+// this replaces shipped for years.
+//
+// So every child runs with telemetry on, pointed at a receiver the harness
+// serves on loopback, and the harness stamps a W3C traceparent into each call
+// it makes. The server reads that traceparent out of _meta, which it already
+// does for any instrumented caller, so its span carries the harness's trace id
+// and the route the dispatcher actually chose. Joining the two is one map
+// lookup on a trace id.
+//
+// Only the traces are read. Metrics and logs are accepted and dropped, because
+// refusing them would make the child's exporter retry for the whole run.
+
+package harness
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"maps"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/mcpotel"
+)
+
+// maxExportBytes bounds one OTLP payload the receiver reads.
+//
+// A child of this suite exports its own spans and nothing else, so a payload
+// this large is a bug rather than a busy run; the bound is here so that a
+// runaway exporter cannot take the test process's memory with it.
+const maxExportBytes = 16 << 20
+
+// receiverReadHeaderTimeout bounds how long the receiver waits for a child's
+// request headers. It exists because an HTTP server with no timeout is a
+// finding in every scanner, and because a child that hangs mid-header should
+// not hold a connection for the life of the run.
+const receiverReadHeaderTimeout = 30 * time.Second
+
+// dispatchRecord is what the server's own span said about one call.
+//
+// Five attributes and a status, which is the whole of what the coverage audit
+// asks of the server side: what ran, in which domain, under which tool, and
+// whether the server declined it and why.
+type dispatchRecord struct {
+	// tool is gen_ai.tool.name: the tool the client named.
+	tool string
+	// action is gitlab_mcp.action: the route the dispatcher chose, after every
+	// alias rewrite.
+	action string
+	// domain is gitlab_mcp.domain.
+	domain string
+	// refusalReason is gitlab_mcp.refusal_reason, set when the server declined
+	// to run what it was asked for.
+	refusalReason string
+	// errorType is error.type.
+	errorType string
+	// status is the span status code, as the protocol spells it.
+	status string
+}
+
+// carriesFacts reports whether a span said anything this record is for.
+//
+// A trace holds more than the MCP server span: every GitLab request the
+// handler made is a child span of it, and none of those carries any of these
+// attributes. Merging one would overwrite the facts with emptiness, so a span
+// that carries none of them is dropped instead.
+func (d dispatchRecord) carriesFacts() bool {
+	return d.tool != "" || d.action != "" || d.domain != "" || d.refusalReason != "" || d.errorType != ""
+}
+
+// merge fills this record's empty fields from another, first non-empty
+// winning, so several spans of one trace add up rather than replace.
+func (d dispatchRecord) merge(other dispatchRecord) dispatchRecord {
+	fields := []struct {
+		into *string
+		from string
+	}{
+		{&d.tool, other.tool},
+		{&d.action, other.action},
+		{&d.domain, other.domain},
+		{&d.refusalReason, other.refusalReason},
+		{&d.errorType, other.errorType},
+		{&d.status, other.status},
+	}
+	for _, field := range fields {
+		if *field.into == "" {
+			*field.into = field.from
+		}
+	}
+	return d
+}
+
+// spanReceiver is the OTLP/HTTP endpoint every child exports to.
+//
+// It keeps only the traces the harness issued. A trace id it never stamped
+// belongs to work no test asked for, such as the server's own startup, and
+// keeping those would grow a map nothing ever reads.
+type spanReceiver struct {
+	// url is the base endpoint a child is pointed at.
+	url string
+
+	mu     sync.Mutex
+	issued map[string]struct{}
+	seen   map[string]dispatchRecord
+
+	// observed is set the first time any dispatch arrives, so a run whose
+	// telemetry never worked can stop waiting for spans that are not coming.
+	observed atomic.Bool
+
+	server   *http.Server
+	listener net.Listener
+}
+
+// The receiver is started once per test process, by whichever session starts
+// first, because its endpoint has to be in the child's environment before that
+// child is launched.
+var (
+	receiverOnce sync.Once
+	receiver     *spanReceiver
+	errReceiver  error
+	// startedSpans is the receiver once it is running, readable from any
+	// goroutine without starting one. The recorder needs exactly that: a test
+	// that made no call must not bind a listener on its way out, and reading
+	// the variable above while another test is starting a session would be a
+	// race.
+	startedSpans atomic.Pointer[spanReceiver]
+)
+
+// spans returns this process's receiver, starting it on the first call.
+func spans() (*spanReceiver, error) {
+	receiverOnce.Do(func() {
+		receiver, errReceiver = startSpanReceiver()
+		if errReceiver == nil {
+			startedSpans.Store(receiver)
+		}
+	})
+	return receiver, errReceiver
+}
+
+// receiverIfStarted returns the running receiver, or nil when none was ever
+// started. It never starts one.
+func receiverIfStarted() *spanReceiver { return startedSpans.Load() }
+
+// startSpanReceiver binds a loopback listener and serves OTLP over it.
+//
+// Loopback because the children are local processes and nothing else has any
+// business reading this suite's spans; port zero because several test binaries
+// of one run are alive at once and a fixed port would make the second refuse
+// to start.
+func startSpanReceiver() (*spanReceiver, error) {
+	var config net.ListenConfig
+	listener, err := config.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("binding the loopback OTLP receiver: %w", err)
+	}
+
+	received := &spanReceiver{
+		url:      "http://" + listener.Addr().String(),
+		issued:   map[string]struct{}{},
+		seen:     map[string]dispatchRecord{},
+		listener: listener,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/traces", received.receiveTraces)
+	// Metrics and logs are exported to the same endpoint and are of no use
+	// here. They are acknowledged rather than refused: a 404 makes the child's
+	// exporter retry the same payload for the rest of the run, which costs the
+	// server under test a background goroutine and the log a warning per batch.
+	mux.HandleFunc("/", acknowledgeExport)
+
+	received.server = &http.Server{Handler: mux, ReadHeaderTimeout: receiverReadHeaderTimeout}
+	go func() {
+		if serveErr := received.server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			log.Printf("e2e: the OTLP receiver stopped: %v", serveErr)
+		}
+	}()
+	return received, nil
+}
+
+// closeSpanReceiver stops the receiver, if one was started.
+//
+// Main calls it after the last record is written. Nothing depends on it in a
+// run that ends normally, since the process is about to exit; it is here so
+// that the listener is released in the order the rest of the shutdown happens
+// in rather than by the operating system.
+func closeSpanReceiver() {
+	if receiver == nil || receiver.server == nil {
+		return
+	}
+	_ = receiver.server.Close()
+}
+
+// issue records a trace id the harness stamped into a call, so the spans of
+// that call are the ones the receiver keeps.
+func (r *spanReceiver) issue(traceID string) {
+	if traceID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.issued[traceID] = struct{}{}
+}
+
+// lookup returns what the server said about one trace, and whether any span of
+// it has arrived.
+func (r *spanReceiver) lookup(traceID string) (dispatchRecord, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	record, found := r.seen[traceID]
+	return record, found
+}
+
+// all returns every dispatch the receiver has kept, keyed by trace id.
+func (r *spanReceiver) all() map[string]dispatchRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return maps.Clone(r.seen)
+}
+
+// receiveTraces decodes one export and keeps what it says about the calls this
+// harness made.
+func (r *spanReceiver) receiveTraces(w http.ResponseWriter, req *http.Request) {
+	body, err := readExportBody(req)
+	if err != nil {
+		http.Error(w, "the export could not be read", http.StatusBadRequest)
+		return
+	}
+
+	var export coltracepb.ExportTraceServiceRequest
+	if err = proto.Unmarshal(body, &export); err != nil {
+		http.Error(w, "the export is not an OTLP trace request", http.StatusBadRequest)
+		return
+	}
+
+	r.absorb(&export)
+	acknowledgeExport(w, req)
+}
+
+// absorb folds every span of an export into the traces the harness issued.
+func (r *spanReceiver) absorb(export *coltracepb.ExportTraceServiceRequest) {
+	for _, resourceSpans := range export.GetResourceSpans() {
+		for _, scopeSpans := range resourceSpans.GetScopeSpans() {
+			for _, span := range scopeSpans.GetSpans() {
+				r.absorbSpan(span)
+			}
+		}
+	}
+}
+
+// absorbSpan keeps one span's facts, if the harness issued its trace and the
+// span carries any.
+func (r *spanReceiver) absorbSpan(span *tracepb.Span) {
+	traceID := hex.EncodeToString(span.GetTraceId())
+	if traceID == "" {
+		return
+	}
+	facts := spanFacts(span)
+	if !facts.carriesFacts() {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, issued := r.issued[traceID]; !issued {
+		return
+	}
+	r.seen[traceID] = r.seen[traceID].merge(facts)
+	r.observed.Store(true)
+}
+
+// spanFacts reads the attributes the record is made of off one span.
+//
+// The attribute keys come from internal/mcpotel rather than being spelled
+// again here: they are the server's own, and a second spelling of them would
+// be a record that quietly emptied itself the day one was renamed.
+func spanFacts(span *tracepb.Span) dispatchRecord {
+	var facts dispatchRecord
+	into := map[string]*string{
+		string(mcpotel.AttrGenAIToolName): &facts.tool,
+		string(mcpotel.AttrActionID):      &facts.action,
+		string(mcpotel.AttrDomain):        &facts.domain,
+		string(mcpotel.AttrRefusalReason): &facts.refusalReason,
+		string(mcpotel.AttrErrorType):     &facts.errorType,
+	}
+	for _, attribute := range span.GetAttributes() {
+		if target, wanted := into[attribute.GetKey()]; wanted {
+			*target = attribute.GetValue().GetStringValue()
+		}
+	}
+	if !facts.carriesFacts() {
+		return facts
+	}
+	facts.status = span.GetStatus().GetCode().String()
+	return facts
+}
+
+// readExportBody reads one request body, decompressing it when the exporter
+// compressed it.
+//
+// The Go OTLP/HTTP exporter sends uncompressed protobuf unless it is told
+// otherwise, and this suite does not tell it otherwise. Handling gzip anyway
+// costs eight lines and removes a way for the whole record to go silently
+// empty if that default ever changes.
+func readExportBody(req *http.Request) ([]byte, error) {
+	reader := io.LimitReader(req.Body, maxExportBytes)
+	if req.Header.Get("Content-Encoding") == "gzip" {
+		decompressed, err := gzip.NewReader(reader)
+		if err != nil {
+			return nil, fmt.Errorf("decompressing the export: %w", err)
+		}
+		defer decompressed.Close()
+		reader = io.LimitReader(decompressed, maxExportBytes)
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading the export: %w", err)
+	}
+	return body, nil
+}
+
+// acknowledgeExport answers one export the way a collector does.
+//
+// An empty ExportServiceResponse is zero bytes of protobuf, which is what a
+// successful export looks like on the wire. Answering anything else makes the
+// exporter treat it as a partial success and log about it.
+func acknowledgeExport(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	w.WriteHeader(http.StatusOK)
+}
+
+// telemetryVariables returns the environment that points one child at this
+// process's receiver.
+//
+// It is called once per session, from the one place a child's environment is
+// built, and it is what makes the dispatch half of the record exist at all. A
+// receiver that cannot start is logged and the child runs without telemetry:
+// the suite is still a suite, the sessions it starts are marked
+// dispatch-unobserved, and every call of theirs is recorded as a claim about
+// what was asked for rather than about what ran.
+func telemetryVariables() map[string]string {
+	received, err := spans()
+	if err != nil {
+		log.Printf("e2e: no OTLP receiver, so no session can say what it dispatched: %v", err)
+		return nil
+	}
+	return map[string]string{
+		"GITLAB_MCP_TELEMETRY":        "true",
+		"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+		"OTEL_EXPORTER_OTLP_ENDPOINT": received.url,
+		// Milliseconds, as an integer: the specification defines every OTEL_
+		// duration that way, and "100ms" parses as nothing and silently keeps
+		// the five-second default, which is longer than a test's whole flush.
+		"OTEL_BSP_SCHEDULE_DELAY": "100",
+	}
+}

--- a/test/e2e/internal/harness/otlp_test.go
+++ b/test/e2e/internal/harness/otlp_test.go
@@ -1,0 +1,343 @@
+//go:build e2e
+
+// otlp_test.go covers the receiver on its own terms: a payload built by hand,
+// posted the way the exporter posts one, and read back as the facts a call
+// line joins to.
+//
+// The whole-binary half is in record_test.go, which is where the two halves
+// meet. What is here is the decoding, the filtering and the refusals, each of
+// which fails silently if it is wrong: a receiver that dropped every span
+// would leave a record that looks complete and says nothing about what ran.
+
+package harness
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/mcpotel"
+)
+
+// testTraceID is the trace the hand-built spans below belong to.
+const testTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+// exportTimeout bounds the requests these tests make of their own receiver.
+const exportTimeout = 10 * time.Second
+
+// stubSpan builds one span carrying the attributes a call line reads.
+func stubSpan(traceID string, attributes map[string]string, code tracepb.Status_StatusCode) *tracepb.Span {
+	decoded, err := hex.DecodeString(traceID)
+	if err != nil {
+		decoded = nil
+	}
+	span := &tracepb.Span{TraceId: decoded, Name: "tools/call", Status: &tracepb.Status{Code: code}}
+	for key, value := range attributes {
+		span.Attributes = append(span.Attributes, &commonpb.KeyValue{
+			Key:   key,
+			Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: value}},
+		})
+	}
+	return span
+}
+
+// exportOf wraps spans in the request an exporter sends.
+func exportOf(spans ...*tracepb.Span) *coltracepb.ExportTraceServiceRequest {
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: spans}},
+		}},
+	}
+}
+
+// postExport sends one payload to a receiver the way the exporter does, and
+// returns the status it answered.
+func postExport(t *testing.T, url, path string, body []byte, encoding string) int {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url+path, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the export request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	if encoding != "" {
+		req.Header.Set("Content-Encoding", encoding)
+	}
+
+	client := &http.Client{Timeout: exportTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("posting the export: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// startTestReceiver starts a receiver of this test's own, apart from the one
+// the sessions share.
+func startTestReceiver(t *testing.T) *spanReceiver {
+	t.Helper()
+
+	received, err := startSpanReceiver()
+	if err != nil {
+		t.Fatalf("starting the receiver: %v", err)
+	}
+	t.Cleanup(func() { _ = received.server.Close() })
+	return received
+}
+
+// marshalExport encodes an export, failing the test when it cannot.
+func marshalExport(t *testing.T, export *coltracepb.ExportTraceServiceRequest) []byte {
+	t.Helper()
+
+	body, err := proto.Marshal(export)
+	if err != nil {
+		t.Fatalf("encoding the export: %v", err)
+	}
+	return body
+}
+
+// TestSpanReceiver_IssuedTrace_KeepsWhatTheServerSaid is the join the whole
+// record rests on: the harness stamps a trace, the server's span carries it
+// back, and these are the five facts read off it.
+func TestSpanReceiver_IssuedTrace_KeepsWhatTheServerSaid(t *testing.T) {
+	received := startTestReceiver(t)
+	received.issue(testTraceID)
+
+	span := stubSpan(testTraceID, map[string]string{
+		string(mcpotel.AttrGenAIToolName): "gitlab_environment",
+		string(mcpotel.AttrActionID):      "environment.protected_get",
+		string(mcpotel.AttrDomain):        "environment",
+		string(mcpotel.AttrRefusalReason): "safe_mode",
+		string(mcpotel.AttrErrorType):     "tool_error",
+	}, tracepb.Status_STATUS_CODE_ERROR)
+
+	if status := postExport(t, received.url, "/v1/traces", marshalExport(t, exportOf(span)), ""); status != http.StatusOK {
+		t.Fatalf("the receiver answered %d, want 200", status)
+	}
+
+	record, arrived := received.lookup(testTraceID)
+	if !arrived {
+		t.Fatal("the receiver kept nothing for a trace the harness issued")
+	}
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "tool", got: record.tool, want: "gitlab_environment"},
+		{name: "action", got: record.action, want: "environment.protected_get"},
+		{name: "domain", got: record.domain, want: "environment"},
+		{name: "refusal reason", got: record.refusalReason, want: "safe_mode"},
+		{name: "error type", got: record.errorType, want: "tool_error"},
+		{name: "status", got: record.status, want: tracepb.Status_STATUS_CODE_ERROR.String()},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.got != testCase.want {
+				t.Errorf("%s = %q, want %q", testCase.name, testCase.got, testCase.want)
+			}
+		})
+	}
+	if !received.observed.Load() {
+		t.Error("the receiver did not mark itself as having observed a dispatch")
+	}
+}
+
+// TestSpanReceiver_TraceItNeverIssued_IsDropped keeps the map to the calls
+// this harness made.
+//
+// A child exports every span it makes, including the ones its own startup
+// produces. Keeping those would grow a map nothing ever reads and, worse,
+// would let a span from work no test asked for answer a lookup.
+func TestSpanReceiver_TraceItNeverIssued_IsDropped(t *testing.T) {
+	received := startTestReceiver(t)
+
+	span := stubSpan(testTraceID, map[string]string{
+		string(mcpotel.AttrActionID): "issue.list",
+	}, tracepb.Status_STATUS_CODE_OK)
+	postExport(t, received.url, "/v1/traces", marshalExport(t, exportOf(span)), "")
+
+	if _, arrived := received.lookup(testTraceID); arrived {
+		t.Error("the receiver kept a trace the harness never stamped into a call")
+	}
+}
+
+// TestSpanReceiver_ChildSpans_DoNotOverwriteTheServerSpan covers the shape
+// every real trace has.
+//
+// One MCP call produces a server span carrying the action and a child span per
+// GitLab request, and those children carry none of these attributes. Merging
+// one would replace the facts with emptiness, which is a record that says a
+// call dispatched nothing.
+func TestSpanReceiver_ChildSpans_DoNotOverwriteTheServerSpan(t *testing.T) {
+	received := startTestReceiver(t)
+	received.issue(testTraceID)
+
+	server := stubSpan(testTraceID, map[string]string{
+		string(mcpotel.AttrActionID): "issue.list",
+		string(mcpotel.AttrDomain):   "issue",
+	}, tracepb.Status_STATUS_CODE_OK)
+	child := stubSpan(testTraceID, map[string]string{"http.request.method": "GET"}, tracepb.Status_STATUS_CODE_UNSET)
+
+	postExport(t, received.url, "/v1/traces", marshalExport(t, exportOf(child, server, child)), "")
+
+	record, arrived := received.lookup(testTraceID)
+	if !arrived {
+		t.Fatal("the receiver kept nothing for the trace")
+	}
+	if record.action != "issue.list" || record.domain != "issue" {
+		t.Errorf("the record is %+v, want the server span's own facts", record)
+	}
+}
+
+// TestSpanReceiver_MetricsAndLogs_AreAcknowledgedAndDropped pins why the
+// catch-all answers 200.
+//
+// Every child exports its metrics and its logs to the same endpoint. Refusing
+// them would make the exporter retry the same payload for the rest of the run,
+// which costs the server under test a background goroutine and its log a
+// warning per batch, for signals nothing here reads.
+func TestSpanReceiver_MetricsAndLogs_AreAcknowledgedAndDropped(t *testing.T) {
+	received := startTestReceiver(t)
+
+	for _, path := range []string{"/v1/metrics", "/v1/logs"} {
+		t.Run(path, func(t *testing.T) {
+			if status := postExport(t, received.url, path, []byte("not a trace export"), ""); status != http.StatusOK {
+				t.Errorf("the receiver answered %d for %s, want 200", status, path)
+			}
+		})
+	}
+	if len(received.all()) != 0 {
+		t.Errorf("the receiver kept %d traces from payloads that carried none", len(received.all()))
+	}
+}
+
+// TestSpanReceiver_UndecodableTrace_IsRefused checks that a payload the
+// receiver cannot read is reported rather than silently counted as an export
+// that said nothing.
+func TestSpanReceiver_UndecodableTrace_IsRefused(t *testing.T) {
+	received := startTestReceiver(t)
+
+	if status := postExport(t, received.url, "/v1/traces", []byte("this is not protobuf at all"), ""); status != http.StatusBadRequest {
+		t.Errorf("the receiver answered %d for a payload that is not an export, want 400", status)
+	}
+	if status := postExport(t, received.url, "/v1/traces", []byte("not gzip either"), "gzip"); status != http.StatusBadRequest {
+		t.Errorf("the receiver answered %d for a body that claims gzip and is not, want 400", status)
+	}
+}
+
+// TestSpanReceiver_GzippedExport_IsRead covers the compression the exporter
+// does not use today.
+//
+// The Go OTLP/HTTP exporter sends uncompressed protobuf unless it is told
+// otherwise, and this suite does not tell it otherwise. Handling gzip anyway
+// removes a way for the whole record to go silently empty if that default ever
+// changes, and this is what keeps that handling honest.
+func TestSpanReceiver_GzippedExport_IsRead(t *testing.T) {
+	received := startTestReceiver(t)
+	received.issue(testTraceID)
+
+	span := stubSpan(testTraceID, map[string]string{string(mcpotel.AttrActionID): "issue.list"},
+		tracepb.Status_STATUS_CODE_OK)
+
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(marshalExport(t, exportOf(span))); err != nil {
+		t.Fatalf("compressing the export: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("closing the compressor: %v", err)
+	}
+
+	if status := postExport(t, received.url, "/v1/traces", compressed.Bytes(), "gzip"); status != http.StatusOK {
+		t.Fatalf("the receiver answered %d for a gzipped export, want 200", status)
+	}
+	if record, arrived := received.lookup(testTraceID); !arrived || record.action != "issue.list" {
+		t.Errorf("the gzipped export was not read: arrived=%t record=%+v", arrived, record)
+	}
+}
+
+// TestDispatchRecord_Merge_KeepsTheFirstNonEmptyValue pins the rule that lets
+// several spans of one trace add up.
+func TestDispatchRecord_Merge_KeepsTheFirstNonEmptyValue(t *testing.T) {
+	first := dispatchRecord{action: "issue.list", status: "STATUS_CODE_OK"}
+	second := dispatchRecord{action: "issue.get", domain: "issue", errorType: "tool_error"}
+
+	merged := first.merge(second)
+
+	if merged.action != "issue.list" {
+		t.Errorf("action = %q, want the first span's own", merged.action)
+	}
+	if merged.domain != "issue" || merged.errorType != "tool_error" {
+		t.Errorf("the merge dropped what only the second span carried: %+v", merged)
+	}
+	if merged.status != "STATUS_CODE_OK" {
+		t.Errorf("status = %q, want the first span's own", merged.status)
+	}
+}
+
+// TestDispatchRecord_CarriesFacts_IsWhatDecidesASpanIsWorthKeeping checks the
+// predicate the child-span rule rests on.
+func TestDispatchRecord_CarriesFacts_IsWhatDecidesASpanIsWorthKeeping(t *testing.T) {
+	cases := []struct {
+		name   string
+		record dispatchRecord
+		want   bool
+	}{
+		{name: "nothing at all", record: dispatchRecord{}, want: false},
+		{name: "a status and nothing else", record: dispatchRecord{status: "STATUS_CODE_OK"}, want: false},
+		{name: "an action", record: dispatchRecord{action: "issue.list"}, want: true},
+		{name: "a refusal", record: dispatchRecord{refusalReason: "safe_mode"}, want: true},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.record.carriesFacts(); got != testCase.want {
+				t.Errorf("carriesFacts() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestTelemetryVariables_PointEveryChildAtThisProcessesReceiver pins the
+// environment that makes the dispatch half of the record exist.
+//
+// The schedule delay is an integer because the specification defines every
+// OTEL_ duration in milliseconds: writing 100ms parses as nothing and silently
+// keeps the five-second default, which is longer than a test's whole flush.
+func TestTelemetryVariables_PointEveryChildAtThisProcessesReceiver(t *testing.T) {
+	vars := telemetryVariables()
+
+	if vars["GITLAB_MCP_TELEMETRY"] != "true" {
+		t.Errorf("GITLAB_MCP_TELEMETRY = %q, want true", vars["GITLAB_MCP_TELEMETRY"])
+	}
+	if vars["OTEL_EXPORTER_OTLP_PROTOCOL"] != "http/protobuf" {
+		t.Errorf("OTEL_EXPORTER_OTLP_PROTOCOL = %q, want http/protobuf", vars["OTEL_EXPORTER_OTLP_PROTOCOL"])
+	}
+	if !strings.HasPrefix(vars["OTEL_EXPORTER_OTLP_ENDPOINT"], "http://127.0.0.1:") {
+		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want a loopback endpoint", vars["OTEL_EXPORTER_OTLP_ENDPOINT"])
+	}
+	if vars["OTEL_BSP_SCHEDULE_DELAY"] != "100" {
+		t.Errorf("OTEL_BSP_SCHEDULE_DELAY = %q, want 100 milliseconds as an integer",
+			vars["OTEL_BSP_SCHEDULE_DELAY"])
+	}
+}
+
+// TestSpanReceiver_IsReachedOnLoopbackOnly checks that nothing outside this
+// machine can post to a suite's receiver or read what it holds.
+func TestSpanReceiver_IsReachedOnLoopbackOnly(t *testing.T) {
+	received := startTestReceiver(t)
+
+	if !strings.HasPrefix(received.url, "http://127.0.0.1:") {
+		t.Errorf("the receiver listens on %q, want loopback", received.url)
+	}
+}

--- a/test/e2e/internal/harness/record.go
+++ b/test/e2e/internal/harness/record.go
@@ -1,0 +1,860 @@
+//go:build e2e
+
+// record.go writes down what the suite actually exercised.
+//
+// The rule the whole rebuild rests on is that coverage is what the server
+// dispatched, in a test that passed, on a named runtime, surface and mode. The
+// command this replaces credited an action because its identifier appeared on
+// a line of a test file, which is how eighteen actions nothing ever ran were
+// counted as covered.
+//
+// Two halves make one line. The client half is a sending middleware on every
+// harness session: it stamps a fresh traceparent into _meta, records what was
+// asked for and what came back, and attributes it to the test that asked
+// through the context. The server half is the span that call produced, read by
+// the receiver in otlp.go and joined on the trace id.
+//
+// Records are buffered per test and written from the first-registered cleanup,
+// which therefore runs last: by then the ledger has undone what the test
+// created, so the cleanup's own calls are in the buffer too, and the test's
+// final status is settled.
+//
+// Writing is off unless GITLAB_MCP_TEST_E2E_CALLS_DIR names a directory. The
+// dispatch assertion is not: a call that ran something other than what it
+// asked for fails its test in every run, recorded or not, because that is a
+// defect in this server or in this harness rather than a gap in a report.
+
+package harness
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil/e2ecalls"
+)
+
+// The MCP methods the recorder names. They are spelled here because the SDK
+// keeps its own constants unexported, and a record's method field is part of
+// the contract with cmd/audit_e2e_coverage rather than an internal detail.
+const (
+	methodCallTool        = "tools/call"
+	methodReadResource    = "resources/read"
+	methodGetPrompt       = "prompts/get"
+	methodComplete        = "completion/complete"
+	methodElicit          = "elicitation/create"
+	methodResourceUpdated = "notifications/resources/updated"
+)
+
+// traceParentKey is the _meta key W3C trace context travels in.
+//
+// MCP reserves it unprefixed by name, and this server already reads it there,
+// so one key is the whole of the client side of the join. Nothing else is put
+// in _meta: a key the server does not read would be noise on every call.
+const traceParentKey = "traceparent"
+
+// sampledTraceFlags marks a traceparent as sampled.
+//
+// Every call this harness makes is sampled, because a span that was not
+// recorded is a call whose dispatch nothing can report, and the whole point of
+// stamping the trace is to read that dispatch back.
+const sampledTraceFlags = "01"
+
+// callAttribution is what only the caller of a request knows: which test made
+// it, on which session, what for, and what it expected.
+//
+// It travels on the context because the middleware that records the call sits
+// on the session's client, which many tests share, while the answer to "whose
+// call is this" belongs to the one Env that made it. The alternative the old
+// suite used was to walk the stack for a test name, which cannot see a purpose
+// or an expectation at all.
+type callAttribution struct {
+	// rec is the buffer the call line goes into.
+	rec *envRecorder
+	// conn is the session the call was made on.
+	conn *sessionConn
+	// purpose says what the call was made for.
+	purpose Purpose
+	// expectation is what the caller asked to happen, in the record's
+	// vocabulary: ok, any, or a failure class named by a verb.
+	expectation string
+	// action is the canonical catalog ID a tool call named, empty for the
+	// methods that name none.
+	action ActionID
+	// target names what a non-tool call addressed: a resource URI, a prompt,
+	// or a completion reference.
+	target string
+	// wantDispatch is the route the caller declared this call would run, when
+	// it is not the action named. Empty means the action itself.
+	wantDispatch ActionID
+}
+
+// attributionKey is the private context key the attribution travels under.
+type attributionKey struct{}
+
+// withAttribution returns a context carrying who is making the next request.
+func withAttribution(ctx context.Context, attr callAttribution) context.Context {
+	return context.WithValue(ctx, attributionKey{}, attr)
+}
+
+// attributionFrom reads the attribution off a context, if the caller set one.
+//
+// A request with none is one the SDK made for itself, such as the initialize
+// handshake or the listings a session start reads. Those are not coverage and
+// are deliberately neither stamped nor recorded: stamping them would issue
+// trace ids nothing ever joins.
+func attributionFrom(ctx context.Context) (callAttribution, bool) {
+	attr, carried := ctx.Value(attributionKey{}).(callAttribution)
+	return attr, carried
+}
+
+// attribute returns a context that records the next request against this
+// session and this test.
+func (s *Session) attribute(purpose Purpose, expectation string, attr callAttribution) context.Context {
+	attr.rec = s.env.recorder
+	attr.conn = s.conn
+	attr.purpose = purpose
+	attr.expectation = expectation
+	return withAttribution(s.env.Ctx, attr)
+}
+
+// newTraceParent mints a trace and returns its id with the header value that
+// carries it.
+//
+// crypto/rand because the ids must not collide across the processes of one
+// run, and because the W3C format forbids an all-zero id, which a seeded
+// counter would have to special-case.
+func newTraceParent() (traceID, traceParent string) {
+	var ids [24]byte
+	// rand.Read fills the slice or panics; it cannot fail on any platform this
+	// suite runs on, and Go 1.24 removed its error return for that reason.
+	rand.Read(ids[:])
+	traceID = hex.EncodeToString(ids[:16])
+	spanID := hex.EncodeToString(ids[16:])
+	return traceID, "00-" + traceID + "-" + spanID + "-" + sampledTraceFlags
+}
+
+// stampTraceParent writes the trace context into a request's _meta, reporting
+// whether it could.
+//
+// The params are copied rather than mutated in place, because Raw hands the
+// caller's own struct over and a test that reuses one should not find a stale
+// traceparent on its second call.
+func stampTraceParent(req mcp.Request, traceParent string) bool {
+	params := req.GetParams()
+	if params == nil {
+		return false
+	}
+	// A typed nil pointer in a non-nil interface is what the SDK hands a
+	// middleware for a method whose params may be missing. Comparing the
+	// interface against nil says false, and the first method call on it
+	// dereferences the pointer.
+	if value := reflect.ValueOf(params); value.Kind() == reflect.Pointer && value.IsNil() {
+		return false
+	}
+
+	meta := maps.Clone(params.GetMeta())
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	meta[traceParentKey] = traceParent
+	params.SetMeta(meta)
+	return true
+}
+
+// pendingCall is one recorded call plus what its test's flush still has to
+// resolve about it.
+type pendingCall struct {
+	// line is the record as the client knows it, before the span arrives.
+	line *e2ecalls.Call
+	// conn is the session the call went to, which the flush marks
+	// dispatch-observed when the span lands.
+	conn *sessionConn
+	// wantDispatch is the route the caller declared, empty when the requested
+	// action is what should have run.
+	wantDispatch ActionID
+}
+
+// envRecorder buffers one test's record and writes it when that test ends.
+type envRecorder struct {
+	env *Env
+
+	mu      sync.Mutex
+	calls   []*pendingCall
+	skips   []*e2ecalls.Skip
+	flushed bool
+}
+
+// newEnvRecorder returns the buffer one Env records into.
+func newEnvRecorder(env *Env) *envRecorder {
+	return &envRecorder{env: env}
+}
+
+// record buffers one call, dropping it when the test has already been written.
+//
+// A late arrival is possible and is not an error: a resource-updated
+// notification can reach the client after the test that subscribed has ended.
+// Dropping it is right, because the line it would produce carries a status
+// that has already been reported for every other call of that test.
+func (r *envRecorder) record(call *pendingCall) {
+	if r == nil || call == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.flushed {
+		return
+	}
+	r.calls = append(r.calls, call)
+}
+
+// noteSkip records why a test did not run.
+//
+// The testing package keeps a skip's reason to itself, so the harness has to
+// be told: every skip it decides on reports here before it calls Skip, and a
+// test that skipped itself is written with no reason rather than with a
+// guessed one.
+func (r *envRecorder) noteSkip(reason string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.flushed {
+		return
+	}
+	r.skips = append(r.skips, &e2ecalls.Skip{Test: r.env.T.Name(), Reason: reason})
+}
+
+// flush is the cleanup the Env registers first, and which therefore runs last.
+func (r *envRecorder) flush() {
+	r.env.T.Helper()
+	r.finish(r.env.T, testStatus(r.env.T))
+}
+
+// finish resolves every buffered call against the spans the server sent,
+// asserts what ran, writes the lines and returns them.
+//
+// The reporter and the status are parameters rather than read from the test,
+// so that the whole of this can be driven from a test of its own: a cleanup
+// that fails its own test cannot be asserted on, because a failing subtest
+// fails its parent.
+func (r *envRecorder) finish(reporter e2ecalls.Reporter, status string) []e2ecalls.Line {
+	r.mu.Lock()
+	if r.flushed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.flushed = true
+	calls := r.calls
+	skips := r.skips
+	r.mu.Unlock()
+
+	awaitDispatch(calls)
+
+	lines := make([]e2ecalls.Line, 0, len(calls)*2+len(skips))
+	for _, call := range calls {
+		call.line.TestStatus = status
+		if record, arrived := dispatchFor(call); arrived {
+			call.line.Dispatched = record.action
+			lines = append(lines, dispatchLine(call.line.TraceID, record))
+			assertDispatch(reporter, call, record)
+		}
+		lines = append(lines, call.line)
+	}
+	for _, skip := range skips {
+		lines = append(lines, skip)
+	}
+
+	e2ecalls.Open().Write(reporter, lines...)
+	return lines
+}
+
+// testStatus names how a test ended, in the record's vocabulary.
+//
+// Failure wins over a skip, because a test that failed and then skipped told
+// us something about the server and a skip line would hide it.
+func testStatus(t *testing.T) string {
+	t.Helper()
+	switch {
+	case t.Failed():
+		return e2ecalls.StatusFailed
+	case t.Skipped():
+		return e2ecalls.StatusSkipped
+	default:
+		return e2ecalls.StatusPassed
+	}
+}
+
+// dispatchWait is how long a test's flush waits for the spans of the calls it
+// made. The children export every hundred milliseconds, so this is generous
+// for the loopback hop and short enough that a stalled exporter is noticed.
+const dispatchWait = 10 * time.Second
+
+// dispatchGrace is what a run whose spans have never arrived waits instead.
+//
+// Without it, a run with telemetry broken would pay the full wait on every
+// test and take hours to say so. One test pays it, says so once, and the rest
+// wait long enough for a late first span to still be picked up.
+const dispatchGrace = 250 * time.Millisecond
+
+// dispatchPoll is how often the wait re-reads the receiver.
+const dispatchPoll = 25 * time.Millisecond
+
+// dispatchGaveUp is set once a flush has waited the full budget and seen no
+// span at all, which is what turns the budget down for every flush after it.
+var dispatchGaveUp atomic.Bool
+
+// awaitDispatch waits until the server has reported on every call of this
+// test, or until the budget runs out.
+func awaitDispatch(calls []*pendingCall) {
+	received := receiverIfStarted()
+	if received == nil {
+		return
+	}
+	pending := make([]string, 0, len(calls))
+	for _, call := range calls {
+		if call.line.TraceID != "" {
+			pending = append(pending, call.line.TraceID)
+		}
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	budget := dispatchWait
+	if !received.observed.Load() && dispatchGaveUp.Load() {
+		budget = dispatchGrace
+	}
+	deadline := time.Now().Add(budget)
+	for {
+		missing := 0
+		for _, traceID := range pending {
+			if _, arrived := received.lookup(traceID); !arrived {
+				missing++
+			}
+		}
+		if missing == 0 || time.Now().After(deadline) {
+			if missing > 0 && !received.observed.Load() && dispatchGaveUp.CompareAndSwap(false, true) {
+				log.Printf("e2e: no server span has arrived; every call is recorded as what was asked for "+
+					"rather than as what ran, and later tests will wait %s instead of %s", dispatchGrace, dispatchWait)
+			}
+			return
+		}
+		time.Sleep(dispatchPoll)
+	}
+}
+
+// dispatchFor returns what the server said about one call, marking its session
+// dispatch-observed when a span arrived.
+func dispatchFor(call *pendingCall) (dispatchRecord, bool) {
+	received := receiverIfStarted()
+	if received == nil || call.line.TraceID == "" {
+		return dispatchRecord{}, false
+	}
+	record, arrived := received.lookup(call.line.TraceID)
+	if arrived && call.conn != nil {
+		call.conn.dispatchObserved.Store(true)
+	}
+	return record, arrived
+}
+
+// assertDispatch fails the test when the server ran something other than what
+// the call asked for.
+//
+// This is the assertion the whole recorder exists to make. A call that named
+// issue.list and ran issue.get proves nothing about issue.list, and the suite
+// would otherwise report it as covered. A test that knows its call is
+// rewritten declares the route with ExpectDispatch and is held to that instead.
+func assertDispatch(reporter e2ecalls.Reporter, call *pendingCall, record dispatchRecord) {
+	if call.line.Action == "" || record.action == "" {
+		return
+	}
+	want := string(call.wantDispatch)
+	if want == "" {
+		want = call.line.Action
+	}
+	if record.action == want {
+		return
+	}
+	if call.wantDispatch != "" {
+		reporter.Errorf("%s on the %s surface dispatched %s, and the test declared it would dispatch %s",
+			call.line.Action, call.line.Surface, record.action, want)
+		return
+	}
+	reporter.Errorf("%s on the %s surface dispatched %s: the call did not run the action it named, so nothing it "+
+		"asserts is about %s. Declare the route with ExpectDispatch if that is what the server should do.",
+		call.line.Action, call.line.Surface, record.action, call.line.Action)
+}
+
+// dispatchLine turns what a span said into the record line the audit joins on
+// the trace id.
+func dispatchLine(traceID string, record dispatchRecord) *e2ecalls.Dispatch {
+	return &e2ecalls.Dispatch{
+		TraceID:       traceID,
+		Tool:          record.tool,
+		Action:        record.action,
+		Domain:        record.domain,
+		RefusalReason: record.refusalReason,
+		ErrorType:     record.errorType,
+		Status:        record.status,
+	}
+}
+
+// recordSending is the client middleware every request of one session leaves
+// through.
+//
+// It runs on the caller's goroutine, between the verb and the wire, which is
+// the only place that holds all three of the attribution, the request as it
+// will be sent, and the answer as it comes back.
+func (c *sessionConn) recordSending() mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			attr, attributed := attributionFrom(ctx)
+			if !attributed || attr.rec == nil {
+				return next(ctx, method, req)
+			}
+
+			traceID, traceParent := newTraceParent()
+			if !stampTraceParent(req, traceParent) {
+				traceID = ""
+			} else if received := receiverIfStarted(); received != nil {
+				received.issue(traceID)
+			}
+
+			release := c.holdInFlight(attr)
+			started := time.Now()
+			result, err := next(ctx, method, req)
+			elapsed := time.Since(started)
+			release()
+
+			attr.rec.record(c.callRecord(attr, method, req, result, err, elapsed, traceID))
+			return result, err
+		}
+	}
+}
+
+// callRecord builds the client half of one call line.
+func (c *sessionConn) callRecord(
+	attr callAttribution,
+	method string,
+	req mcp.Request,
+	result mcp.Result,
+	err error,
+	elapsed time.Duration,
+	traceID string,
+) *pendingCall {
+	tool, arguments := describeToolRequest(req)
+	line := &e2ecalls.Call{
+		Test:        attr.rec.env.T.Name(),
+		Purpose:     string(attr.purpose),
+		Expectation: attr.expectation,
+		Method:      method,
+		Tool:        tool,
+		Action:      string(attr.action),
+		Target:      attr.target,
+		Arguments:   arguments,
+		Outcome:     outcomeOf(method, result, err),
+		DurationMS:  float64(elapsed.Microseconds()) / 1000,
+		TraceID:     traceID,
+	}
+	c.describeSession(line)
+	return &pendingCall{line: line, conn: c, wantDispatch: attr.wantDispatch}
+}
+
+// describeSession fills in the half of a call line that is the session's
+// rather than the call's.
+//
+// The session's shape is repeated on every call line on purpose: the audit can
+// then classify one line without joining it back to the session that served
+// it, and a shard whose session line was lost still says what a call covered.
+func (c *sessionConn) describeSession(line *e2ecalls.Call) {
+	line.Session = c.label
+	line.Surface = string(c.cfg.Surface)
+	line.Mode = string(c.cfg.Mode)
+	line.Capabilities = string(c.cfg.Capabilities)
+	if c.inst != nil {
+		line.Requirement = c.inst.requirement.token()
+	}
+}
+
+// describeToolRequest returns the tool a request named and its top-level
+// argument names, for the methods that name one.
+//
+// The values are left out deliberately: a value is a fixture and belongs to
+// one run, while a name is part of the call and is what a coverage report
+// compares against a schema.
+func describeToolRequest(req mcp.Request) (tool string, arguments []string) {
+	params, isToolCall := req.GetParams().(*mcp.CallToolParams)
+	if !isToolCall || params == nil {
+		return "", nil
+	}
+	named, isObject := params.Arguments.(map[string]any)
+	if !isObject {
+		return params.Name, nil
+	}
+	return params.Name, argumentNames(named)
+}
+
+// outcomeOf classifies one answer in the record's vocabulary.
+//
+// A tool call goes through the same classify the assertions use, so a record
+// and a failure message can never disagree about whether the server refused
+// something. Every other method has two outcomes: it answered, or it did not.
+func outcomeOf(method string, result mcp.Result, err error) string {
+	if method == methodCallTool {
+		toolResult, _ := result.(*mcp.CallToolResult)
+		return classify(toolResult, err).outcome
+	}
+	if err == nil {
+		return e2ecalls.OutcomeOK
+	}
+	if isTransportError(err) {
+		return e2ecalls.OutcomeTransportError
+	}
+	return e2ecalls.OutcomeProtocolError
+}
+
+// recordReceiving is the client middleware every request the server sends back
+// arrives through.
+//
+// Two of them are worth recording. An elicitation is the server asking the
+// caller something mid-call, and it is the only evidence an interactive flow
+// ran at all. A resource-updated notification is the other end of a
+// subscription, and without it a subscription's coverage would be the
+// subscribe call and nothing about whether anything was ever delivered.
+func (c *sessionConn) recordReceiving() mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			switch method {
+			case methodElicit:
+				c.recordElicitation(req)
+			case methodResourceUpdated:
+				c.recordResourceUpdate(req)
+			}
+			return next(ctx, method, req)
+		}
+	}
+}
+
+// recordElicitation records one elicitation request against the test whose
+// call provoked it.
+//
+// The attribution is the session's in-flight call, because an elicitation
+// arrives on the SDK's own receiving goroutine, inside a tools/call that is
+// still waiting for an answer. When the session is serving several calls at
+// once the harness declines to guess whose it is and records nothing: a line
+// attributed to the wrong test is worse than a missing one.
+func (c *sessionConn) recordElicitation(req mcp.Request) {
+	attr, known := c.currentInFlight()
+	if !known {
+		return
+	}
+	params, isElicit := req.GetParams().(*mcp.ElicitParams)
+	if !isElicit || params == nil {
+		return
+	}
+
+	line := &e2ecalls.Call{
+		Test:        attr.rec.env.T.Name(),
+		Purpose:     string(attr.purpose),
+		Expectation: e2ecalls.ExpectationAny,
+		Method:      methodElicit,
+		Target:      params.Message,
+		Arguments:   elicitationKeys(params.RequestedSchema),
+		Outcome:     e2ecalls.OutcomeOK,
+	}
+	c.describeSession(line)
+	attr.rec.record(&pendingCall{line: line, conn: c})
+}
+
+// elicitationKeys returns the sorted property names an elicitation asked for.
+//
+// The schema arrives as whatever the server marshaled, which on the client
+// side is a map. A schema that is not one is recorded as asking for nothing
+// rather than as an error: what is being recorded is that the flow elicited,
+// and the field list is detail beside it.
+func elicitationKeys(schema any) []string {
+	object, isObject := schema.(map[string]any)
+	if !isObject {
+		return nil
+	}
+	properties, hasProperties := object["properties"].(map[string]any)
+	if !hasProperties {
+		return nil
+	}
+	return slices.Sorted(maps.Keys(properties))
+}
+
+// recordResourceUpdate records one notification against every test watching
+// that resource.
+//
+// Every test, rather than one: a session is shared, and two tests subscribed
+// to the same URI both observe the change. The index is what makes this exact,
+// since the notification itself says only which resource changed.
+func (c *sessionConn) recordResourceUpdate(req mcp.Request) {
+	params, isUpdate := req.GetParams().(*mcp.ResourceUpdatedNotificationParams)
+	if !isUpdate || params == nil {
+		return
+	}
+	for _, rec := range c.subscribers.recordersFor(params.URI) {
+		line := &e2ecalls.Call{
+			Test:        rec.env.T.Name(),
+			Purpose:     string(PurposeTest),
+			Expectation: e2ecalls.ExpectationAny,
+			Method:      methodResourceUpdated,
+			Target:      params.URI,
+			Outcome:     e2ecalls.OutcomeOK,
+		}
+		c.describeSession(line)
+		rec.record(&pendingCall{line: line, conn: c})
+	}
+}
+
+// holdInFlight registers a call as in flight on this session and returns the
+// function that takes it off again.
+func (c *sessionConn) holdInFlight(attr callAttribution) func() {
+	id := c.inFlightNext.Add(1)
+
+	c.inFlightMu.Lock()
+	if c.inFlight == nil {
+		c.inFlight = map[int64]callAttribution{}
+	}
+	c.inFlight[id] = attr
+	c.inFlightMu.Unlock()
+
+	return func() {
+		c.inFlightMu.Lock()
+		delete(c.inFlight, id)
+		c.inFlightMu.Unlock()
+	}
+}
+
+// currentInFlight returns the one call this session is serving, when there is
+// exactly one.
+func (c *sessionConn) currentInFlight() (callAttribution, bool) {
+	c.inFlightMu.Lock()
+	defer c.inFlightMu.Unlock()
+
+	if len(c.inFlight) != 1 {
+		return callAttribution{}, false
+	}
+	for _, attr := range c.inFlight {
+		return attr, attr.rec != nil
+	}
+	return callAttribution{}, false
+}
+
+// subscriberIndex remembers which test is watching which resource on one
+// session, so a notification that arrives on the SDK's goroutine can be
+// recorded against the tests that asked for it.
+//
+// It is kept apart from the notifier that fans the channels out because the
+// two answer different questions: the notifier wakes whoever is waiting, and
+// this says whose record the notification belongs in. A watcher that has
+// stopped waiting still has a record.
+type subscriberIndex struct {
+	mu       sync.Mutex
+	watchers map[string][]*envRecorder
+}
+
+// newSubscriberIndex returns an index watching nothing.
+func newSubscriberIndex() *subscriberIndex {
+	return &subscriberIndex{watchers: map[string][]*envRecorder{}}
+}
+
+// add registers one test as a watcher of a URI and returns the removal.
+func (i *subscriberIndex) add(uri string, rec *envRecorder) func() {
+	if rec == nil {
+		return func() {}
+	}
+	i.mu.Lock()
+	i.watchers[uri] = append(i.watchers[uri], rec)
+	i.mu.Unlock()
+
+	return func() { i.remove(uri, rec) }
+}
+
+// remove drops one watcher, and the URI with it when it was the last.
+func (i *subscriberIndex) remove(uri string, rec *envRecorder) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	remaining := make([]*envRecorder, 0, len(i.watchers[uri]))
+	dropped := false
+	for _, watcher := range i.watchers[uri] {
+		if watcher == rec && !dropped {
+			dropped = true
+			continue
+		}
+		remaining = append(remaining, watcher)
+	}
+	if len(remaining) == 0 {
+		delete(i.watchers, uri)
+		return
+	}
+	i.watchers[uri] = remaining
+}
+
+// recordersFor returns the buffers a notification about one URI belongs in.
+func (i *subscriberIndex) recordersFor(uri string) []*envRecorder {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return slices.Clone(i.watchers[uri])
+}
+
+// logReporter reports a shard failure at the end of a run, where there is no
+// test left to fail.
+//
+// The per-test writes report through the test that was writing, which is what
+// makes a broken shard directory fail one test rather than all of them. The
+// run and session lines are written after the last test has ended, so the only
+// thing left to tell is the log.
+type logReporter struct{}
+
+// Errorf writes one failure to the run's log.
+func (logReporter) Errorf(format string, args ...any) {
+	log.Printf("e2e: "+format, args...)
+}
+
+// flushRunRecords writes the lines that belong to the package rather than to
+// any one test: what runtime it ran on, what each session served, and every
+// span that arrived after the test that made the call had already been
+// written.
+//
+// It runs after the last test, because that is when a session's
+// dispatch-observed flag has settled. Writing a session line per test instead
+// would write two versions of the same session, one before its first span
+// arrived and one after.
+func flushRunRecords() {
+	writer := e2ecalls.Open()
+	if writer == nil {
+		return
+	}
+
+	lines := []e2ecalls.Line{runLine(&state)}
+	lines = append(lines, sessionLines()...)
+	lines = append(lines, lateDispatchLines()...)
+	writer.Write(logReporter{}, lines...)
+}
+
+// runLine records what this package found and whether it went on to run.
+//
+// A refused run is written too. A missing run line and a run that refused to
+// start are different answers to "was this runtime exercised", and a release
+// gate that could not tell them apart would pass on a shard nothing produced.
+//
+// The state is a parameter rather than the package's own, because a runState
+// carries the bootstrap's sync.Once and cannot be copied: a test that wanted
+// to ask what a refused run writes would otherwise have to overwrite the run
+// this process is in the middle of.
+func runLine(s *runState) *e2ecalls.Run {
+	run := &e2ecalls.Run{
+		Package:     s.pkg,
+		Requirement: s.requirement.token(),
+		RunID:       s.runID,
+		Commit:      s.settings.get(envCommit),
+		Filter:      testRunFilter(),
+		Status:      e2ecalls.RunStarted,
+	}
+	if s.kind != refusalNone {
+		run.Status = e2ecalls.RunRefused
+		run.Reason = s.refusal
+	}
+	if inst := s.inst; inst != nil {
+		run.Edition = inst.facts.editionToken()
+		run.Tier = inst.facts.Tier.String()
+		run.TierConfirmed = inst.facts.TierConfirmed
+		run.GitLabVersion = inst.facts.Version
+		run.Fixtures = fixtureProfile(inst)
+	}
+	return run
+}
+
+// fixtureProfile records what the runtime had available.
+//
+// A scenario that needs a CI runner is absent rather than failing when there
+// is none, so a coverage figure that cannot say which fixtures were up is not
+// worth reading: the same shard means two different things on a stack with a
+// runner and on one without.
+func fixtureProfile(inst *instance) e2ecalls.FixtureProfile {
+	return e2ecalls.FixtureProfile{
+		Runner:         inst.hasRunner(),
+		FixtureService: inst.settings.get(envFixtureURL) != "",
+		Bitbucket:      inst.settings.get(envBitbucketServerURL) != "",
+		GHToken:        inst.settings.get(envGitHubToken) != "",
+		Seeds:          seedNames(inst.settings.get(envSeeds)),
+	}
+}
+
+// seedNames splits the seed list the provisioning script publishes.
+func seedNames(configured string) []string {
+	var seeds []string
+	for seed := range strings.SplitSeq(configured, ",") {
+		if trimmed := strings.TrimSpace(seed); trimmed != "" {
+			seeds = append(seeds, trimmed)
+		}
+	}
+	slices.Sort(seeds)
+	return slices.Compact(seeds)
+}
+
+// sessionLines records what every session this package started served.
+//
+// The served sets are the denominator of the whole report: an action no
+// session served is absent rather than untested, and those are different
+// findings about different things.
+func sessionLines() []e2ecalls.Line {
+	var lines []e2ecalls.Line
+	sessions.Range(func(_, value any) bool {
+		entry, isEntry := value.(*sessionEntry)
+		if !isEntry || entry.conn == nil {
+			return true
+		}
+		conn := entry.conn
+		lines = append(lines, &e2ecalls.Session{
+			Label:             conn.label,
+			Surface:           string(conn.cfg.Surface),
+			Mode:              string(conn.cfg.Mode),
+			Capabilities:      string(conn.cfg.Capabilities),
+			Transport:         string(conn.cfg.Transport),
+			Tools:             slices.Clone(conn.served.tools),
+			Resources:         slices.Clone(conn.served.resources),
+			ResourceTemplates: slices.Clone(conn.served.templates),
+			Prompts:           slices.Clone(conn.served.prompts),
+			DispatchObserved:  conn.dispatchObserved.Load(),
+		})
+		return true
+	})
+	return lines
+}
+
+// lateDispatchLines writes every span the receiver holds.
+//
+// A call whose span arrived after its test's flush was written with no
+// dispatched action, and this is what lets the audit join one to it anyway.
+// Re-offering a line that was already written costs nothing: the writer drops
+// a line whose JSON it has already seen.
+func lateDispatchLines() []e2ecalls.Line {
+	received := receiverIfStarted()
+	if received == nil {
+		return nil
+	}
+	all := received.all()
+	lines := make([]e2ecalls.Line, 0, len(all))
+	for traceID, record := range all {
+		lines = append(lines, dispatchLine(traceID, record))
+	}
+	return lines
+}

--- a/test/e2e/internal/harness/record_test.go
+++ b/test/e2e/internal/harness/record_test.go
@@ -1,0 +1,877 @@
+//go:build e2e
+
+// record_test.go drives the recorder the way a run drives it: the real binary,
+// on a real surface, against a stub GitLab, with the server's own spans coming
+// back over the loopback receiver.
+//
+// One thing cannot be asserted from inside a test, and it shapes the file: a
+// failing subtest fails its parent, so a test cannot let the flush fail and
+// then check that it did. Every test that asks what the flush would report
+// therefore calls finish with a reporter of its own, which is the same code
+// the cleanup runs and differs only in where the failure goes.
+
+package harness
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil/e2ecalls"
+)
+
+// The two errors the outcome classification tells apart: a server that
+// answered no, and a connection that went away before it could.
+var (
+	errUnknownPrompt = errors.New("prompts/get: unknown prompt")
+	errBrokenPipe    = errors.New("write |1: broken pipe")
+)
+
+// capturedReporter is a test's stand-in for the testing.T a flush reports
+// through, so an assertion about a failure does not have to produce one.
+type capturedReporter struct {
+	mu       sync.Mutex
+	failures []string
+}
+
+// Errorf records one failure.
+func (c *capturedReporter) Errorf(format string, args ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failures = append(c.failures, strings.TrimSpace(fmt.Sprintf(format, args...)))
+}
+
+// reported returns what was reported, joined for a message.
+func (c *capturedReporter) reported() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.failures, "\n")
+}
+
+// count returns how many failures were reported.
+func (c *capturedReporter) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.failures)
+}
+
+// startLicensedStubGitLab serves what an Ultimate instance answers at startup.
+//
+// The license is what this stub adds: the alias rewrite that turns
+// gitlab_environment get into protected_get only fires when the catalog has
+// protected_get, and that route is licensed. Without a license the rewrite
+// cannot happen and there is nothing for the dispatch assertion to see.
+func startLicensedStubGitLab(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		writeStubJSON(w, map[string]any{"version": "18.0.0", "revision": "abcdef", "enterprise": true})
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		writeStubJSON(w, map[string]any{"id": 7, "username": "harness", "name": "Harness", "is_admin": true})
+	})
+	mux.HandleFunc("/api/v4/license", func(w http.ResponseWriter, _ *http.Request) {
+		writeStubJSON(w, map[string]any{"id": 1, "plan": "ultimate"})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// offlineInstance builds an instance with no GitLab behind it, for the tests
+// whose subject is the record rather than a call.
+func offlineInstance() *instance {
+	return &instance{
+		settings:    testSettings(map[string]string{envGitLabURL: "http://gitlab.test", envGitLabToken: stubToken}),
+		requirement: Any,
+		pkg:         "harness",
+		runID:       "run-offline",
+		facts:       runtimeFacts{URL: "http://gitlab.test", Version: "18.0.0", Tier: edition.Free},
+	}
+}
+
+// recordInto points this test's records at a directory of its own and returns
+// it.
+//
+// Release is registered straight after the directory is created, so the shard
+// is closed before the directory is removed: on Windows a directory holding an
+// open file cannot be removed, and a test would then fail in cleanup with
+// every one of its own assertions passed.
+func recordInto(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Cleanup(e2ecalls.Release)
+	t.Setenv(e2ecalls.DirEnv, dir)
+	return dir
+}
+
+// TestRecorder_MetaAliasRewrite_RecordsTheRouteThatRanAndFailsAnUndeclaredCall
+// is the assertion the whole recorder exists to make.
+//
+// gitlab_environment with action get and an environment named rather than
+// numbered runs protected_get. A record crediting what the test asked for
+// would credit environment.get for a call that never ran it, which is exactly
+// the class of false coverage this rebuild replaces. The call is therefore
+// recorded with both halves, and a test that did not declare the rewrite is
+// failed.
+func TestRecorder_MetaAliasRewrite_RecordsTheRouteThatRanAndFailsAnUndeclaredCall(t *testing.T) {
+	inst := instanceForStub(t, startLicensedStubGitLab(t))
+	params := map[string]any{"project_id": "group/project", "environment_id": "production"}
+
+	t.Run("undeclared", func(t *testing.T) {
+		env := newEnv(t, inst)
+		session := env.Session(ServerConfig{Surface: SurfaceMeta, Private: true})
+
+		_, _ = Try[map[string]any](session, "environment.get", params)
+
+		reporter := &capturedReporter{}
+		lines := env.recorder.finish(reporter, e2ecalls.StatusPassed)
+
+		call := callLineFor(t, lines, "environment.get")
+		if call.Dispatched != "environment.protected_get" {
+			t.Errorf("dispatched = %q, want environment.protected_get; the server rewrote the action and the "+
+				"record has to say so", call.Dispatched)
+		}
+		if !strings.Contains(reporter.reported(), "environment.protected_get") {
+			t.Errorf("the flush reported %q, want it to fail the test and name the route that ran",
+				reporter.reported())
+		}
+	})
+
+	t.Run("declared", func(t *testing.T) {
+		env := newEnv(t, inst)
+		session := env.Session(ServerConfig{Surface: SurfaceMeta, Private: true})
+
+		_, _ = Try[map[string]any](session, "environment.get", params, ExpectDispatch("environment.protected_get"))
+
+		reporter := &capturedReporter{}
+		lines := env.recorder.finish(reporter, e2ecalls.StatusPassed)
+
+		call := callLineFor(t, lines, "environment.get")
+		if call.Dispatched != "environment.protected_get" {
+			t.Errorf("dispatched = %q, want environment.protected_get", call.Dispatched)
+		}
+		if reporter.count() != 0 {
+			t.Errorf("the flush failed a test that declared the rewrite: %s", reporter.reported())
+		}
+	})
+}
+
+// callLineFor returns the one call line naming an action, failing when the
+// record holds no such call.
+func callLineFor(t *testing.T, lines []e2ecalls.Line, action string) *e2ecalls.Call {
+	t.Helper()
+
+	for _, line := range lines {
+		call, isCall := line.(*e2ecalls.Call)
+		if isCall && call.Action == action {
+			return call
+		}
+	}
+	t.Fatalf("the record holds no call of %s: %s", action, describeLines(lines))
+	return nil
+}
+
+// describeLines summarizes a record for a failure message.
+func describeLines(lines []e2ecalls.Line) string {
+	described := make([]string, 0, len(lines))
+	for _, line := range lines {
+		switch typed := line.(type) {
+		case *e2ecalls.Call:
+			described = append(described, fmt.Sprintf("call %s/%s %s", typed.Method, typed.Action, typed.Outcome))
+		case *e2ecalls.Dispatch:
+			described = append(described, fmt.Sprintf("dispatch %s %s", typed.Action, typed.RefusalReason))
+		case *e2ecalls.Skip:
+			described = append(described, fmt.Sprintf("skip %s: %s", typed.Test, typed.Reason))
+		default:
+			described = append(described, fmt.Sprintf("%T", line))
+		}
+	}
+	return strings.Join(described, "; ")
+}
+
+// TestRecorder_IndividualSafeMode_RecordsAPreviewAndTheServersRefusal covers
+// the outcome no client-side classification can produce on its own.
+//
+// A safe-mode preview is a successful result carrying a description of the
+// mutation that did not happen, and the server records it as a refusal with
+// the reason safe_mode. The record has to carry both: the client's outcome, so
+// a report knows the mutation never ran, and the server's reason, so it knows
+// why.
+func TestRecorder_IndividualSafeMode_RecordsAPreviewAndTheServersRefusal(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Surface: SurfaceIndividual, Mode: ModeSafe, Private: true})
+
+	_, _ = Try[map[string]any](session, "project.create", map[string]any{"name": env.Name("safe-mode")})
+
+	reporter := &capturedReporter{}
+	lines := env.recorder.finish(reporter, e2ecalls.StatusPassed)
+
+	call := callLineFor(t, lines, "project.create")
+	if call.Outcome != e2ecalls.OutcomePreview {
+		t.Errorf("outcome = %q, want %q: safe mode answered with a preview and the record calls it a success",
+			call.Outcome, e2ecalls.OutcomePreview)
+	}
+	if reason := dispatchReasonFor(lines, call.TraceID); reason != "safe_mode" {
+		t.Errorf("the server's refusal reason = %q, want safe_mode; the record cannot say why the mutation did "+
+			"not run", reason)
+	}
+	if reporter.count() != 0 {
+		t.Errorf("the flush failed a call that dispatched what it asked for: %s", reporter.reported())
+	}
+}
+
+// dispatchReasonFor returns the refusal reason the server reported for one
+// trace, or the empty string when no span carried one.
+func dispatchReasonFor(lines []e2ecalls.Line, traceID string) string {
+	for _, line := range lines {
+		dispatch, isDispatch := line.(*e2ecalls.Dispatch)
+		if isDispatch && dispatch.TraceID == traceID {
+			return dispatch.RefusalReason
+		}
+	}
+	return ""
+}
+
+// TestRecorder_ShardDirectoryUnset_WritesNothing pins that recording costs an
+// ordinary run nothing.
+//
+// The harness records unconditionally and never branches on the variable: a
+// writer for a directory nobody named is nil, and a nil writer's Write does
+// nothing. This is what makes that safe to rely on.
+func TestRecorder_ShardDirectoryUnset_WritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(e2ecalls.Release)
+	t.Setenv(e2ecalls.DirEnv, "")
+
+	env := newEnv(t, offlineInstance())
+	env.recorder.record(fabricatedCall(env, "issue.list"))
+	reporter := &capturedReporter{}
+
+	env.recorder.finish(reporter, e2ecalls.StatusPassed)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading the directory nothing should have written to: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("the record wrote %d files with no directory named", len(entries))
+	}
+	if reporter.count() != 0 {
+		t.Errorf("a run with recording off reported %s", reporter.reported())
+	}
+}
+
+// TestRecorder_ShardDirectoryNamed_WritesTheCallLine is the other half: with a
+// directory named, the line reaches the shard the coverage audit reads.
+func TestRecorder_ShardDirectoryNamed_WritesTheCallLine(t *testing.T) {
+	dir := recordInto(t)
+
+	env := newEnv(t, offlineInstance())
+	env.recorder.record(fabricatedCall(env, "issue.list"))
+
+	env.recorder.finish(&capturedReporter{}, e2ecalls.StatusPassed)
+	e2ecalls.Release()
+
+	records, err := e2ecalls.Read(dir)
+	if err != nil {
+		t.Fatalf("reading the shard back: %v", err)
+	}
+	found := false
+	for _, record := range records {
+		if record.Call != nil && record.Call.Action == "issue.list" {
+			found = true
+			if record.Call.TestStatus != e2ecalls.StatusPassed {
+				t.Errorf("test_status = %q, want passed", record.Call.TestStatus)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("the shard holds no call of issue.list; %d records were written", len(records))
+	}
+}
+
+// TestRecorder_RelativeShardDirectory_IsRefusedWithTheReason checks that a
+// directory that would scatter shards nothing can find is refused rather than
+// resolved.
+//
+// A test binary runs in its own package directory, so a relative path writes
+// one shard under each of the suite's packages and the merge finds none of
+// them. The refusal has to say that, because the alternative is a coverage
+// report that is silently empty.
+func TestRecorder_RelativeShardDirectory_IsRefusedWithTheReason(t *testing.T) {
+	t.Cleanup(e2ecalls.Release)
+	t.Setenv(e2ecalls.DirEnv, filepath.Join("dist", "e2e-calls"))
+
+	env := newEnv(t, offlineInstance())
+	env.recorder.record(fabricatedCall(env, "issue.list"))
+	reporter := &capturedReporter{}
+
+	env.recorder.finish(reporter, e2ecalls.StatusPassed)
+
+	if !strings.Contains(reporter.reported(), "absolute path") {
+		t.Errorf("the refusal is %q, want it to say the directory must be absolute", reporter.reported())
+	}
+}
+
+// TestRecorder_SkippedSubtest_WritesASkipLineWithItsReason covers the whole
+// skip path, from the need that was not provided to the shard.
+//
+// A skip is the honest third answer beside covered and absent: an action whose
+// only scenario skips for want of a runner is not covered, and a report that
+// said why is worth more than an empty cell. The testing package keeps a skip
+// message to itself, so the harness has to record the reason before it skips,
+// and this is what proves the two are wired together.
+func TestRecorder_SkippedSubtest_WritesASkipLineWithItsReason(t *testing.T) {
+	dir := recordInto(t)
+	inst := offlineInstance()
+
+	// A skipped subtest does not fail its parent, so the skip can be provoked
+	// for real rather than simulated.
+	t.Run("needs a runner", func(t *testing.T) {
+		newEnv(t, inst, Needs(NeedRunner))
+		t.Error("the test was not skipped, and this run has no CI runner")
+	})
+	e2ecalls.Release()
+
+	records, err := e2ecalls.Read(dir)
+	if err != nil {
+		t.Fatalf("reading the shard back: %v", err)
+	}
+	for _, record := range records {
+		if record.Skip == nil {
+			continue
+		}
+		if !strings.Contains(record.Skip.Test, "needs_a_runner") {
+			continue
+		}
+		if !strings.Contains(record.Skip.Reason, "runner") {
+			t.Errorf("the skip reason is %q, want it to name the requirement", record.Skip.Reason)
+		}
+		return
+	}
+	t.Errorf("the shard holds no skip line for the subtest; %d records were written", len(records))
+}
+
+// fabricatedCall builds one recorded call without making one, for the tests
+// whose subject is the writing rather than the calling.
+//
+// It carries no trace, which is the shape of a call the harness could not
+// stamp: the flush then has no span to wait for and these tests do not pay the
+// dispatch budget for one that was never issued.
+func fabricatedCall(env *Env, action ActionID) *pendingCall {
+	return &pendingCall{line: &e2ecalls.Call{
+		Test:        env.T.Name(),
+		Purpose:     string(PurposeTest),
+		Expectation: ExpectationOK,
+		Session:     "dynamic-default-full",
+		Surface:     string(SurfaceDynamic),
+		Mode:        string(ModeDefault),
+		Method:      methodCallTool,
+		Tool:        "gitlab_execute_action",
+		Action:      string(action),
+		Outcome:     e2ecalls.OutcomeOK,
+	}}
+}
+
+// TestCallOptions_Expecting_IsTheVerbsOwnAndNotTheCallers pins where the
+// expectation comes from.
+//
+// The verb is the assertion: Do expects success, Refused expects a class,
+// Try constrains nothing. A caller cannot override it, because a record whose
+// expectation disagreed with the assertion the test made would classify the
+// call under a state no test ever asked for.
+func TestCallOptions_Expecting_IsTheVerbsOwnAndNotTheCallers(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "ok", want: ExpectationOK},
+		{name: "any", want: ExpectationAny},
+		{name: "a failure class", want: string(FailureNeedsConfirmation)},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resolved := resolveCallOptions(nil).expecting(testCase.want)
+			if resolved.expectation != testCase.want {
+				t.Errorf("expectation = %q, want %q", resolved.expectation, testCase.want)
+			}
+		})
+	}
+
+	if defaults := resolveCallOptions(nil); defaults.expectation != ExpectationOK {
+		t.Errorf("a call with no verb applied expects %q, want %q", defaults.expectation, ExpectationOK)
+	}
+}
+
+// TestExpectDispatch_DeclaresTheRouteTheCallWillRun checks the option the
+// dispatch assertion reads.
+func TestExpectDispatch_DeclaresTheRouteTheCallWillRun(t *testing.T) {
+	resolved := resolveCallOptions([]CallOption{ExpectDispatch("environment.protected_get")})
+
+	if resolved.dispatch != "environment.protected_get" {
+		t.Errorf("dispatch = %q, want environment.protected_get", resolved.dispatch)
+	}
+}
+
+// TestNewTraceParent_IsAFreshSampledTraceEveryTime checks the value the server
+// reads the trace off.
+//
+// Sampled, because a span that was not recorded is a call whose dispatch
+// nothing can report. Fresh, because two calls sharing a trace id would join
+// to each other's spans, and a retry is a call of its own.
+func TestNewTraceParent_IsAFreshSampledTraceEveryTime(t *testing.T) {
+	traceID, traceParent := newTraceParent()
+	other, _ := newTraceParent()
+
+	if len(traceID) != 32 {
+		t.Errorf("trace id %q is %d characters, want 32", traceID, len(traceID))
+	}
+	if traceID == other {
+		t.Errorf("two calls were given the same trace id %q", traceID)
+	}
+	if want := "00-" + traceID + "-"; !strings.HasPrefix(traceParent, want) {
+		t.Errorf("traceparent = %q, want it to start with %q", traceParent, want)
+	}
+	if !strings.HasSuffix(traceParent, "-01") {
+		t.Errorf("traceparent = %q, want it to end sampled", traceParent)
+	}
+}
+
+// TestStampTraceParent_WritesTheOneKeyTheServerReads pins the client half of
+// the join.
+//
+// MCP reserves traceparent unprefixed at the top level of _meta, and this
+// server already reads it there. Nothing else is written: a key the server
+// does not read would be noise on every call of the run.
+func TestStampTraceParent_WritesTheOneKeyTheServerReads(t *testing.T) {
+	params := &mcp.CallToolParams{Name: "gitlab_issue_list", Arguments: map[string]any{"project_id": "a/b"}}
+	req := &mcp.ClientRequest[*mcp.CallToolParams]{Params: params}
+
+	if !stampTraceParent(req, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01") {
+		t.Fatal("the traceparent was not stamped onto a request that carries params")
+	}
+	meta := params.GetMeta()
+	if meta[traceParentKey] != "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" {
+		t.Errorf("_meta[%q] = %v, want the traceparent", traceParentKey, meta[traceParentKey])
+	}
+	if len(meta) != 1 {
+		t.Errorf("_meta carries %d keys, want only the traceparent: %v", len(meta), meta)
+	}
+}
+
+// TestStampTraceParent_TypedNilParams_StampsNothing covers the shape that
+// panics if it is trusted.
+//
+// A method whose params may be missing is handed to a middleware as a typed
+// nil pointer inside a non-nil interface. Comparing the interface against nil
+// says false, and the first method call on it dereferences the pointer, which
+// is a panic in the middle of every list request.
+func TestStampTraceParent_TypedNilParams_StampsNothing(t *testing.T) {
+	req := &mcp.ClientRequest[*mcp.ListToolsParams]{Params: nil}
+
+	if stampTraceParent(req, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01") {
+		t.Error("a request carrying no params was reported as stamped")
+	}
+}
+
+// TestOutcomeOf_ClassifiesEveryMethodInTheRecordsVocabulary checks that a
+// record and a failure message can never disagree.
+//
+// A tool call goes through the same classify the assertions use; every other
+// method has two outcomes, and the one that matters is the difference between
+// a server that said no and a connection that went away.
+func TestOutcomeOf_ClassifiesEveryMethodInTheRecordsVocabulary(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		result mcp.Result
+		err    error
+		want   string
+	}{
+		{
+			name:   "a tool call that ran",
+			method: methodCallTool,
+			result: &mcp.CallToolResult{StructuredContent: map[string]any{"id": 1}},
+			want:   e2ecalls.OutcomeOK,
+		},
+		{
+			name:   "a tool call the handler refused",
+			method: methodCallTool,
+			result: errorResult("something went wrong"),
+			want:   e2ecalls.OutcomeToolError,
+		},
+		{
+			name:   "a resource read that answered",
+			method: methodReadResource,
+			result: &mcp.ReadResourceResult{},
+			want:   e2ecalls.OutcomeOK,
+		},
+		{
+			name:   "a prompt the server refused",
+			method: methodGetPrompt,
+			err:    errUnknownPrompt,
+			want:   e2ecalls.OutcomeProtocolError,
+		},
+		{
+			name:   "a call whose connection went away",
+			method: methodComplete,
+			err:    errBrokenPipe,
+			want:   e2ecalls.OutcomeTransportError,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := outcomeOf(testCase.method, testCase.result, testCase.err); got != testCase.want {
+				t.Errorf("outcome = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestDescribeToolRequest_NamesTheToolAndItsArgumentNames pins what a call
+// line carries about the arguments.
+//
+// The names and not the values: a value is a fixture and belongs to one run,
+// while a name is part of the call and is what a coverage report compares
+// against a schema.
+func TestDescribeToolRequest_NamesTheToolAndItsArgumentNames(t *testing.T) {
+	req := &mcp.ClientRequest[*mcp.CallToolParams]{Params: &mcp.CallToolParams{
+		Name:      "gitlab_issue_list",
+		Arguments: map[string]any{"project_id": "a/b", "state": "opened"},
+	}}
+
+	tool, arguments := describeToolRequest(req)
+
+	if tool != "gitlab_issue_list" {
+		t.Errorf("tool = %q, want gitlab_issue_list", tool)
+	}
+	if strings.Join(arguments, ",") != "project_id,state" {
+		t.Errorf("arguments = %v, want the sorted names", arguments)
+	}
+	if strings.Contains(strings.Join(arguments, ","), "a/b") {
+		t.Errorf("arguments = %v, and a record must carry no values", arguments)
+	}
+}
+
+// TestCurrentInFlight_AnswersOnlyWhenOneCallIsInFlight pins how an elicitation
+// is attributed.
+//
+// An elicitation arrives on the SDK's own receiving goroutine, inside a call
+// that is still waiting. With one call in flight the attribution is exact;
+// with several the harness declines to guess, because a line attributed to the
+// wrong test is worse than a missing one.
+func TestCurrentInFlight_AnswersOnlyWhenOneCallIsInFlight(t *testing.T) {
+	env := newEnv(t, offlineInstance())
+	conn := &sessionConn{label: "dynamic-default-full", inst: env.inst}
+
+	if _, known := conn.currentInFlight(); known {
+		t.Error("a session serving nothing reported a call in flight")
+	}
+
+	releaseFirst := conn.holdInFlight(callAttribution{rec: env.recorder, action: "issue.list"})
+	attr, known := conn.currentInFlight()
+	if !known || attr.action != "issue.list" {
+		t.Errorf("one call in flight was reported as %q (known=%t), want issue.list", attr.action, known)
+	}
+
+	releaseSecond := conn.holdInFlight(callAttribution{rec: env.recorder, action: "issue.get"})
+	if _, known = conn.currentInFlight(); known {
+		t.Error("two calls in flight were attributed to one of them")
+	}
+
+	releaseSecond()
+	releaseFirst()
+	if _, known = conn.currentInFlight(); known {
+		t.Error("a released call is still reported as in flight")
+	}
+}
+
+// TestSubscriberIndex_RecordsEveryWatcherAndForgetsTheReleasedOne checks the
+// index that says whose record a resource-updated notification belongs in.
+func TestSubscriberIndex_RecordsEveryWatcherAndForgetsTheReleasedOne(t *testing.T) {
+	env := newEnv(t, offlineInstance())
+	other := newEnvRecorder(env)
+	index := newSubscriberIndex()
+
+	releaseFirst := index.add("gitlab://project/7", env.recorder)
+	releaseSecond := index.add("gitlab://project/7", other)
+
+	if watchers := index.recordersFor("gitlab://project/7"); len(watchers) != 2 {
+		t.Errorf("the index holds %d watchers, want both tests watching one resource", len(watchers))
+	}
+	if watchers := index.recordersFor("gitlab://project/8"); len(watchers) != 0 {
+		t.Errorf("a resource nobody watches has %d watchers", len(watchers))
+	}
+
+	releaseSecond()
+	if watchers := index.recordersFor("gitlab://project/7"); len(watchers) != 1 || watchers[0] != env.recorder {
+		t.Errorf("the wrong watcher was dropped: %d left", len(watchers))
+	}
+	releaseFirst()
+	if watchers := index.recordersFor("gitlab://project/7"); len(watchers) != 0 {
+		t.Errorf("the last watcher was not dropped: %d left", len(watchers))
+	}
+}
+
+// TestElicitationKeys_NamesTheFieldsAskedFor covers what an elicitation record
+// carries about the request.
+func TestElicitationKeys_NamesTheFieldsAskedFor(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema any
+		want   string
+	}{
+		{
+			name:   "a form schema",
+			schema: map[string]any{"properties": map[string]any{"title": map[string]any{}, "confirm": map[string]any{}}},
+			want:   "confirm,title",
+		},
+		{name: "a schema with no properties", schema: map[string]any{"type": "object"}, want: ""},
+		{name: "no schema at all", schema: nil, want: ""},
+		{name: "something that is not a schema", schema: "confirm?", want: ""},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := strings.Join(elicitationKeys(testCase.schema), ","); got != testCase.want {
+				t.Errorf("keys = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestSeedNames_ReadsTheListTheProvisioningScriptPublishes pins the one
+// setting the fixture profile reads that the harness does not create itself.
+func TestSeedNames_ReadsTheListTheProvisioningScriptPublishes(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{name: "a list", configured: "registry-image,pending-user", want: "pending-user,registry-image"},
+		{name: "padded and repeated", configured: " a , a ,b ", want: "a,b"},
+		{name: "nothing provisioned", configured: "", want: ""},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := strings.Join(seedNames(testCase.configured), ","); got != testCase.want {
+				t.Errorf("seeds = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestTestStatus_NamesHowATestEnded checks the field a report divides by: a
+// call made by a test that failed is not coverage.
+func TestTestStatus_NamesHowATestEnded(t *testing.T) {
+	if got := testStatus(t); got != e2ecalls.StatusPassed {
+		t.Errorf("a test that has not failed is %q, want passed", got)
+	}
+
+	t.Run("skipped", func(t *testing.T) {
+		t.Cleanup(func() {
+			if got := testStatus(t); got != e2ecalls.StatusSkipped {
+				t.Errorf("a skipped test is %q, want skipped", got)
+			}
+		})
+		t.Skip("on purpose, to read the status back")
+	})
+}
+
+// TestRecorder_FlushedTwice_WritesOnce checks that a test whose record was
+// read by an assertion is not written again by its own cleanup.
+func TestRecorder_FlushedTwice_WritesOnce(t *testing.T) {
+	env := newEnv(t, offlineInstance())
+	env.recorder.record(fabricatedCall(env, "issue.list"))
+
+	first := env.recorder.finish(&capturedReporter{}, e2ecalls.StatusPassed)
+	second := env.recorder.finish(&capturedReporter{}, e2ecalls.StatusPassed)
+
+	if len(first) == 0 {
+		t.Fatal("the first flush wrote nothing")
+	}
+	if len(second) != 0 {
+		t.Errorf("the second flush wrote %d lines, want none", len(second))
+	}
+}
+
+// TestRecorder_LateArrival_IsDropped checks that a notification reaching a
+// test that has already been written does not produce a line with a status
+// nothing else of that test carries.
+func TestRecorder_LateArrival_IsDropped(t *testing.T) {
+	env := newEnv(t, offlineInstance())
+
+	env.recorder.finish(&capturedReporter{}, e2ecalls.StatusPassed)
+	env.recorder.record(fabricatedCall(env, "issue.list"))
+	env.recorder.noteSkip("too late to matter")
+
+	if lines := env.recorder.finish(&capturedReporter{}, e2ecalls.StatusPassed); len(lines) != 0 {
+		t.Errorf("a record written after the flush produced %d lines", len(lines))
+	}
+}
+
+// TestRunLine_RefusedRun_SaysSoWithItsReason pins that a package which refused
+// its runtime is written down rather than left silent.
+//
+// A missing run line and a run that refused to start are different answers to
+// "was this runtime exercised", and a release gate that could not tell them
+// apart would pass on a shard nothing produced.
+func TestRunLine_RefusedRun_SaysSoWithItsReason(t *testing.T) {
+	refused := &runState{
+		settings:    testSettings(map[string]string{envCommit: "abc1234"}),
+		requirement: Licensed,
+		pkg:         "ee",
+		runID:       "run-1",
+		kind:        refusalMismatch,
+		refusal:     "this GitLab has no license",
+	}
+
+	run := runLine(refused)
+
+	if run.Status != e2ecalls.RunRefused {
+		t.Errorf("status = %q, want refused", run.Status)
+	}
+	if run.Reason != "this GitLab has no license" {
+		t.Errorf("reason = %q, want the refusal", run.Reason)
+	}
+	if run.Requirement != "licensed" {
+		t.Errorf("requirement = %q, want licensed", run.Requirement)
+	}
+	if run.Commit != "abc1234" {
+		t.Errorf("commit = %q, want the revision under test", run.Commit)
+	}
+}
+
+// TestRunLine_StartedRun_CarriesWhatTheRuntimeWas checks the denominator every
+// other line is read against: an action means nothing without the edition and
+// tier it was served at.
+func TestRunLine_StartedRun_CarriesWhatTheRuntimeWas(t *testing.T) {
+	inst := offlineInstance()
+	inst.facts = runtimeFacts{
+		URL: "http://gitlab.test", Version: "18.1.0", Enterprise: true,
+		Tier: edition.Ultimate, TierConfirmed: true,
+	}
+	inst.runner = true
+	inst.runnerOnce.Do(func() {})
+	started := &runState{settings: inst.settings, requirement: Any, pkg: "common", runID: "run-2", inst: inst}
+
+	run := runLine(started)
+
+	if run.Status != e2ecalls.RunStarted {
+		t.Errorf("status = %q, want started", run.Status)
+	}
+	if run.Edition != "enterprise" || run.Tier != edition.Ultimate.String() || !run.TierConfirmed {
+		t.Errorf("runtime = %q/%q (confirmed=%t), want enterprise/ultimate confirmed",
+			run.Edition, run.Tier, run.TierConfirmed)
+	}
+	if run.GitLabVersion != "18.1.0" {
+		t.Errorf("version = %q, want 18.1.0", run.GitLabVersion)
+	}
+	if !run.Fixtures.Runner {
+		t.Error("the fixture profile does not record the runner this run had")
+	}
+}
+
+// TestAwaitDispatch_NothingToWaitFor_ReturnsAtOnce checks that a flush only
+// waits when there is a span it could be waiting for.
+//
+// A test that made no traced call must not pay the dispatch budget, and
+// neither must a call the harness could not stamp: both would add ten seconds
+// per test to a suite of hundreds.
+func TestAwaitDispatch_NothingToWaitFor_ReturnsAtOnce(t *testing.T) {
+	cases := []struct {
+		name  string
+		calls []*pendingCall
+	}{
+		{name: "no calls at all", calls: nil},
+		{name: "a call with no trace", calls: []*pendingCall{{line: &e2ecalls.Call{Action: "issue.list"}}}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			started := time.Now()
+
+			awaitDispatch(testCase.calls)
+
+			if waited := time.Since(started); waited > time.Second {
+				t.Errorf("the flush waited %s with no span to wait for", waited)
+			}
+		})
+	}
+}
+
+// TestSessionLines_NameWhatEachSessionServed covers the denominator of the
+// whole report.
+//
+// An action no session served is absent rather than untested, and those are
+// different findings about different things. The session line is where that
+// distinction comes from, so it has to carry what the session actually listed
+// rather than what the catalog says it might have.
+func TestSessionLines_NameWhatEachSessionServed(t *testing.T) {
+	inst := stubInstance(t)
+	env := newEnv(t, inst)
+	session := env.Session(ServerConfig{Surface: SurfaceDynamic, Private: true})
+
+	for _, line := range sessionLines() {
+		recorded, isSession := line.(*e2ecalls.Session)
+		if !isSession || recorded.Label != session.Label() {
+			continue
+		}
+		if recorded.Surface != string(SurfaceDynamic) || recorded.Mode != string(ModeDefault) {
+			t.Errorf("the session line says %s/%s, want dynamic/default", recorded.Surface, recorded.Mode)
+		}
+		if recorded.Transport != string(TransportStdio) {
+			t.Errorf("transport = %q, want stdio", recorded.Transport)
+		}
+		if len(recorded.Tools) == 0 {
+			t.Error("the session line lists no tools, so nothing can be divided by it")
+		}
+		if len(recorded.Prompts) == 0 {
+			t.Error("the session line lists no prompts, and the full capability surface serves them")
+		}
+		return
+	}
+	t.Errorf("no session line names %s; the sessions a run started are what its coverage is measured against",
+		session.Label())
+}
+
+// TestFlushRunRecords_WritesTheLinesThatBelongToThePackage covers the one
+// write that happens after the last test.
+//
+// The run line and the session lines are written there rather than per test,
+// because a session's dispatch-observed flag has only settled once every test
+// is done: writing one per test would write two versions of the same session,
+// one before its first span arrived and one after.
+func TestFlushRunRecords_WritesTheLinesThatBelongToThePackage(t *testing.T) {
+	dir := recordInto(t)
+
+	flushRunRecords()
+	e2ecalls.Release()
+
+	records, err := e2ecalls.Read(dir)
+	if err != nil {
+		t.Fatalf("reading the shard back: %v", err)
+	}
+	for _, record := range records {
+		if record.Run != nil {
+			return
+		}
+	}
+	t.Errorf("the shard holds no run line; %d records were written", len(records))
+}

--- a/test/e2e/internal/harness/runtime.go
+++ b/test/e2e/internal/harness/runtime.go
@@ -58,6 +58,21 @@ func (r Requirement) String() string {
 	}
 }
 
+// token names the requirement in a record: one word, which is what a report
+// groups by. String is the sentence a refusal prints and would be a poor key.
+func (r Requirement) token() string {
+	switch r {
+	case Free:
+		return "free"
+	case Licensed:
+		return "licensed"
+	case Any:
+		return "any"
+	default:
+		return "unknown"
+	}
+}
+
 // target names the Makefile target that provides this requirement, which is
 // what a refusal tells the reader to run instead.
 func (r Requirement) target() string {
@@ -99,6 +114,15 @@ func (f runtimeFacts) editionName() string {
 		return "Enterprise Edition"
 	}
 	return "Community Edition"
+}
+
+// editionToken names the image's edition in a record: one word, beside the
+// sentence editionName prints for a person.
+func (f runtimeFacts) editionToken() string {
+	if f.Enterprise {
+		return "enterprise"
+	}
+	return "community"
 }
 
 // tierDescription says what the tier is and whether a license confirmed it.

--- a/test/e2e/internal/harness/session.go
+++ b/test/e2e/internal/harness/session.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -232,6 +233,11 @@ func (c ServerConfig) label(private int64) string {
 
 // childVariables returns the environment variables this configuration sets on
 // the server child, which is the whole of what it configures.
+//
+// The telemetry variables are merged in here rather than at the launcher,
+// because this is the one place a session's child environment is built and
+// every child runs with telemetry on: a session whose server exported no spans
+// could only ever record what its tests asked for, never what ran.
 func (c ServerConfig) childVariables() map[string]string {
 	vars := map[string]string{
 		"GITLAB_MCP_TOOL_SURFACE":       string(c.Surface),
@@ -243,6 +249,7 @@ func (c ServerConfig) childVariables() map[string]string {
 	if len(c.ExcludeTools) > 0 {
 		vars["GITLAB_MCP_EXCLUDE_TOOLS"] = strings.Join(c.ExcludeTools, ",")
 	}
+	maps.Copy(vars, telemetryVariables())
 	return vars
 }
 
@@ -320,6 +327,21 @@ type sessionConn struct {
 	// notifier fans resource-updated notifications out to the subscriptions
 	// tests opened on this session.
 	notifier *updateNotifier
+	// subscribers says whose record a resource-updated notification belongs
+	// in, which the notifier cannot answer: it wakes channels, not tests.
+	subscribers *subscriberIndex
+
+	// dispatchObserved is set the first time a span of this session's own
+	// arrives. While it is false every call of the session is a claim about
+	// what was asked for and not about what ran, and the session line says so.
+	dispatchObserved atomic.Bool
+
+	// inFlight holds the attribution of every call this session is serving
+	// right now, so an elicitation the server sends back mid-call can be
+	// recorded against the test that provoked it.
+	inFlightMu   sync.Mutex
+	inFlight     map[int64]callAttribution
+	inFlightNext atomic.Int64
 }
 
 // sessionEntry is one pooled session, started by the first test that asks for
@@ -458,11 +480,12 @@ func startSession(inst *instance, cfg ServerConfig, token, key string) (*session
 	}
 
 	conn := &sessionConn{
-		label:    label,
-		cfg:      cfg,
-		inst:     inst,
-		proc:     newServerProcess(label, bin, newChildEnv(settingsForChild, dir, cfg.childVariables())),
-		notifier: newUpdateNotifier(),
+		label:       label,
+		cfg:         cfg,
+		inst:        inst,
+		proc:        newServerProcess(label, bin, newChildEnv(settingsForChild, dir, cfg.childVariables())),
+		notifier:    newUpdateNotifier(),
+		subscribers: newSubscriberIndex(),
 	}
 	if connectErr := conn.connect(); connectErr != nil {
 		return nil, connectErr
@@ -533,6 +556,11 @@ func (c *sessionConn) connect() error {
 	defer cancel()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "gitlab-mcp-e2e-harness", Version: "1"}, c.clientOptions())
+	// The recorder sits on the client rather than on the session, because that
+	// is where the SDK keeps its middleware, and it is installed before
+	// Connect so the handshake is inside it rather than beside it.
+	client.AddSendingMiddleware(c.recordSending())
+	client.AddReceivingMiddleware(c.recordReceiving())
 	session, err := client.Connect(ctx, c.proc.transport(lifetime), nil)
 	if err != nil {
 		return fmt.Errorf("connecting to the %s server: %w\nserver stderr:\n%s", c.label, err, c.proc.stderrTail())

--- a/test/e2e/internal/harness/session_test.go
+++ b/test/e2e/internal/harness/session_test.go
@@ -13,6 +13,7 @@ package harness
 
 import (
 	"context"
+	"net/http/httptest"
 	"slices"
 	"strings"
 	"testing"
@@ -36,8 +37,18 @@ const stubToken = "glpat-harness-stub"
 // uses, including the probe.
 func stubInstance(t *testing.T) *instance {
 	t.Helper()
+	return instanceForStub(t, startStubGitLab(t))
+}
 
-	stub := startStubGitLab(t)
+// instanceForStub builds the instance a harness test drives against a stub
+// GitLab the caller chose.
+//
+// Split from stubInstance because the tier is a property of the instance the
+// probe finds: a test of the licensed catalog needs a stub that answers the
+// license endpoint, and a test of everything else needs one that does not.
+func instanceForStub(t *testing.T, stub *httptest.Server) *instance {
+	t.Helper()
+
 	client, err := gitlabclient.NewClientWithToken(stub.URL, stubToken, false)
 	if err != nil {
 		t.Fatalf("building a client for the stub: %v", err)

--- a/test/e2e/internal/harness/verbs.go
+++ b/test/e2e/internal/harness/verbs.go
@@ -27,7 +27,8 @@ import (
 func (s *Session) ReadResource(uri string) *mcp.ReadResourceResult {
 	s.env.T.Helper()
 
-	result, err := s.conn.client().ReadResource(s.env.Ctx, &mcp.ReadResourceParams{URI: uri})
+	ctx := s.attribute(PurposeTest, ExpectationOK, callAttribution{target: uri})
+	result, err := s.conn.client().ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
 	if err != nil {
 		s.env.T.Fatalf("resources/read %s: %v%s", uri, err, s.conn.failureContext())
 	}
@@ -38,14 +39,17 @@ func (s *Session) ReadResource(uri string) *mcp.ReadResourceResult {
 // whose subject is the refusal.
 func (s *Session) TryReadResource(uri string) (*mcp.ReadResourceResult, error) {
 	s.env.T.Helper()
-	return s.conn.client().ReadResource(s.env.Ctx, &mcp.ReadResourceParams{URI: uri})
+
+	ctx := s.attribute(PurposeTest, ExpectationAny, callAttribution{target: uri})
+	return s.conn.client().ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
 }
 
 // GetPrompt renders one prompt, failing the test when the server refuses.
 func (s *Session) GetPrompt(name string, arguments map[string]string) *mcp.GetPromptResult {
 	s.env.T.Helper()
 
-	result, err := s.conn.client().GetPrompt(s.env.Ctx, &mcp.GetPromptParams{Name: name, Arguments: arguments})
+	ctx := s.attribute(PurposeTest, ExpectationOK, callAttribution{target: name})
+	result, err := s.conn.client().GetPrompt(ctx, &mcp.GetPromptParams{Name: name, Arguments: arguments})
 	if err != nil {
 		s.env.T.Fatalf("prompts/get %s: %v%s", name, err, s.conn.failureContext())
 	}
@@ -55,7 +59,9 @@ func (s *Session) GetPrompt(name string, arguments map[string]string) *mcp.GetPr
 // TryGetPrompt renders one prompt and hands both halves back.
 func (s *Session) TryGetPrompt(name string, arguments map[string]string) (*mcp.GetPromptResult, error) {
 	s.env.T.Helper()
-	return s.conn.client().GetPrompt(s.env.Ctx, &mcp.GetPromptParams{Name: name, Arguments: arguments})
+
+	ctx := s.attribute(PurposeTest, ExpectationAny, callAttribution{target: name})
+	return s.conn.client().GetPrompt(ctx, &mcp.GetPromptParams{Name: name, Arguments: arguments})
 }
 
 // CompletePrompt asks for the values one prompt argument offers.
@@ -74,7 +80,11 @@ func (s *Session) CompleteResource(uriTemplate, argument, value string) []string
 func (s *Session) complete(ref *mcp.CompleteReference, argument, value string) []string {
 	s.env.T.Helper()
 
-	result, err := s.conn.client().Complete(s.env.Ctx, &mcp.CompleteParams{
+	// The reference and the argument together are what a completion covers, so
+	// the record names both: a template whose project variable completes says
+	// nothing about its branch variable.
+	ctx := s.attribute(PurposeTest, ExpectationOK, callAttribution{target: completionTarget(ref) + " " + argument})
+	result, err := s.conn.client().Complete(ctx, &mcp.CompleteParams{
 		Ref:      ref,
 		Argument: mcp.CompleteParamsArgument{Name: argument, Value: value},
 	})
@@ -101,7 +111,12 @@ func completionTarget(ref *mcp.CompleteReference) string {
 // no projection would produce.
 func (s *Session) Raw(params *mcp.CallToolParams) (*mcp.CallToolResult, error) {
 	s.env.T.Helper()
-	return s.conn.client().CallTool(s.env.Ctx, params)
+
+	// PurposeRaw, so the coverage report never credits an action for a call
+	// that named a tool directly: the subject of a raw call is the envelope,
+	// and what the server made of it is somebody else's evidence.
+	ctx := s.attribute(PurposeRaw, ExpectationAny, callAttribution{})
+	return s.conn.client().CallTool(ctx, params)
 }
 
 // Subscription is one resource this test is watching.
@@ -125,8 +140,15 @@ func (s *Session) Subscribe(uri string) *Subscription {
 	s.env.T.Helper()
 
 	updates := s.conn.notifier.watch(uri)
-	if err := s.conn.client().Subscribe(s.env.Ctx, &mcp.SubscribeParams{URI: uri}); err != nil {
+	// The index is what lets an update notification be recorded against this
+	// test: it arrives on the SDK's own goroutine, where nothing says whose
+	// subscription it answers.
+	unregister := s.conn.subscribers.add(uri, s.env.recorder)
+
+	subscribeCtx := s.attribute(PurposeTest, ExpectationOK, callAttribution{target: uri})
+	if err := s.conn.client().Subscribe(subscribeCtx, &mcp.SubscribeParams{URI: uri}); err != nil {
 		s.conn.notifier.forget(uri, updates)
+		unregister()
 		s.env.T.Fatalf("resources/subscribe %s: %v%s", uri, err, s.conn.failureContext())
 		return nil
 	}
@@ -136,8 +158,13 @@ func (s *Session) Subscribe(uri string) *Subscription {
 		// would leave it polling GitLab for the rest of the run.
 		ctx, cancel := context.WithTimeout(context.Background(), unsubscribeTimeout)
 		defer cancel()
+		ctx = withAttribution(ctx, callAttribution{
+			rec: s.env.recorder, conn: s.conn, purpose: PurposeCleanup,
+			expectation: ExpectationAny, target: uri,
+		})
 		_ = s.conn.client().Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: uri})
 		s.conn.notifier.forget(uri, updates)
+		unregister()
 	})
 	return &Subscription{session: s, uri: uri, updates: updates}
 }


### PR DESCRIPTION
Step S06 of the e2e rebuild (issue 704): the recorder, which is what makes coverage a fact about the server rather than about the source.

A client sending middleware stamps a fresh sampled W3C `traceparent` into `_meta` on every attributed request and records one call line; attribution comes off the context, so the initialize handshake and the session-start listings are neither stamped nor recorded. A receiving middleware records elicitation requests and resource-updated notifications, the former attributed through the session's in-flight call and dropped rather than guessed at when a shared session has more than one call in flight, since a line attributed to the wrong test is worse than a missing one.

Every child runs with telemetry on and its OTLP endpoint pointing at a loopback receiver the harness owns for the whole run. The receiver keeps every span the server exports, and a dispatch line is written for each tool-call span, carrying the action the server says it dispatched. The tool-call outcome goes through the same classification the assertions use, so a record and a failure message cannot disagree.

Records are buffered per `Env` and flushed from the first-registered `t.Cleanup`, so each line carries the test's final status. The run line and the session lines are written once from `Main`, because a session's dispatch-observed flag settles only after its last test. The receiver decodes gzip although the Go exporter does not send it today: eight lines that stop the whole record going silently empty if that default ever changes.
