### PR TITLE
test(e2e): admin_mode on the fixture token, and one seed per consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,39 +467,39 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,256 |     277,084 |
-| Unit tests (`_test.go`)  |       761 |     461,405 |
-| End-to-end tests         |       246 |      67,019 |
-| **Total**                | **2,263** | **805,508** |
+| Source (`.go`, non-test) |     1,260 |     277,898 |
+| Unit tests (`_test.go`)  |       764 |     462,353 |
+| End-to-end tests         |       279 |      77,529 |
+| **Total**                | **2,303** | **817,780** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                | 10,257 |
-| . Exported (public)             |  3,125 |
-| . Unexported (private)          |  7,132 |
-| Unit test functions (`TestXxx`) | 15,195 |
-| Subtests (`t.Run(...)`)         |  6,014 |
-| End-to-end test functions       |    614 |
+| Source functions                | 10,276 |
+| . Exported (public)             |  3,131 |
+| . Unexported (private)          |  7,145 |
+| Unit test functions (`TestXxx`) | 15,221 |
+| Subtests (`t.Run(...)`)         |  6,074 |
+| End-to-end test functions       |    775 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.67× more tests than code |
+| Test lines vs source lines         | 1.66× more tests than code |
 | Average source file length         |                 ~221 lines |
-| Average test file length           |                 ~606 lines |
-| Comment lines in source            |  54,699 (~19.7% of source) |
+| Average test file length           |                 ~605 lines |
+| Comment lines in source            |  55,086 (~19.8% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 8,288 |
-| `defer` statements                 | 1,384 |
-| `struct` types defined             | 3,271 |
+| `if err != nil` checks             | 8,389 |
+| `defer` statements                 | 1,433 |
+| `struct` types defined             | 3,279 |
 | `//nolint` suppressions            |   354 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -507,23 +507,23 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   269 |
-| Direct dependencies (`go.mod`) |    32 |
-| Indirect dependencies          |    39 |
+| Go packages                    |   271 |
+| Direct dependencies (`go.mod`) |    34 |
+| Indirect dependencies          |    37 |
 
 ### Hall of fame
 
 | Record              | File                                    |
 | ------------------- | --------------------------------------- |
 | Longest source file | `cmd/server/main.go`. 4,773 lines       |
-| Longest test file   | `cmd/server/main_test.go`. 10,833 lines |
+| Longest test file   | `cmd/server/main_test.go`. 10,837 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~5,037 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 15,353 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~5,052 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 15,360 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,15 +18,15 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 15,809 |
-| Unit test functions                                   | 15,195 |
-| E2E test functions                                    |    614 |
-| cmd test functions                                    |  3,061 |
-| Test files (internal/)                                |    551 |
+| Total test functions                                  | 15,996 |
+| Unit test functions                                   | 15,221 |
+| E2E test functions                                    |    775 |
+| cmd test functions                                    |  3,064 |
+| Test files (internal/)                                |    554 |
 | Test files (cmd/)                                     |    210 |
-| Test files (test/e2e/)                                |    240 |
+| Test files (test/e2e/)                                |    255 |
 | Tool sub-packages tested                              |    177 |
-| Core packages tested                                  |     22 |
+| Core packages tested                                  |     23 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  98.4% |
 | Overall coverage (`go test ./internal/...`)           |  98.6% |
 | Average package coverage                              |  98.7% |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 12,391 | 78.4% |
-| `TestFunc` (no underscore)             |    944 |  6.0% |
-| `TestFunc_Scenario_Expected` (3+ part) |  2,474 | 15.6% |
+| `TestFunc_Scenario` (2-part)           | 12,444 | 77.8% |
+| `TestFunc` (no underscore)             |    944 |  5.9% |
+| `TestFunc_Scenario_Expected` (3+ part) |  2,608 | 16.3% |
 
 ## Test Distribution
 
@@ -45,40 +45,41 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,683 |        157 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,706 |        160 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            366 |         16 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (177) |          9,085 |        378 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            614 |        240 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          3,061 |        210 | server entry point and developer command utilities                                              |
-| **Total**               |     **15,809** |  **1,001** |                                                                                                 |
+| E2E integration         |            775 |        255 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          3,064 |        210 | server entry point and developer command utilities                                              |
+| **Total**               |     **15,996** |  **1,019** |                                                                                                 |
 
 ### Core Packages
 
-| Package       |     Tests | Coverage | Description                                                                                                                                                                                                                                                        |
-| ------------- | --------: | -------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| cachehints    |         8 |   100.0% | Package cachehints applies SEP-2549 cache hints (ttlMs/cacheScope) to MCP results.                                                                                                                                                                                 |
-| capguard      |         1 |   100.0% | Package capguard keeps the methods this server answers in step with the capabilities it declares.                                                                                                                                                                  |
-| clientcompat  |        18 |   100.0% | Package clientcompat applies per-client response compatibility profiles to MCP results.                                                                                                                                                                            |
-| cmdutil       |         8 |   100.0% | Package cmdutil provides shared helpers for repository command utilities.                                                                                                                                                                                          |
-| completions   |       101 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                                                                           |
-| config        |       109 |   100.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                                                                   |
-| edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                                                                      |
-| elicitation   |       129 |    98.3% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                                                                       |
-| freshness     |         3 |   100.0% | Package freshness reads the one harness setting that decides whether a test comparing a committed, generated artifact runs that comparison now or leaves it to the run where the artifact is refreshed.                                                            |
-| gatewaycompat |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
-| gitlab        |       109 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
-| graphqlschema |        20 |   100.0% | Package graphqlschema holds the pinned GitLab GraphQL schema and validates documents against it.                                                                                                                                                                   |
-| mcpotel       |       107 |   100.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
-| oauth         |        80 |   100.0% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
-| progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
-| prompts       |       295 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
-| resources     |       194 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
-| serverpool    |       122 |   100.0% | Package serverpool manages a pool of credential entries keyed by GitLab token and URL.                                                                                                                                                                             |
-| subscriptions |        99 |   100.0% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
-| telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
-| testutil      |       116 |   100.0% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
-| toolutil      |     1,021 |    98.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,683** |          |                                                                                                                                                                                                                                                                    |
+| Package           |     Tests | Coverage | Description                                                                                                                                                                                                                                                        |
+| ----------------- | --------: | -------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| cachehints        |         8 |   100.0% | Package cachehints applies SEP-2549 cache hints (ttlMs/cacheScope) to MCP results.                                                                                                                                                                                 |
+| capguard          |         1 |   100.0% | Package capguard keeps the methods this server answers in step with the capabilities it declares.                                                                                                                                                                  |
+| clientcompat      |        18 |   100.0% | Package clientcompat applies per-client response compatibility profiles to MCP results.                                                                                                                                                                            |
+| cmdutil           |         8 |   100.0% | Package cmdutil provides shared helpers for repository command utilities.                                                                                                                                                                                          |
+| completions       |       101 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                                                                           |
+| config            |       109 |   100.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                                                                   |
+| edition           |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                                                                      |
+| elicitation       |       129 |    98.3% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                                                                       |
+| freshness         |         3 |   100.0% | Package freshness reads the one harness setting that decides whether a test comparing a committed, generated artifact runs that comparison now or leaves it to the run where the artifact is refreshed.                                                            |
+| gatewaycompat     |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
+| gitlab            |       109 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
+| graphqlschema     |        20 |   100.0% | Package graphqlschema holds the pinned GitLab GraphQL schema and validates documents against it.                                                                                                                                                                   |
+| mcpotel           |       107 |   100.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
+| oauth             |        80 |   100.0% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
+| progress          |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
+| prompts           |       295 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
+| resources         |       194 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
+| serverpool        |       122 |   100.0% | Package serverpool manages a pool of credential entries keyed by GitLab token and URL.                                                                                                                                                                             |
+| subscriptions     |        99 |   100.0% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
+| telemetry         |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
+| testutil          |       116 |   100.0% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
+| testutil/e2ecalls |        23 |      n/a | Package e2ecalls declares the record the end-to-end suite writes down while it runs, and the coverage audit reads back afterwards: what a test asked the server to do, what the server dispatched, and on which runtime, surface and mode.                         |
+| toolutil          |     1,021 |    98.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
+| **Subtotal**      | **2,706** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -367,30 +368,31 @@
 
 ### Core Packages
 
-| Package       | Coverage |
-| ------------- | -------: |
-| cachehints    |   100.0% |
-| capguard      |   100.0% |
-| clientcompat  |   100.0% |
-| cmdutil       |   100.0% |
-| completions   |   100.0% |
-| config        |   100.0% |
-| edition       |    87.0% |
-| elicitation   |    98.3% |
-| freshness     |   100.0% |
-| gatewaycompat |    99.4% |
-| gitlab        |   100.0% |
-| graphqlschema |   100.0% |
-| mcpotel       |   100.0% |
-| oauth         |   100.0% |
-| progress      |    83.8% |
-| prompts       |   100.0% |
-| resources     |   100.0% |
-| serverpool    |   100.0% |
-| subscriptions |   100.0% |
-| telemetry     |    93.1% |
-| testutil      |   100.0% |
-| toolutil      |    98.7% |
+| Package           | Coverage |
+| ----------------- | -------: |
+| cachehints        |   100.0% |
+| capguard          |   100.0% |
+| clientcompat      |   100.0% |
+| cmdutil           |   100.0% |
+| completions       |   100.0% |
+| config            |   100.0% |
+| edition           |    87.0% |
+| elicitation       |    98.3% |
+| freshness         |   100.0% |
+| gatewaycompat     |    99.4% |
+| gitlab            |   100.0% |
+| graphqlschema     |   100.0% |
+| mcpotel           |   100.0% |
+| oauth             |   100.0% |
+| progress          |    83.8% |
+| prompts           |   100.0% |
+| resources         |   100.0% |
+| serverpool        |   100.0% |
+| subscriptions     |   100.0% |
+| telemetry         |    93.1% |
+| testutil          |   100.0% |
+| testutil/e2ecalls |      n/a |
+| toolutil          |    98.7% |
 
 ### Tool Sub-Packages
 

--- a/test/e2e/scripts/setup-gitlab.sh
+++ b/test/e2e/scripts/setup-gitlab.sh
@@ -291,13 +291,13 @@ ENTERPRISE_ACTIVATION_CODE="$(env_or_dotenv GITLAB_ACTIVATION_CODE)"
 ENTERPRISE_LICENSE_CACHED="$(enterprise_license_file_value)"
 ENTERPRISE_LICENSE=""
 ENTERPRISE_LICENSE_SOURCE=""
-if [ -n "$ENTERPRISE_LICENSE_RAW" ] && ! looks_like_activation_code "$ENTERPRISE_LICENSE_RAW" ]; then
+if [ -n "$ENTERPRISE_LICENSE_RAW" ] && ! looks_like_activation_code "$ENTERPRISE_LICENSE_RAW"; then
     ENTERPRISE_LICENSE="$ENTERPRISE_LICENSE_RAW"
     ENTERPRISE_LICENSE_SOURCE="ENTERPRISE_LICENSE"
 elif [ -n "$ENTERPRISE_LICENSE_CACHED" ]; then
     ENTERPRISE_LICENSE="$ENTERPRISE_LICENSE_CACHED"
     ENTERPRISE_LICENSE_SOURCE="$ENTERPRISE_LICENSE_FILE_DISPLAY"
-elif [ -z "$ENTERPRISE_ACTIVATION_CODE" ] && looks_like_activation_code "$ENTERPRISE_LICENSE_RAW" ]; then
+elif [ -z "$ENTERPRISE_ACTIVATION_CODE" ] && looks_like_activation_code "$ENTERPRISE_LICENSE_RAW"; then
     ENTERPRISE_ACTIVATION_CODE="$ENTERPRISE_LICENSE_RAW"
 fi
 if [ "$ENTERPRISE_MODE" = "true" ]; then
@@ -511,6 +511,14 @@ else
 fi
 
 # 3. Create Personal Access Token for test user (with retry for timing issues)
+#
+# admin_mode is part of the set because the server narrows its own catalog to
+# the scopes the token reports at startup (cmd/server/main.go), and without it
+# the five admin groups listed in internal/tools/scope_filter.go are withheld:
+# gitlab_admin, gitlab_enterprise_user, gitlab_project_alias, gitlab_geo and
+# gitlab_storage_move. The user is created with admin=true above, so GitLab
+# accepts the scope; a suite that drives the real binary would otherwise be
+# served a smaller surface than the one it means to cover.
 echo "  [3/4] Creating Personal Access Token..."
 PAT=""
 for attempt in 1 2 3; do
@@ -521,6 +529,7 @@ for attempt in 1 2 3; do
         -d "scopes[]=read_user" \
         -d "scopes[]=read_repository" \
         -d "scopes[]=write_repository" \
+        -d "scopes[]=admin_mode" \
         --retry 3 --retry-delay 2 --retry-all-errors \
         --connect-timeout 5 --max-time 30 2>/dev/null || true)
 
@@ -575,24 +584,70 @@ curl -sSf -o /dev/null -X PUT "${GITLAB_URL}/api/v4/application/settings" \
     --data "import_sources[]=github&import_sources[]=bitbucket&import_sources[]=bitbucket_server&default_branch_protection=0" \
     --connect-timeout 5 --max-time 30 || echo "      WARNING: instance settings update rejected; importer and branch-protection coverage may misbehave"
 
-# 6. Seed a container image so the registry repository/tag e2e coverage can
+# Seed consumers: the runtime package and surface that each take a private
+# copy of a single-use seed. A destructive scenario eats its seed, so the
+# three surfaces cannot share one: the individual delete would take the tag
+# the meta run still needs, and whichever ran second would have to skip.
+# Both seeded scenarios below (registry tags, pending approvals) drive Free
+# actions, so their tests live in the rebuilt suite's `common` package, which
+# runs on every runtime; `ce` and `ee` gain a slot here when a scenario of
+# theirs starts consuming one. The frozen suite keeps reading the unsuffixed
+# variables, which are still written beside these.
+SEED_CONSUMERS="common:individual common:meta common:dynamic"
+
+# Suffix a consumer slot contributes to a seed variable name, so that
+# common:individual reads back as E2E_..._COMMON_INDIVIDUAL.
+seed_slot_suffix() {
+    printf '_%s' "$(printf '%s' "${1}" | tr '[:lower:]' '[:upper:]' | tr ':-' '__')"
+}
+
+# Infix a consumer slot contributes to a seeded object's own name, so that
+# common:individual reads back as ...-common-individual-...
+seed_slot_infix() {
+    printf '%s' "${1}" | tr ':' '-'
+}
+
+# 6. Seed container images so the registry repository/tag e2e coverage can
 # exercise real repositories instead of skipping. The registry listens on
 # plain HTTP at localhost:5050 (Docker treats localhost registries as
 # insecure by default), and GitLab issues the push token for the test user's
 # PAT. Best-effort: without a docker CLI the suite skips those subtests.
+# One project per consumer slot, because deleting a tag (or the repository)
+# is itself a scenario: a shared project would leave the second surface to
+# run without the tag it asserts on.
 REGISTRY_HOST="${REGISTRY_HOST:-localhost:5050}"
 REGISTRY_PROJECT_NAME="e2e-registry-seed"
-if command -v docker >/dev/null 2>&1; then
-    echo "  [6/8] Seeding container registry image (${REGISTRY_HOST})..."
-    seed_project_json=$(curl -sS -X POST "${GITLAB_URL}/api/v4/projects" \
+
+# Create one registry seed project, push seed-a and seed-b into it, and record
+# its path under the given variable name. The image must already be pulled.
+seed_registry_project() {
+    local project_name="$1"
+    local var_name="$2"
+    local project_json project_path
+    project_json=$(curl -sS -X POST "${GITLAB_URL}/api/v4/projects" \
         -H "PRIVATE-TOKEN: ${PAT}" \
-        --data "name=${REGISTRY_PROJECT_NAME}&visibility=private" \
+        --data-urlencode "name=${project_name}" \
+        --data "visibility=private" \
         --connect-timeout 5 --max-time 30 2>/dev/null || true)
-    seed_path=$(json_field "${seed_project_json}" "path_with_namespace")
-    if [ -z "${seed_path}" ]; then
+    project_path=$(json_field "${project_json}" "path_with_namespace")
+    if [ -z "${project_path}" ]; then
         # Project may already exist from a previous provisioning run.
-        seed_path="${TEST_USER}/${REGISTRY_PROJECT_NAME}"
+        project_path="${TEST_USER}/${project_name}"
     fi
+    if DOCKER_CONFIG="${seed_docker_config}" docker tag busybox:stable "${REGISTRY_HOST}/${project_path}:seed-a" \
+        && DOCKER_CONFIG="${seed_docker_config}" docker tag busybox:stable "${REGISTRY_HOST}/${project_path}:seed-b" \
+        && DOCKER_CONFIG="${seed_docker_config}" docker push "${REGISTRY_HOST}/${project_path}:seed-a" >/dev/null \
+        && DOCKER_CONFIG="${seed_docker_config}" docker push "${REGISTRY_HOST}/${project_path}:seed-b" >/dev/null; then
+        echo "${var_name}=${project_path}" >> "${ENV_FILE}"
+        echo "      Seeded ${REGISTRY_HOST}/${project_path} with tags seed-a, seed-b (${var_name})"
+        return 0
+    fi
+    echo "      WARNING: registry image seeding failed for ${project_path}; ${var_name} coverage will skip"
+    return 1
+}
+
+if command -v docker >/dev/null 2>&1; then
+    echo "  [6/8] Seeding container registry images (${REGISTRY_HOST})..."
     # docker login is avoided on purpose: on macOS the credential helper
     # requires an unlocked keychain, which non-interactive sessions (CI,
     # agents) do not have. A scratch DOCKER_CONFIG with the base64 auth
@@ -605,15 +660,15 @@ if command -v docker >/dev/null 2>&1; then
     (umask 177 && printf '{"auths":{"%s":{"auth":"%s"}}}' "${REGISTRY_HOST}" "${seed_auth}" > "${seed_docker_config}/config.json")
     [ -d "${HOME}/.docker/contexts" ] && ln -s "${HOME}/.docker/contexts" "${seed_docker_config}/contexts"
     [ -d "${HOME}/.docker/cli-plugins" ] && ln -s "${HOME}/.docker/cli-plugins" "${seed_docker_config}/cli-plugins"
-    if DOCKER_CONFIG="${seed_docker_config}" docker pull busybox:stable >/dev/null \
-        && DOCKER_CONFIG="${seed_docker_config}" docker tag busybox:stable "${REGISTRY_HOST}/${seed_path}:seed-a" \
-        && DOCKER_CONFIG="${seed_docker_config}" docker tag busybox:stable "${REGISTRY_HOST}/${seed_path}:seed-b" \
-        && DOCKER_CONFIG="${seed_docker_config}" docker push "${REGISTRY_HOST}/${seed_path}:seed-a" >/dev/null \
-        && DOCKER_CONFIG="${seed_docker_config}" docker push "${REGISTRY_HOST}/${seed_path}:seed-b" >/dev/null; then
-        echo "E2E_REGISTRY_PROJECT=${seed_path}" >> "${ENV_FILE}"
-        echo "      Seeded ${REGISTRY_HOST}/${seed_path} with tags seed-a, seed-b"
+    if DOCKER_CONFIG="${seed_docker_config}" docker pull busybox:stable >/dev/null; then
+        seed_registry_project "${REGISTRY_PROJECT_NAME}" "E2E_REGISTRY_PROJECT" || true
+        for seed_consumer in ${SEED_CONSUMERS}; do
+            seed_registry_project \
+                "${REGISTRY_PROJECT_NAME}-$(seed_slot_infix "${seed_consumer}")" \
+                "E2E_REGISTRY_PROJECT$(seed_slot_suffix "${seed_consumer}")" || true
+        done
     else
-        echo "      WARNING: registry image seeding failed; registry tag e2e coverage will skip"
+        echo "      WARNING: could not pull busybox:stable; registry tag e2e coverage will skip"
     fi
 else
     echo "  [6/8] docker CLI not found; skipping registry image seeding"
@@ -627,6 +682,10 @@ fi
 # instance ends the run in the same state it started. The newest version is
 # used because GitLab squashes old migrations: only recent versions are
 # guaranteed to still have a migration file the mark service can resolve.
+# This is the one seed that cannot be given a copy per consumer: an instance
+# has a single schema_migrations table and a single newest post_migrate
+# version, and marking it puts the row back. Its scenario therefore runs on
+# one surface, which the test declares with OnSurfaces and this reason.
 if command -v docker >/dev/null 2>&1; then
     echo "  [7/8] Seeding a pending schema migration for db_migration_mark coverage..."
     # The version must be one the WEB process can resolve to a migration
@@ -651,52 +710,87 @@ else
     echo "  [7/8] docker CLI not found; skipping db_migration_mark seeding"
 fi
 
-# 8. Seed two users in blocked_pending_approval state so the
+# 8. Seed users in blocked_pending_approval state so the
 # approve_user/reject_user happy paths can run: admin-created users are born
 # active on current GitLab (the require-admin-approval setting only affects
 # self-signups, which have no API), so the users are created through the API
 # and their state is flipped through the Rails console — exactly the state a
 # real pending signup would have. The approve test re-activates one and the
 # reject test deletes the other, so nothing lingers.
+# One pair per consumer slot: approving and rejecting each consume their user,
+# so a shared pair would serve exactly one surface.
+
+# Create one throwaway user for a pending-approval seed. Prints its numeric id
+# and returns non-zero when GitLab did not create it.
+create_pending_user() {
+    local username="$1"
+    local role="$2"
+    local password user_json user_id
+    # Random throwaway credential; the account only ever gets approved or
+    # rejected and nothing logs in with it.
+    password="E2eP!$(openssl rand -hex 8)"
+    user_json=$(curl -sS -X POST "${GITLAB_URL}/api/v4/users" \
+        -H "PRIVATE-TOKEN: ${PAT}" \
+        --data-urlencode "username=${username}" \
+        --data-urlencode "email=${username}@e2e-test.local" \
+        --data-urlencode "name=E2E Pending ${role}" \
+        --data-urlencode "password=${password}" \
+        --data-urlencode "skip_confirmation=true" \
+        --connect-timeout 5 --max-time 30 2>/dev/null || true)
+    user_id=$(json_field "${user_json}" "id")
+    case "${user_id}" in
+        # API data is interpolated into Ruby below: digits only.
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    printf '%s' "${user_id}"
+}
+
+# Create one approve/reject pair for a seed consumer slot, collecting the ids
+# for the single state flip below and the lines the env file gets once that
+# flip succeeded. The slot's name infix and variable suffix are empty for the
+# pair the frozen suite reads. A pair that could not be created warns and
+# leaves the other slots alone.
+seed_pending_pair() {
+    local slot_label="$1"
+    local name_infix="$2"
+    local var_suffix="$3"
+    local approve_id reject_id
+    approve_id=$(create_pending_user "e2e-pending-approve-${name_infix}${pending_suffix}" "approve" || true)
+    reject_id=$(create_pending_user "e2e-pending-reject-${name_infix}${pending_suffix}" "reject" || true)
+    if [ -z "${approve_id}" ] || [ -z "${reject_id}" ]; then
+        echo "      WARNING: could not create the ${slot_label} pending pair; its approve/reject happy path will skip"
+        return 0
+    fi
+    pending_ids="${pending_ids} ${approve_id} ${reject_id}"
+    pending_env="${pending_env}E2E_PENDING_APPROVE_USER_ID${var_suffix}=${approve_id}
+E2E_PENDING_REJECT_USER_ID${var_suffix}=${reject_id}
+"
+    echo "      Users ${approve_id} (approve) and ${reject_id} (reject) seeded for ${slot_label}"
+}
+
 if command -v docker >/dev/null 2>&1; then
     echo "  [8/8] Seeding pending-approval users for approve/reject coverage..."
     pending_suffix=$(date +%s)
     pending_ids=""
-    for role in approve reject; do
-        pending_username="e2e-pending-${role}-${pending_suffix}"
-        # Random throwaway credential; the account only ever gets approved or
-        # rejected and nothing logs in with it.
-        pending_password="E2eP!$(openssl rand -hex 8)"
-        pending_json=$(curl -sS -X POST "${GITLAB_URL}/api/v4/users" \
-            -H "PRIVATE-TOKEN: ${PAT}" \
-            --data-urlencode "username=${pending_username}" \
-            --data-urlencode "email=${pending_username}@e2e-test.local" \
-            --data-urlencode "name=E2E Pending ${role}" \
-            --data-urlencode "password=${pending_password}" \
-            --data-urlencode "skip_confirmation=true" \
-            --connect-timeout 5 --max-time 30 2>/dev/null || true)
-        pending_id=$(json_field "${pending_json}" "id")
-        case "${pending_id}" in
-            *[!0-9]*) pending_id="" ;; # API data is interpolated into Ruby below: digits only
-        esac
-        if [ -z "${pending_id}" ]; then
-            echo "      WARNING: could not create pending-${role} user; approve/reject happy path will skip"
-            pending_ids=""
-            break
-        fi
-        pending_ids="${pending_ids} ${pending_id}"
+    pending_env=""
+    seed_pending_pair "the frozen suite" "" ""
+    for seed_consumer in ${SEED_CONSUMERS}; do
+        seed_pending_pair \
+            "${seed_consumer}" \
+            "$(seed_slot_infix "${seed_consumer}")-" \
+            "$(seed_slot_suffix "${seed_consumer}")"
     done
     if [ -n "${pending_ids}" ]; then
-        pending_ids_csv=$(echo ${pending_ids} | tr ' ' ',')
+        # The leading separator goes first: the list is interpolated into a
+        # Ruby array literal, which an empty first element would not parse.
+        pending_ids_csv=$(printf '%s' "${pending_ids# }" | tr ' ' ',')
         if docker compose -f "${COMPOSE_FILE}" exec -T gitlab gitlab-rails runner \
             "User.where(id: [${pending_ids_csv}]).update_all(state: 'blocked_pending_approval')" \
             >/dev/null 2>&1; then
-            set -- ${pending_ids}
-            echo "E2E_PENDING_APPROVE_USER_ID=$1" >> "${ENV_FILE}"
-            echo "E2E_PENDING_REJECT_USER_ID=$2" >> "${ENV_FILE}"
-            echo "      Users $1 (approve) and $2 (reject) set to blocked_pending_approval"
+            printf '%s' "${pending_env}" >> "${ENV_FILE}"
+            echo "      Users ${pending_ids_csv} set to blocked_pending_approval"
         else
-            echo "      WARNING: could not flip user states to pending approval; approve/reject happy path will skip"
+            echo "      WARNING: could not flip user states to pending approval; approve/reject happy paths will skip"
         fi
     fi
 else


### PR DESCRIPTION
Step S07 of the e2e rebuild (issue 704): the fixture script does the two things the new suite needs of it.

`admin_mode` joins the scopes of the test token. The binary narrows its catalog to the scopes the token reports at startup, and without that scope `internal/tools/scope_filter.go` withholds `gitlab_admin`, `gitlab_enterprise_user`, `gitlab_project_alias`, `gitlab_geo` and `gitlab_storage_move`: a suite driving the real binary would be served a smaller surface than the one it means to cover. The user is created with `admin=true`, so GitLab accepts it, verified live.

One seed per consumer. `SEED_CONSUMERS` names the runtime package and surface that each take a private copy of a single-use seed, with the reason beside it: a destructive scenario eats its seed, so the surface that ran second had to skip. Both seeded scenarios, the registry project and the pending approvals, loop over that list and record one variable per slot. Slots are emitted for `common` only, since both scenarios drive Free actions; `ce` and `ee` gain one when a scenario of theirs starts consuming.

Verified by bringing the Docker stack up on truenas phase by phase and running the existing suite against it, without the Bitbucket profile (its four subtests skip identically in the base run) and with the evaluator preset in smoke mode, so no model was called. Three shellcheck findings that predate the change were fixed with it, since the step's verification line runs shellcheck over the whole file.

The generated counts are refreshed here, at the top of the stack.
