### PR TITLE
feat(e2e): the fixture library, with the shared World and the run-scoped sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,47 +467,47 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,260 |     277,898 |
-| Unit tests (`_test.go`)  |       764 |     462,353 |
-| End-to-end tests         |       279 |      77,529 |
-| **Total**                | **2,303** | **817,780** |
+| Source (`.go`, non-test) |     1,275 |     282,263 |
+| Unit tests (`_test.go`)  |       778 |     465,581 |
+| End-to-end tests         |       316 |      82,942 |
+| **Total**                | **2,369** | **830,786** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                | 10,276 |
-| . Exported (public)             |  3,131 |
-| . Unexported (private)          |  7,145 |
-| Unit test functions (`TestXxx`) | 15,221 |
-| Subtests (`t.Run(...)`)         |  6,074 |
-| End-to-end test functions       |    775 |
+| Source functions                | 10,434 |
+| . Exported (public)             |  3,136 |
+| . Unexported (private)          |  7,298 |
+| Unit test functions (`TestXxx`) | 15,332 |
+| Subtests (`t.Run(...)`)         |  6,142 |
+| End-to-end test functions       |    861 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.66× more tests than code |
+| Test lines vs source lines         | 1.65× more tests than code |
 | Average source file length         |                 ~221 lines |
-| Average test file length           |                 ~605 lines |
-| Comment lines in source            |  55,086 (~19.8% of source) |
+| Average test file length           |                 ~598 lines |
+| Comment lines in source            |  56,043 (~19.9% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 8,389 |
-| `defer` statements                 | 1,433 |
-| `struct` types defined             | 3,279 |
-| `//nolint` suppressions            |   354 |
+| `if err != nil` checks             | 8,514 |
+| `defer` statements                 | 1,469 |
+| `struct` types defined             | 3,322 |
+| `//nolint` suppressions            |   358 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   271 |
+| Go packages                    |   280 |
 | Direct dependencies (`go.mod`) |    34 |
 | Indirect dependencies          |    37 |
 
@@ -522,8 +522,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~5,052 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 15,360 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~5,132 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 15,398 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,13 +18,13 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 15,996 |
-| Unit test functions                                   | 15,221 |
-| E2E test functions                                    |    775 |
-| cmd test functions                                    |  3,064 |
+| Total test functions                                  | 16,166 |
+| Unit test functions                                   | 15,323 |
+| E2E test functions                                    |    843 |
+| cmd test functions                                    |  3,165 |
 | Test files (internal/)                                |    554 |
-| Test files (cmd/)                                     |    210 |
-| Test files (test/e2e/)                                |    255 |
+| Test files (cmd/)                                     |    221 |
+| Test files (test/e2e/)                                |    270 |
 | Tool sub-packages tested                              |    177 |
 | Core packages tested                                  |     23 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  98.4% |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 12,444 | 77.8% |
-| `TestFunc` (no underscore)             |    944 |  5.9% |
-| `TestFunc_Scenario_Expected` (3+ part) |  2,608 | 16.3% |
+| `TestFunc_Scenario` (2-part)           | 12,445 | 77.0% |
+| `TestFunc` (no underscore)             |    944 |  5.8% |
+| `TestFunc_Scenario_Expected` (3+ part) |  2,777 | 17.2% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,706 |        160 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,707 |        160 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            366 |         16 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (177) |          9,085 |        378 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            775 |        255 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          3,064 |        210 | server entry point and developer command utilities                                              |
-| **Total**               |     **15,996** |  **1,019** |                                                                                                 |
+| E2E integration         |            843 |        270 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          3,165 |        221 | server entry point and developer command utilities                                              |
+| **Total**               |     **16,166** |  **1,045** |                                                                                                 |
 
 ### Core Packages
 
@@ -77,9 +77,9 @@
 | subscriptions     |        99 |   100.0% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry         |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil          |       116 |   100.0% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
-| testutil/e2ecalls |        23 |      n/a | Package e2ecalls declares the record the end-to-end suite writes down while it runs, and the coverage audit reads back afterwards: what a test asked the server to do, what the server dispatched, and on which runtime, surface and mode.                         |
+| testutil/e2ecalls |        24 |      n/a | Package e2ecalls declares the record the end-to-end suite writes down while it runs, and the coverage audit reads back afterwards: what a test asked the server to do, what the server dispatched, and on which runtime, surface and mode.                         |
 | toolutil          |     1,021 |    98.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**      | **2,706** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**      | **2,707** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -319,6 +319,7 @@
 | cmd/audit_doc_coverage                         |    91.6% |
 | cmd/audit_doc_tool_names                       |    94.2% |
 | cmd/audit_dynamic_aliases                      |    77.4% |
+| cmd/audit_e2e_coverage                         |      n/a |
 | cmd/audit_e2e_gaps                             |    92.9% |
 | cmd/audit_edition_tier                         |    86.9% |
 | cmd/audit_gateway_chars                        |    87.5% |

--- a/test/e2e/internal/fixture/deployment.go
+++ b/test/e2e/internal/fixture/deployment.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+// deployment.go builds an environment and a deployment into it, stating the
+// two things GitLab 19 insists on and older releases let a caller omit.
+
+package fixture
+
+import (
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Environment is an environment a builder created.
+type Environment struct {
+	// ID is what the environment actions take.
+	ID int64
+	// Name is what a deployment names.
+	Name string
+}
+
+// Deployment is a deployment a builder created.
+type Deployment struct {
+	// ID is what the deployment actions take.
+	ID int64
+	// Environment is the environment it went to.
+	Environment Environment
+	// SHA is the commit it deployed.
+	SHA string
+	// Status is the status it was created in.
+	Status string
+}
+
+// NewEnvironment creates an environment in the project, named with the run's
+// own scoping. It goes with the project, so nothing is registered.
+func NewEnvironment(e *harness.Env, project Project, prefix string) Environment {
+	e.T.Helper()
+
+	name := e.Name(prefix)
+	environment, err := retryTransient(e, "create environment "+name, createRetries, func() (Environment, error) {
+		created, _, err := e.Client().GL().Environments.CreateEnvironment(project.ID, &gl.CreateEnvironmentOptions{Name: new(name)}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Environment{}, err
+		}
+		return Environment{ID: created.ID, Name: created.Name}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating environment %q in project %d: %v", name, project.ID, err)
+	}
+	return environment
+}
+
+// DeploymentRefIsBranch is the tag flag every fixture deployment states.
+//
+// GitLab 19 rejects a deployment creation that omits the flag, where earlier
+// releases inferred it from the ref, so a request has to say that the ref is
+// a branch. It is a named constant so that a test building the same request
+// through the server can state the same fact by the same name.
+const DeploymentRefIsBranch = false
+
+// DeploymentStatus is the status every fixture deployment is created in.
+//
+// GitLab 19 rejects "created" as an API deployment status; "running" is
+// accepted, and on a protected environment it is the state that yields a
+// blocked, approvable deployment, which is what the approval tests need.
+const DeploymentStatus = gl.DeploymentStatusRunning
+
+// NewDeployment creates a deployment of sha from the project's default
+// branch into environment, in the running status. It goes with the project,
+// so nothing is registered.
+func NewDeployment(e *harness.Env, project Project, environment Environment, sha string) Deployment {
+	e.T.Helper()
+
+	deployment, err := retryTransient(e, "create deployment", createRetries, func() (Deployment, error) {
+		created, _, err := e.Client().GL().Deployments.CreateProjectDeployment(project.ID, &gl.CreateProjectDeploymentOptions{
+			Environment: new(environment.Name),
+			Ref:         new(project.DefaultBranch),
+			SHA:         new(sha),
+			Tag:         new(DeploymentRefIsBranch),
+			Status:      new(DeploymentStatus),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Deployment{}, err
+		}
+		return Deployment{ID: created.ID, Environment: environment, SHA: created.SHA, Status: created.Status}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating a deployment of %s into %q in project %d: %v", ShortSHA(sha), environment.Name, project.ID, err)
+	}
+	return deployment
+}

--- a/test/e2e/internal/fixture/deployment_test.go
+++ b/test/e2e/internal/fixture/deployment_test.go
@@ -1,0 +1,24 @@
+//go:build e2e
+
+// deployment_test.go pins the two facts a GitLab 19 deployment request has
+// to state, so a change to either is a deliberate one.
+
+package fixture
+
+import (
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+)
+
+// TestDeploymentFacts_Constants_StateWhatGitLab19Demands checks that a
+// fixture deployment says its ref is a branch and is created running, the
+// two things GitLab 19 refuses a request without.
+func TestDeploymentFacts_Constants_StateWhatGitLab19Demands(t *testing.T) {
+	if DeploymentRefIsBranch {
+		t.Errorf("DeploymentRefIsBranch = true, want false: the fixture deploys a branch")
+	}
+	if DeploymentStatus != gl.DeploymentStatusRunning {
+		t.Errorf("DeploymentStatus = %q, want %q", DeploymentStatus, gl.DeploymentStatusRunning)
+	}
+}

--- a/test/e2e/internal/fixture/doc.go
+++ b/test/e2e/internal/fixture/doc.go
@@ -1,0 +1,19 @@
+// Package fixture is the GitLab state an end-to-end test stands on.
+//
+// Everything here is created through client-go rather than through the server
+// under test, on purpose: fixture traffic never counts as coverage, and a
+// broken tool then fails only the test that exercises it rather than every
+// test that needs a project to start from. Each builder registers its own
+// undo on the test's Env, so what a test creates is gone when the test ends,
+// and the World a package shares is built once and torn down after the last
+// test, with a digest that says whether anything changed it in between.
+//
+// The GitLab behavior the suite this replaces learned the hard way lives here
+// with its reasons: the retries a project creation needs under load, the
+// two-step permanent delete, the Sidekiq drain before a readiness wait, the
+// waits themselves, and the facts about GitLab 19 that a request has to state.
+//
+// The builders carry the e2e build tag; this file is what a plain build sees
+// of the package, the convention test/e2e/http/doc.go states. Like the
+// harness, the package is importable only from test/e2e by Go's internal rule.
+package fixture

--- a/test/e2e/internal/fixture/facts.go
+++ b/test/e2e/internal/fixture/facts.go
@@ -1,0 +1,23 @@
+//go:build e2e
+
+// facts.go holds what the suite this replaces learned about the GitLab
+// release it runs against and that a test cannot discover for itself. Each
+// fact is a function or a constant a test names, so the reason lives in one
+// place and the test that relies on it reads as a claim rather than as a
+// number.
+//
+// The deployment facts, which are requests rather than answers, are stated
+// on the deployment builder beside the request they shape.
+
+package fixture
+
+import "net/http"
+
+// NonSQLMetricsUnserved reports whether err is the answer GitLab 19 CE gives
+// on the usage-data non-SQL metrics endpoint: a 404, even with its feature
+// flag enabled, verified by live probing. A test of that action asserts the
+// documented error path with this, and passes unchanged on a future GitLab
+// that serves the endpoint, since it then gets no error to classify.
+func NonSQLMetricsUnserved(err error) bool {
+	return IsStatus(err, http.StatusNotFound)
+}

--- a/test/e2e/internal/fixture/facts_test.go
+++ b/test/e2e/internal/fixture/facts_test.go
@@ -1,0 +1,34 @@
+//go:build e2e
+
+// facts_test.go pins the GitLab 19 facts the tests rely on.
+
+package fixture
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// TestNonSQLMetricsUnserved_Answers_MatchesOnlyTheDocumented404 checks the
+// predicate a test of the non-SQL metrics action asserts its error path
+// with.
+func TestNonSQLMetricsUnserved_Answers_MatchesOnlyTheDocumented404(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "served", err: nil, want: false},
+		{name: "documented 404", err: statusError(http.StatusNotFound, "404 Not Found"), want: true},
+		{name: "forbidden", err: statusError(http.StatusForbidden, "403 Forbidden"), want: false},
+		{name: "network", err: errors.New("EOF"), want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := NonSQLMetricsUnserved(testCase.err); got != testCase.want {
+				t.Errorf("NonSQLMetricsUnserved(%v) = %t, want %t", testCase.err, got, testCase.want)
+			}
+		})
+	}
+}

--- a/test/e2e/internal/fixture/group.go
+++ b/test/e2e/internal/fixture/group.go
@@ -1,0 +1,148 @@
+//go:build e2e
+
+// group.go builds groups and subgroups, and removes them the way projects are
+// removed: marked, re-read, then permanently deleted under the renamed path.
+
+package fixture
+
+import (
+	"context"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Group is a group a builder created, as a test refers to it.
+type Group struct {
+	// ID is the numeric identifier every group-scoped action takes.
+	ID int64
+	// Path is the full path, parents included.
+	Path string
+	// Name is the group's display name.
+	Name string
+	// ParentID is the parent group's ID, zero for a top-level group.
+	ParentID int64
+}
+
+// groupSpec is what a builder asks GitLab for.
+type groupSpec struct {
+	name       string
+	visibility gl.VisibilityValue
+	parentID   int64
+}
+
+// GroupOption adjusts one group builder.
+type GroupOption func(*groupSpec)
+
+// WithGroupVisibility sets the group's visibility; private is the default.
+func WithGroupVisibility(visibility gl.VisibilityValue) GroupOption {
+	return func(spec *groupSpec) { spec.visibility = visibility }
+}
+
+// WithGroupNamePrefix changes the prefix the generated name opens with.
+func WithGroupNamePrefix(prefix string) GroupOption {
+	return func(spec *groupSpec) { spec.name = prefix }
+}
+
+// NewGroup creates a private top-level group and registers its permanent
+// deletion on the Env. Deleting the group deletes everything under it, so a
+// project built with InGroup needs no deletion of its own, though it is given
+// one anyway since the ledger runs it first and a project that fails to delete
+// says so on its own line.
+func NewGroup(e *harness.Env, opts ...GroupOption) Group {
+	e.T.Helper()
+	return newGroup(e, 0, opts)
+}
+
+// NewSubgroup creates a private group under parent and registers its
+// deletion on the Env.
+func NewSubgroup(e *harness.Env, parent Group, opts ...GroupOption) Group {
+	e.T.Helper()
+	return newGroup(e, parent.ID, opts)
+}
+
+// newGroup is the shared half of the two group builders.
+func newGroup(e *harness.Env, parentID int64, opts []GroupOption) Group {
+	e.T.Helper()
+	armSweep(e)
+
+	spec := groupSpec{name: "grp", visibility: gl.PrivateVisibility, parentID: parentID}
+	for _, opt := range opts {
+		opt(&spec)
+	}
+
+	group, err := createGroup(e, spec, func() string { return e.Name(spec.name) })
+	if err != nil {
+		e.T.Fatalf("creating the group fixture: %v", err)
+	}
+	e.Defer("group "+group.Path, func(ctx context.Context) error {
+		return DeleteGroup(ctx, e.Client(), group.ID, group.Path)
+	})
+	return group
+}
+
+// createGroup asks GitLab for a group under a fresh name on every attempt,
+// retried on the same failures a project creation is.
+func createGroup(e *harness.Env, spec groupSpec, nextName func() string) (Group, error) {
+	e.T.Helper()
+
+	enterprise := e.Runtime().Tier.IsEnterprise()
+	return retryWhen(e, "create group", createRetries,
+		func(err error) bool { return CreateRetryable(err, enterprise) },
+		func() (Group, error) {
+			name := nextName()
+			opts := &gl.CreateGroupOptions{
+				Name:       new(name),
+				Path:       new(name),
+				Visibility: new(spec.visibility),
+			}
+			if spec.parentID != 0 {
+				opts.ParentID = new(spec.parentID)
+			}
+			created, _, err := e.Client().GL().Groups.CreateGroup(opts, gl.WithContext(e.Ctx))
+			if err != nil {
+				return Group{}, err
+			}
+			return groupOf(created), nil
+		})
+}
+
+// groupOf reads what a test needs out of what GitLab returned.
+func groupOf(g *gl.Group) Group {
+	return Group{ID: g.ID, Path: g.FullPath, Name: g.Name, ParentID: g.ParentID}
+}
+
+// DeleteGroup removes a group permanently, with everything under it.
+//
+// It follows the project's two steps for the same reason: an instance with
+// delayed deletion marks the group first and renames its path while it waits,
+// and the permanent removal has to name that path. An instance without
+// delayed deletion removes it on the first step, and the second step's 404
+// then says the job is done.
+//
+//nolint:dupl // DeleteProject is this step for step on a service of its own, and the shared part is deletePermanently
+func DeleteGroup(ctx context.Context, client *gitlabclient.Client, groupID int64, path string) error {
+	groups := client.GL().Groups
+	return deletePermanently(ctx, "group", groupID, path, deletionSteps{
+		mark: func(ctx context.Context) error {
+			_, err := groups.DeleteGroup(groupID, nil, gl.WithContext(ctx))
+			return err
+		},
+		currentPath: func(ctx context.Context) (string, error) {
+			current, _, err := groups.GetGroup(groupID, nil, gl.WithContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			return current.FullPath, nil
+		},
+		remove: func(ctx context.Context, path string) error {
+			_, err := groups.DeleteGroup(groupID, &gl.DeleteGroupOptions{
+				PermanentlyRemove: new(true),
+				FullPath:          new(path),
+			}, gl.WithContext(ctx))
+			return err
+		},
+	})
+}

--- a/test/e2e/internal/fixture/group_test.go
+++ b/test/e2e/internal/fixture/group_test.go
@@ -1,0 +1,71 @@
+//go:build e2e
+
+// group_test.go drives the group's permanent deletion against the stub.
+
+package fixture
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+)
+
+// TestDeleteGroup_Unmarked_MarksThenRemovesUnderTheRenamedPath checks that a
+// group goes through the same two steps a project does: mark, re-read the
+// renamed path, remove permanently under it.
+func TestDeleteGroup_Unmarked_MarksThenRemovesUnderTheRenamedPath(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addGroup(3, "e2e-grp", "e2e-grp")
+
+	if err := DeleteGroup(context.Background(), client, 3, "e2e-grp"); err != nil {
+		t.Fatalf("DeleteGroup() error = %v, want nil", err)
+	}
+	want := []string{
+		"group 3 ",
+		"group 3 full_path=e2e-grp-deletion_scheduled-3&permanently_remove=true",
+	}
+	if got := stub.recordedDeletes(); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("deletes = %q, want %q", got, want)
+	}
+	if _, groups := stub.remaining(); len(groups) != 0 {
+		t.Errorf("groups left = %v, want none", groups)
+	}
+}
+
+// TestDeleteGroup_AlreadyMarked_StillRemovesIt checks that a group a test
+// already marked is removed rather than refused.
+func TestDeleteGroup_AlreadyMarked_StillRemovesIt(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addGroup(5, "e2e-marked", "e2e-marked")
+	if _, err := client.GL().Groups.DeleteGroup(int64(5), nil); err != nil {
+		t.Fatalf("marking through the client: %v", err)
+	}
+
+	if err := DeleteGroup(context.Background(), client, 5, "e2e-marked"); err != nil {
+		t.Fatalf("DeleteGroup() error = %v, want nil", err)
+	}
+	if _, groups := stub.remaining(); len(groups) != 0 {
+		t.Errorf("groups left = %v, want none", groups)
+	}
+}
+
+// TestDeleteGroup_Gone_IsNotAnError checks that a group nothing can find
+// counts as deleted.
+func TestDeleteGroup_Gone_IsNotAnError(t *testing.T) {
+	_, client := newStubGitLab(t)
+	if err := DeleteGroup(context.Background(), client, 4, "never"); err != nil {
+		t.Fatalf("DeleteGroup() error = %v, want nil for a group that is gone", err)
+	}
+}
+
+// TestGroupOf_Fields_ReadsWhatATestNeeds checks the projection of what
+// GitLab returned into what a test refers to.
+func TestGroupOf_Fields_ReadsWhatATestNeeds(t *testing.T) {
+	got := groupOf(&gl.Group{ID: 9, Name: "Sub", FullPath: "parent/sub", ParentID: 2})
+	want := Group{ID: 9, Path: "parent/sub", Name: "Sub", ParentID: 2}
+	if got != want {
+		t.Errorf("groupOf() = %+v, want %+v", got, want)
+	}
+}

--- a/test/e2e/internal/fixture/issue.go
+++ b/test/e2e/internal/fixture/issue.go
@@ -1,0 +1,121 @@
+//go:build e2e
+
+// issue.go builds the objects that hang off a project's issue tracker: an
+// issue, a label and a milestone. All three go with the project, so none
+// registers a deletion of its own.
+
+package fixture
+
+import (
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Issue is an issue a builder created.
+type Issue struct {
+	// IID is the project-scoped identifier every issue action takes.
+	IID int64
+	// ID is the instance-wide identifier.
+	ID int64
+	// Title is what it was created with.
+	Title string
+}
+
+// Label is a project label a builder created.
+type Label struct {
+	// ID is the label's identifier.
+	ID int64
+	// Name is what a label filter takes.
+	Name string
+	// Color is the hex color it was created with.
+	Color string
+}
+
+// Milestone is a project milestone a builder created.
+type Milestone struct {
+	// ID is the instance-wide identifier a milestone_id parameter takes.
+	ID int64
+	// IID is the project-scoped identifier.
+	IID int64
+	// Title is what it was created with.
+	Title string
+}
+
+// NewIssue creates an issue in the project.
+func NewIssue(e *harness.Env, project Project, title string) Issue {
+	e.T.Helper()
+
+	issue, err := retryTransient(e, "create issue", createRetries, func() (Issue, error) {
+		created, _, err := e.Client().GL().Issues.CreateIssue(project.ID, &gl.CreateIssueOptions{
+			Title:       new(title),
+			Description: new("e2e: " + e.T.Name()),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Issue{}, err
+		}
+		return Issue{IID: created.IID, ID: created.ID, Title: created.Title}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating an issue in project %d: %v", project.ID, err)
+	}
+	return issue
+}
+
+// labelColor is the color every fixture label gets. GitLab requires one and
+// no test cares which.
+const labelColor = "#428BCA"
+
+// NewLabel creates a project label, named with the run's own scoping so two
+// tests sharing a project cannot collide on it.
+func NewLabel(e *harness.Env, project Project, prefix string) Label {
+	e.T.Helper()
+	return createLabel(e, project, e.Name(prefix))
+}
+
+// createLabel creates a project label under exactly the given name.
+func createLabel(e *harness.Env, project Project, name string) Label {
+	e.T.Helper()
+
+	label, err := retryTransient(e, "create label "+name, createRetries, func() (Label, error) {
+		created, _, err := e.Client().GL().Labels.CreateLabel(project.ID, &gl.CreateLabelOptions{
+			Name:        new(name),
+			Color:       new(labelColor),
+			Description: new("e2e: " + e.T.Name()),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Label{}, err
+		}
+		return Label{ID: created.ID, Name: created.Name, Color: created.Color}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating label %q in project %d: %v", name, project.ID, err)
+	}
+	return label
+}
+
+// NewMilestone creates a project milestone titled with the run's own scoping.
+func NewMilestone(e *harness.Env, project Project, prefix string) Milestone {
+	e.T.Helper()
+	return createMilestone(e, project, e.Name(prefix))
+}
+
+// createMilestone creates a project milestone under exactly the given title.
+func createMilestone(e *harness.Env, project Project, title string) Milestone {
+	e.T.Helper()
+
+	milestone, err := retryTransient(e, "create milestone "+title, createRetries, func() (Milestone, error) {
+		created, _, err := e.Client().GL().Milestones.CreateMilestone(project.ID, &gl.CreateMilestoneOptions{
+			Title:       new(title),
+			Description: new("e2e: " + e.T.Name()),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Milestone{}, err
+		}
+		return Milestone{ID: created.ID, IID: created.IID, Title: created.Title}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating milestone %q in project %d: %v", title, project.ID, err)
+	}
+	return milestone
+}

--- a/test/e2e/internal/fixture/merge_request.go
+++ b/test/e2e/internal/fixture/merge_request.go
@@ -1,0 +1,149 @@
+//go:build e2e
+
+// merge_request.go builds a merge request and waits until GitLab has
+// finished thinking about it.
+//
+// A merge request exists the moment it is created and is useless for a while
+// after: GitLab computes its diff and its merge ref in the background, and
+// while detailed_merge_status reads "preparing", "checking" or "unchecked"
+// the commits, diff versions and mergeability endpoints answer with nothing.
+// Every test that reads any of those would be flaky on a slow Docker GitLab
+// without the wait below, and none of them should have to know why.
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// MergeRequest is a merge request a builder created.
+type MergeRequest struct {
+	// IID is the project-scoped identifier every merge request action takes.
+	IID int64
+	// ID is the instance-wide identifier.
+	ID int64
+	// SourceBranch and TargetBranch are the two sides of it.
+	SourceBranch string
+	TargetBranch string
+	// Title is what it was created with.
+	Title string
+	// Status is the detailed_merge_status it settled on: "mergeable" for a
+	// fixture whose branches differ and do not conflict.
+	Status string
+}
+
+// NewMergeRequest creates a merge request from source into target and waits
+// until GitLab has finished preparing it. The source branch needs at least
+// one commit the target does not have, or GitLab creates nothing to merge.
+//
+// The merge request goes with the project, so nothing is registered.
+func NewMergeRequest(e *harness.Env, project Project, source, target, title string) MergeRequest {
+	e.T.Helper()
+
+	mr, err := retryTransient(e, "create merge request", createRetries, func() (MergeRequest, error) {
+		created, _, err := e.Client().GL().MergeRequests.CreateMergeRequest(project.ID, &gl.CreateMergeRequestOptions{
+			Title:        new(title),
+			SourceBranch: new(source),
+			TargetBranch: new(target),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return MergeRequest{}, err
+		}
+		return mergeRequestOf(created), nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating a merge request %q -> %q in project %d: %v", source, target, project.ID, err)
+	}
+
+	mr.Status = WaitForMergeRequest(e, project, mr.IID)
+	return mr
+}
+
+// mergeRequestOf reads what a test needs out of what GitLab returned.
+func mergeRequestOf(mr *gl.MergeRequest) MergeRequest {
+	return MergeRequest{
+		IID:          mr.IID,
+		ID:           mr.ID,
+		SourceBranch: mr.SourceBranch,
+		TargetBranch: mr.TargetBranch,
+		Title:        mr.Title,
+		Status:       mr.DetailedMergeStatus,
+	}
+}
+
+// The waits a merge request may take to leave its transitional states.
+const (
+	mergeRequestWait           = 120 * time.Second
+	enterpriseMergeRequestWait = 300 * time.Second
+	mergeRequestPollInterval   = 500 * time.Millisecond
+)
+
+// WaitForMergeRequest drains Sidekiq and polls the merge request until its
+// detailed_merge_status leaves the transitional values, returning the status
+// it settled on.
+//
+// It is best effort and never fails the test on its own: a merge request that
+// is still "checking" when the budget runs out is logged and handed back, so
+// the test's own assertion produces the message that says what it needed.
+func WaitForMergeRequest(e *harness.Env, project Project, iid int64) string {
+	e.T.Helper()
+
+	DrainSidekiq(e.Ctx, e.Client())
+	status, err := waitForMergeRequestReady(e.Ctx, e.Client(), project.ID, iid, budget(e, mergeRequestWait, enterpriseMergeRequestWait))
+	if err != nil {
+		e.T.Logf("merge request !%d in project %d: readiness wait ended: %v", iid, project.ID, err)
+	}
+	return status
+}
+
+// waitForMergeRequestReady polls until the merge request leaves the
+// transitional states or the budget is spent, returning the last status seen.
+func waitForMergeRequestReady(ctx context.Context, client *gitlabclient.Client, projectID, iid int64, wait time.Duration) (string, error) {
+	pollCtx, cancel := context.WithTimeout(ctx, wait)
+	defer cancel()
+
+	status := ""
+	err := harness.Poll(pollCtx, mergeRequestPollInterval, wait, func() (bool, string, error) {
+		mr, resp, err := client.GL().MergeRequests.GetMergeRequest(projectID, iid, nil, gl.WithContext(pollCtx))
+		if err == nil {
+			status = mr.DetailedMergeStatus
+			return !transitionalMergeStatus(status), "detailed_merge_status=" + status, nil
+		}
+		if pollCtx.Err() != nil {
+			return false, "", pollCtx.Err()
+		}
+		state := fmt.Sprintf("merge request !%d in project %d: %v", iid, projectID, err)
+		if resp != nil {
+			state = fmt.Sprintf("merge request !%d in project %d: HTTP %d", iid, projectID, resp.StatusCode)
+		}
+		if resp == nil && !IsTransientNetwork(err) {
+			return false, state, fmt.Errorf("reading merge request !%d of project %d: %w", iid, projectID, err)
+		}
+		if resp != nil && resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode < http.StatusInternalServerError {
+			return false, state, fmt.Errorf("reading merge request !%d of project %d: %w", iid, projectID, err)
+		}
+		return false, state, nil
+	})
+	return status, err
+}
+
+// transitionalMergeStatus reports whether a detailed_merge_status is one
+// GitLab reports while it is still computing the diff and the merge ref. The
+// empty string is one of them: older releases answered nothing at all until
+// the check had run.
+func transitionalMergeStatus(status string) bool {
+	switch status {
+	case "preparing", "checking", "unchecked", "":
+		return true
+	default:
+		return false
+	}
+}

--- a/test/e2e/internal/fixture/merge_request_test.go
+++ b/test/e2e/internal/fixture/merge_request_test.go
@@ -1,0 +1,92 @@
+//go:build e2e
+
+// merge_request_test.go drives the merge request readiness wait against the
+// stub.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestWaitForMergeRequestReady_Transitional_WaitsForASettledStatus checks
+// that the three states GitLab reports while it computes the merge ref are
+// waited through, and the status it settles on is what comes back.
+func TestWaitForMergeRequestReady_Transitional_WaitsForASettledStatus(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() { stub.mergeStatuses = []string{"preparing", "checking", "unchecked", "mergeable"} })
+
+	status, err := waitForMergeRequestReady(context.Background(), client, 1, 2, 5*time.Second)
+	if err != nil {
+		t.Fatalf("waitForMergeRequestReady() error = %v, want nil", err)
+	}
+	if status != "mergeable" {
+		t.Errorf("status = %q, want mergeable", status)
+	}
+}
+
+// TestWaitForMergeRequestReady_NeverSettles_ReportsTheLastStatus checks the
+// timeout hands back what was last seen, since the caller logs it and goes
+// on.
+func TestWaitForMergeRequestReady_NeverSettles_ReportsTheLastStatus(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() { stub.mergeStatuses = []string{"checking"} })
+
+	status, err := waitForMergeRequestReady(context.Background(), client, 1, 2, 300*time.Millisecond)
+	if !errors.Is(err, harness.ErrPollTimeout) {
+		t.Fatalf("waitForMergeRequestReady() error = %v, want a poll timeout", err)
+	}
+	if status != "checking" {
+		t.Errorf("status = %q, want the last one seen", status)
+	}
+}
+
+// TestWaitForMergeRequestReady_NotFound_EndsTheWait checks that an answer
+// the wait cannot poll through, a 404 for a merge request that is not there,
+// ends it with that error rather than with a timeout.
+func TestWaitForMergeRequestReady_NotFound_EndsTheWait(t *testing.T) {
+	_, client := newStubGitLab(t)
+
+	_, err := waitForMergeRequestReady(context.Background(), client, 1, 404, 5*time.Second)
+	if err == nil || errors.Is(err, harness.ErrPollTimeout) {
+		t.Fatalf("waitForMergeRequestReady() error = %v, want the 404 itself", err)
+	}
+}
+
+// TestTransitionalMergeStatus_Values_NamesTheThreeAndEmpty pins the set.
+func TestTransitionalMergeStatus_Values_NamesTheThreeAndEmpty(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{status: "preparing", want: true},
+		{status: "checking", want: true},
+		{status: "unchecked", want: true},
+		{status: "", want: true},
+		{status: "mergeable", want: false},
+		{status: "conflict", want: false},
+	}
+	for _, testCase := range cases {
+		t.Run("status "+testCase.status, func(t *testing.T) {
+			if got := transitionalMergeStatus(testCase.status); got != testCase.want {
+				t.Errorf("transitionalMergeStatus(%q) = %t, want %t", testCase.status, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestMergeRequestOf_Fields_ReadsWhatATestNeeds checks the projection.
+func TestMergeRequestOf_Fields_ReadsWhatATestNeeds(t *testing.T) {
+	got := mergeRequestOf(&gl.MergeRequest{IID: 3, ID: 30, SourceBranch: "feature", TargetBranch: "main", Title: "t", DetailedMergeStatus: "mergeable"})
+	want := MergeRequest{IID: 3, ID: 30, SourceBranch: "feature", TargetBranch: "main", Title: "t", Status: "mergeable"}
+	if got != want {
+		t.Errorf("mergeRequestOf() = %+v, want %+v", got, want)
+	}
+}

--- a/test/e2e/internal/fixture/network.go
+++ b/test/e2e/internal/fixture/network.go
@@ -1,0 +1,133 @@
+//go:build e2e
+
+// network.go answers where things are on the Docker network, which is not
+// where the test sees them.
+//
+// The test reaches GitLab at a host-facing address such as localhost:8929,
+// and GitLab cannot reach itself there: a mirror, a direct transfer or a
+// release-cli call made from inside the compose network has to name the
+// service instead. The suite this replaces spelled that address in three
+// places with three fallbacks; this file is the one place it lives now, and
+// every URL that has to be reachable from inside GitLab is built here.
+
+package fixture
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The configuration keys the network helpers read, as setup-gitlab.sh writes
+// them into .env.docker.
+const (
+	// SettingInternalGitLabURL is the address GitLab is reachable at from
+	// inside the compose network.
+	SettingInternalGitLabURL = "E2E_GITLAB_INTERNAL_URL"
+	// SettingFixtureURL is the address of the fixture service, which answers
+	// webhook deliveries, custom emoji images and mirror pushes.
+	SettingFixtureURL = "E2E_FIXTURE_URL"
+	// SettingGitLabToken is the run's own credential, which a mirror target
+	// embeds so GitLab can push to itself.
+	SettingGitLabToken = "GITLAB_TOKEN"
+)
+
+// The addresses the Docker stack uses when the settings say nothing, which
+// are the service names docker-compose.yml declares.
+const (
+	DefaultInternalGitLabURL = "http://gitlab-e2e"
+	DefaultFixtureURL        = "http://e2e-fixture:8080"
+)
+
+// InternalGitLabURL returns the address GitLab reaches itself at from inside
+// the Docker network, with no trailing slash.
+func InternalGitLabURL(e *harness.Env) string {
+	return resolveInternalGitLabURL(e.Setting(SettingInternalGitLabURL))
+}
+
+// resolveInternalGitLabURL is InternalGitLabURL over a raw setting.
+func resolveInternalGitLabURL(configured string) string {
+	return withoutTrailingSlash(configured, DefaultInternalGitLabURL)
+}
+
+// RepositoryURL returns the clone URL of a project as GitLab reaches it from
+// inside the Docker network, which is what a pull mirror names as its source.
+// Outside Docker mode, where no internal address is configured, it is the
+// URL GitLab itself published for the project.
+func RepositoryURL(e *harness.Env, project Project) string {
+	return repositoryURL(e.Setting(SettingInternalGitLabURL), project.Path, project.HTTPURLToRepo)
+}
+
+// repositoryURL is RepositoryURL over raw values.
+func repositoryURL(configured, path, published string) string {
+	if strings.TrimSpace(configured) == "" {
+		return published
+	}
+	return withoutTrailingSlash(configured, "") + "/" + strings.TrimLeft(path, "/") + ".git"
+}
+
+// MirrorTargetURL returns an authenticated clone URL for target that GitLab
+// can push to from inside the Docker network, for a push mirror. The run's
+// own token rides in the URL as the oauth2 user, which is how GitLab
+// authenticates a mirror push against itself.
+func MirrorTargetURL(e *harness.Env, target Project) string {
+	e.T.Helper()
+
+	token := e.Setting(SettingGitLabToken)
+	if token == "" {
+		e.T.Fatalf("%s is required to configure a mirror target", SettingGitLabToken)
+	}
+	targetURL, err := mirrorTargetURL(InternalGitLabURL(e), token, target.Path)
+	if err != nil {
+		e.T.Fatalf("building the mirror target URL: %v", err)
+	}
+	return targetURL
+}
+
+// mirrorTargetURL is MirrorTargetURL over raw values.
+func mirrorTargetURL(base, token, path string) (string, error) {
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parsing the internal GitLab URL %q: %w", base, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("the internal GitLab URL %q names no scheme or host", base)
+	}
+	parsed.User = url.UserPassword("oauth2", token)
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/" + strings.TrimLeft(path, "/") + ".git"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+// HasFixtureService reports whether the fixture service should be reachable
+// from GitLab in this run: either its address is configured, or the run is
+// in Docker mode, where the stack always starts it. NeedFixtureService is the
+// declaration; this is the same answer for a test that decides at runtime.
+func HasFixtureService(e *harness.Env) bool {
+	return e.Setting(SettingFixtureURL) != "" || e.DockerMode()
+}
+
+// ServiceURL returns the address of one resource on the fixture service, as
+// GitLab reaches it: a webhook receiver, a custom emoji image, a mirror
+// target the Docker stack answers deterministically.
+func ServiceURL(e *harness.Env, resourcePath string) string {
+	return fixtureServiceURL(e.Setting(SettingFixtureURL), resourcePath)
+}
+
+// fixtureServiceURL is ServiceURL over a raw setting.
+func fixtureServiceURL(configured, resourcePath string) string {
+	return withoutTrailingSlash(configured, DefaultFixtureURL) + "/" + strings.TrimLeft(resourcePath, "/")
+}
+
+// withoutTrailingSlash returns configured with its trailing slashes removed,
+// or fallback when configured is blank.
+func withoutTrailingSlash(configured, fallback string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(configured), "/")
+	if trimmed == "" {
+		return strings.TrimRight(fallback, "/")
+	}
+	return trimmed
+}

--- a/test/e2e/internal/fixture/network_test.go
+++ b/test/e2e/internal/fixture/network_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+
+// network_test.go pins the URL resolution that replaced three copies in the
+// suite before it.
+
+package fixture
+
+import (
+	"testing"
+)
+
+// TestResolveInternalGitLabURL_Settings_DefaultsToTheServiceName checks the
+// fallback, the trimming, and that a configured address wins.
+func TestResolveInternalGitLabURL_Settings_DefaultsToTheServiceName(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{name: "unset", configured: "", want: "http://gitlab-e2e"},
+		{name: "blank", configured: "  ", want: "http://gitlab-e2e"},
+		{name: "configured", configured: "http://gitlab.internal:8080", want: "http://gitlab.internal:8080"},
+		{name: "trailing slash", configured: "http://gitlab.internal/", want: "http://gitlab.internal"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := resolveInternalGitLabURL(testCase.configured); got != testCase.want {
+				t.Errorf("resolveInternalGitLabURL(%q) = %q, want %q", testCase.configured, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestRepositoryURL_Settings_UsesTheInternalAddressWhenConfigured checks
+// the mirror source: the internal address with the project path when there
+// is one, the URL GitLab published otherwise.
+func TestRepositoryURL_Settings_UsesTheInternalAddressWhenConfigured(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		path       string
+		published  string
+		want       string
+	}{
+		{name: "docker", configured: "http://gitlab-e2e/", path: "user/proj", published: "http://localhost:8929/user/proj.git", want: "http://gitlab-e2e/user/proj.git"},
+		{name: "self-hosted", configured: "", path: "user/proj", published: "https://gitlab.example/user/proj.git", want: "https://gitlab.example/user/proj.git"},
+		{name: "leading slash", configured: "http://gitlab-e2e", path: "/user/proj", published: "", want: "http://gitlab-e2e/user/proj.git"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := repositoryURL(testCase.configured, testCase.path, testCase.published); got != testCase.want {
+				t.Errorf("repositoryURL() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestMirrorTargetURL_Token_EmbedsTheCredentialAsOAuth2 checks the push
+// mirror target carries the token the way GitLab authenticates a push to
+// itself, and that query and fragment never survive.
+func TestMirrorTargetURL_Token_EmbedsTheCredentialAsOAuth2(t *testing.T) {
+	got, err := mirrorTargetURL("http://gitlab-e2e/?x=1#frag", "glpat-secret", "/user/target")
+	if err != nil {
+		t.Fatalf("mirrorTargetURL() error = %v", err)
+	}
+	if want := "http://oauth2:glpat-secret@gitlab-e2e/user/target.git"; got != want {
+		t.Errorf("mirrorTargetURL() = %q, want %q", got, want)
+	}
+}
+
+// TestMirrorTargetURL_BadBase_IsRefused checks that an address with no host
+// is an error rather than a URL GitLab would fail to push to later.
+func TestMirrorTargetURL_BadBase_IsRefused(t *testing.T) {
+	cases := []struct {
+		name string
+		base string
+	}{
+		{name: "no scheme", base: "gitlab-e2e"},
+		{name: "unparseable", base: "http://[::1"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := mirrorTargetURL(testCase.base, "t", "p"); err == nil {
+				t.Errorf("mirrorTargetURL(%q) error = nil, want a refusal", testCase.base)
+			}
+		})
+	}
+}
+
+// TestFixtureServiceURL_Settings_JoinsWithoutDoubleSlashes checks the
+// fixture service address and the join.
+func TestFixtureServiceURL_Settings_JoinsWithoutDoubleSlashes(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		resource   string
+		want       string
+	}{
+		{name: "default", configured: "", resource: "webhook", want: "http://e2e-fixture:8080/webhook"},
+		{name: "both slashes", configured: "http://fixture:9000/", resource: "/emoji.png", want: "http://fixture:9000/emoji.png"},
+		{name: "nested", configured: "http://fixture:9000", resource: "mirror/target.git", want: "http://fixture:9000/mirror/target.git"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := fixtureServiceURL(testCase.configured, testCase.resource); got != testCase.want {
+				t.Errorf("fixtureServiceURL() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}

--- a/test/e2e/internal/fixture/pipeline.go
+++ b/test/e2e/internal/fixture/pipeline.go
@@ -1,0 +1,209 @@
+//go:build e2e
+
+// pipeline.go builds a pipeline and waits for it to finish, which needs the
+// one thing a GitLab cannot provide by itself: a runner.
+//
+// Without a runner a pipeline stays pending forever, so the builder asks the
+// harness whether one is registered and skips the test with that reason
+// rather than spending the whole budget on nothing. With one, the wait is
+// long and tolerant of a slow runner in an ephemeral container, and it fails
+// the test when the budget runs out: a pipeline that never finished is a
+// fact about the run, and the suite this replaces used to hand the caller a
+// non-terminal status to make of what it could.
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// CIYAML is a minimal .gitlab-ci.yml with one fast job and no runner tags, so
+// it runs on whatever runner the instance has. Commit it with CIFile before
+// creating a pipeline.
+const CIYAML = `stages:
+  - test
+
+fast-pass:
+  stage: test
+  script:
+    - echo "e2e pipeline job"
+  tags: []
+`
+
+// CIFilePath is where GitLab looks for the pipeline configuration.
+const CIFilePath = ".gitlab-ci.yml"
+
+// Pipeline is a pipeline a builder created and waited for.
+type Pipeline struct {
+	// ID is what every pipeline action takes.
+	ID int64
+	// Ref is the branch it ran on.
+	Ref string
+	// SHA is the commit it ran against.
+	SHA string
+	// Status is the terminal status it reached.
+	Status string
+}
+
+// CIFile commits CIYAML to the project's default branch and returns the
+// commit, so that a pipeline created next has a configuration to run.
+func CIFile(e *harness.Env, project Project) Commit {
+	e.T.Helper()
+	return CommitFile(e, project, project.DefaultBranch, CIFilePath, CIYAML, "ci: add the e2e pipeline configuration")
+}
+
+// The pipeline wait's bounds: generous, because an ephemeral runner in a
+// container pulls its image on the first job, and tolerant of a run of API
+// errors, because a GitLab under load answers some polls with nothing.
+const (
+	pipelineWait                 = 15 * time.Minute
+	pipelineMaxConsecutiveErrors = 10
+)
+
+// pipelinePollInterval is how often the wait asks; a variable so the
+// package's own tests can ask faster than a real runner answers.
+var pipelinePollInterval = 5 * time.Second
+
+// NewPipeline creates a pipeline on ref and waits until it reaches a
+// terminal status, failing the test if it does not within the budget. The
+// test is skipped when no runner is registered.
+//
+// The pipeline goes with the project, so nothing is registered.
+func NewPipeline(e *harness.Env, project Project, ref string) Pipeline {
+	e.T.Helper()
+	requireRunner(e)
+
+	pipeline, err := retryTransient(e, "create pipeline", createRetries, func() (Pipeline, error) {
+		created, _, err := e.Client().GL().Pipelines.CreatePipeline(project.ID, &gl.CreatePipelineOptions{Ref: new(ref)}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Pipeline{}, err
+		}
+		return Pipeline{ID: created.ID, Ref: created.Ref, SHA: created.SHA, Status: created.Status}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating a pipeline on %q in project %d: %v", ref, project.ID, err)
+	}
+
+	pipeline.Status = WaitForPipeline(e, project, pipeline.ID, pipelineWait)
+	return pipeline
+}
+
+// WaitForPipeline drains Sidekiq and polls the pipeline until it reaches a
+// terminal status, returning that status. It fails the test when the budget
+// runs out, naming the last status it saw, and when ten polls in a row
+// failed. A zero timeout takes the default budget.
+func WaitForPipeline(e *harness.Env, project Project, pipelineID int64, timeout time.Duration) string {
+	e.T.Helper()
+
+	if timeout <= 0 {
+		timeout = pipelineWait
+	}
+	DrainSidekiq(e.Ctx, e.Client())
+	status, err := waitForPipelineStatus(e.Ctx, e.Client(), project.ID, pipelineID, timeout)
+	if err != nil {
+		e.T.Fatalf("pipeline %d in project %d did not reach a terminal status within %s (last status: %s): %v",
+			pipelineID, project.ID, timeout, status, err)
+	}
+	e.T.Logf("pipeline %d in project %d reached terminal status %s", pipelineID, project.ID, status)
+	return status
+}
+
+// waitForPipelineStatus polls until the pipeline's status is terminal,
+// returning the last status seen beside any error.
+func waitForPipelineStatus(ctx context.Context, client *gitlabclient.Client, projectID, pipelineID int64, timeout time.Duration) (string, error) {
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	lastStatus := "unknown"
+	consecutiveErrors := 0
+	err := harness.Poll(pollCtx, pipelinePollInterval, timeout, func() (bool, string, error) {
+		pipeline, _, err := client.GL().Pipelines.GetPipeline(projectID, pipelineID, gl.WithContext(pollCtx))
+		if err != nil {
+			consecutiveErrors++
+			state := fmt.Sprintf("pipeline %d in project %d: last_status=%s consecutive_errors=%d/%d error=%v",
+				pipelineID, projectID, lastStatus, consecutiveErrors, pipelineMaxConsecutiveErrors, err)
+			if consecutiveErrors >= pipelineMaxConsecutiveErrors {
+				return false, state, fmt.Errorf("reading pipeline %d of project %d failed %d times in a row: %w",
+					pipelineID, projectID, consecutiveErrors, err)
+			}
+			return false, state, nil
+		}
+		consecutiveErrors = 0
+		lastStatus = pipeline.Status
+		return IsTerminalPipelineStatus(lastStatus), fmt.Sprintf("pipeline %d in project %d: status=%s", pipelineID, projectID, lastStatus), nil
+	})
+	return lastStatus, err
+}
+
+// IsTerminalPipelineStatus reports whether status is one a pipeline never
+// leaves.
+func IsTerminalPipelineStatus(status string) bool {
+	switch status {
+	case "success", "failed", "canceled", "skipped":
+		return true
+	default:
+		return false
+	}
+}
+
+// requireRunner skips a test whose fixture needs a runner the run does not
+// have.
+func requireRunner(e *harness.Env) {
+	e.T.Helper()
+	if !e.HasRunner() {
+		e.Skipf("a pipeline fixture needs a CI runner, and none is registered; declare harness.Needs(harness.NeedRunner)")
+	}
+}
+
+// DockerRunnerDescription is the description register-runner.sh gives the
+// runner the Docker stack registers, which is how a test finds it.
+const DockerRunnerDescription = "e2e-docker-runner"
+
+// runnerPageSize is how many runners one listing page carries.
+const runnerPageSize = 100
+
+// DockerRunnerID returns the ID of the instance runner the Docker stack
+// registered, failing the test when it is not there. The runner actions need
+// an ID and nothing else on the instance is a safe target for them.
+func DockerRunnerID(e *harness.Env) int64 {
+	e.T.Helper()
+
+	id, count, err := findRunner(e.Ctx, e.Client(), DockerRunnerDescription)
+	if err != nil {
+		e.T.Fatalf("listing the instance runners: %v", err)
+	}
+	if id == 0 {
+		e.T.Fatalf("no instance runner is described %q; %d runner(s) listed", DockerRunnerDescription, count)
+	}
+	return id
+}
+
+// findRunner lists every instance runner and returns the ID of the one with
+// the given description, or zero, beside how many it looked at.
+func findRunner(ctx context.Context, client *gitlabclient.Client, description string) (id int64, seen int, err error) {
+	var page int64 = 1
+	for page != 0 {
+		opts := &gl.ListRunnersOptions{Type: new("instance_type")}
+		opts.Page = page
+		opts.PerPage = runnerPageSize
+		runners, resp, listErr := client.GL().Runners.ListAllRunners(opts, gl.WithContext(ctx))
+		if listErr != nil {
+			return 0, seen, listErr
+		}
+		for _, runner := range runners {
+			seen++
+			if runner.Description == description {
+				return runner.ID, seen, nil
+			}
+		}
+		page = resp.NextPage
+	}
+	return 0, seen, nil
+}

--- a/test/e2e/internal/fixture/pipeline_test.go
+++ b/test/e2e/internal/fixture/pipeline_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+
+// pipeline_test.go drives the pipeline wait and the runner lookup against
+// the stub.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// shortPipelinePolls makes the pipeline wait poll quickly for one test; the
+// production interval is sized for a real runner.
+func shortPipelinePolls(t *testing.T) {
+	t.Helper()
+	saved := pipelinePollInterval
+	pipelinePollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pipelinePollInterval = saved })
+}
+
+// TestWaitForPipelineStatus_Running_ReturnsTheTerminalStatus checks that the
+// wait polls through a running pipeline to its terminal status and tolerates
+// a burst of API errors on the way.
+func TestWaitForPipelineStatus_Running_ReturnsTheTerminalStatus(t *testing.T) {
+	shortPipelinePolls(t)
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.pipelineFailures = 2
+		stub.pipelineStatuses = []string{"pending", "running", "success"}
+	})
+
+	status, err := waitForPipelineStatus(context.Background(), client, 1, 10, 30*time.Second)
+	if err != nil {
+		t.Fatalf("waitForPipelineStatus() error = %v, want nil", err)
+	}
+	if status != "success" {
+		t.Errorf("status = %q, want success", status)
+	}
+}
+
+// TestWaitForPipelineStatus_NeverTerminal_FailsWithTheLastStatus checks the
+// budget is enforced and the last status is named, which is the property the
+// EE wait it replaces lacked.
+func TestWaitForPipelineStatus_NeverTerminal_FailsWithTheLastStatus(t *testing.T) {
+	shortPipelinePolls(t)
+	stub, client := newStubGitLab(t)
+	stub.configure(func() { stub.pipelineStatuses = []string{"pending"} })
+
+	status, err := waitForPipelineStatus(context.Background(), client, 1, 10, 200*time.Millisecond)
+	if !errors.Is(err, harness.ErrPollTimeout) {
+		t.Fatalf("waitForPipelineStatus() error = %v, want a poll timeout", err)
+	}
+	if status != "pending" {
+		t.Errorf("status = %q, want the last one seen", status)
+	}
+}
+
+// TestWaitForPipelineStatus_ErrorsInARow_GivesUpAfterTen checks that a
+// GitLab that stops answering ends the wait with the error rather than with
+// the budget, naming how many polls failed.
+func TestWaitForPipelineStatus_ErrorsInARow_GivesUpAfterTen(t *testing.T) {
+	shortPipelinePolls(t)
+	stub, client := newStubGitLab(t)
+	stub.configure(func() { stub.pipelineFailures = pipelineMaxConsecutiveErrors + 5 })
+
+	status, err := waitForPipelineStatus(context.Background(), client, 1, 10, 30*time.Second)
+	if err == nil || errors.Is(err, harness.ErrPollTimeout) {
+		t.Fatalf("waitForPipelineStatus() error = %v, want the API error after ten failures", err)
+	}
+	if status != "unknown" {
+		t.Errorf("status = %q, want unknown when no poll ever answered", status)
+	}
+	var left int
+	stub.configure(func() { left = stub.pipelineFailures })
+	if left != 5 {
+		t.Errorf("polls made = %d, want exactly %d", pipelineMaxConsecutiveErrors+5-left, pipelineMaxConsecutiveErrors)
+	}
+}
+
+// TestIsTerminalPipelineStatus_Values_NamesTheFour pins the set a pipeline
+// never leaves.
+func TestIsTerminalPipelineStatus_Values_NamesTheFour(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{status: "success", want: true},
+		{status: "failed", want: true},
+		{status: "canceled", want: true},
+		{status: "skipped", want: true},
+		{status: "pending", want: false},
+		{status: "running", want: false},
+		{status: "created", want: false},
+		{status: "", want: false},
+	}
+	for _, testCase := range cases {
+		t.Run("status "+testCase.status, func(t *testing.T) {
+			if got := IsTerminalPipelineStatus(testCase.status); got != testCase.want {
+				t.Errorf("IsTerminalPipelineStatus(%q) = %t, want %t", testCase.status, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestFindRunner_Description_ReturnsTheDockerRunner checks the lookup that
+// replaces the two copies of findDockerRunnerID: the runner is found by the
+// description register-runner.sh gives it, and its absence is reported with
+// the count that was looked at.
+func TestFindRunner_Description_ReturnsTheDockerRunner(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.runners = []*gl.Runner{
+			{ID: 11, Description: "somebody-else"},
+			{ID: 12, Description: DockerRunnerDescription},
+		}
+	})
+
+	id, seen, err := findRunner(context.Background(), client, DockerRunnerDescription)
+	if err != nil {
+		t.Fatalf("findRunner() error = %v, want nil", err)
+	}
+	if id != 12 || seen != 2 {
+		t.Errorf("findRunner() = (%d, %d), want (12, 2)", id, seen)
+	}
+
+	id, seen, err = findRunner(context.Background(), client, "not-registered")
+	if err != nil || id != 0 || seen != 2 {
+		t.Errorf("findRunner(absent) = (%d, %d, %v), want (0, 2, nil)", id, seen, err)
+	}
+}
+
+// TestCIYAML_Shape_RunsOnAnyRunner pins the two properties the pipeline
+// fixture relies on: one stage with one job, and no runner tags, so it is
+// picked up by whatever runner the instance has.
+func TestCIYAML_Shape_RunsOnAnyRunner(t *testing.T) {
+	want := "stages:\n  - test\n\nfast-pass:\n  stage: test\n  script:\n    - echo \"e2e pipeline job\"\n  tags: []\n"
+	if CIYAML != want {
+		t.Errorf("CIYAML = %q, want %q", CIYAML, want)
+	}
+	if CIFilePath != ".gitlab-ci.yml" {
+		t.Errorf("CIFilePath = %q, want .gitlab-ci.yml", CIFilePath)
+	}
+}

--- a/test/e2e/internal/fixture/project.go
+++ b/test/e2e/internal/fixture/project.go
@@ -1,0 +1,375 @@
+//go:build e2e
+
+// project.go builds the project most tests start from, and knows how to make
+// one disappear for good.
+//
+// Deleting is the harder half. GitLab keeps a deleted project around for a
+// retention period and renames its path while it waits, so a test that
+// deleted its project and a sweep that found it later have to do the same
+// two-step dance: mark, re-read the path GitLab gave it, then remove it
+// permanently under that path. The dance lives here once and every deletion
+// in the package goes through it.
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// DefaultBranch is the branch every project this package creates is
+// initialized with. It is spelled once so that a test naming a ref and a
+// builder creating one agree.
+const DefaultBranch = "main"
+
+// Project is a project a builder created, as a test refers to it.
+type Project struct {
+	// ID is the numeric identifier every project-scoped action takes.
+	ID int64
+	// Path is the full path with its namespace, such as e2e-user/name.
+	Path string
+	// Name is the project's display name.
+	Name string
+	// DefaultBranch is the branch the repository was initialized with.
+	DefaultBranch string
+	// HTTPURLToRepo is the clone URL GitLab published for it, which is what
+	// a mirror needs when no internal address is configured.
+	HTTPURLToRepo string
+	// NamespaceID is the namespace it was created in: the group's when a
+	// group was named, the user's otherwise.
+	NamespaceID int64
+}
+
+// projectSpec is what a builder asks GitLab for.
+type projectSpec struct {
+	name        string
+	description string
+	visibility  gl.VisibilityValue
+	readme      bool
+	namespaceID int64
+}
+
+// ProjectOption adjusts one project builder.
+type ProjectOption func(*projectSpec)
+
+// InGroup creates the project under the given group rather than under the
+// authenticated user's own namespace. Iterations, epics and group-level
+// policies need a project with a group parent.
+func InGroup(group Group) ProjectOption {
+	return func(spec *projectSpec) { spec.namespaceID = group.ID }
+}
+
+// WithVisibility sets the project's visibility. Private is the default,
+// because a public project on a shared instance is visible to everyone else
+// running tests there.
+func WithVisibility(visibility gl.VisibilityValue) ProjectOption {
+	return func(spec *projectSpec) { spec.visibility = visibility }
+}
+
+// WithoutReadme creates an empty repository with no default branch. A test of
+// the very first commit, or of an import into an empty project, needs one.
+func WithoutReadme() ProjectOption {
+	return func(spec *projectSpec) { spec.readme = false }
+}
+
+// WithNamePrefix changes the prefix the project's generated name opens with.
+// The run ID and the test's own name follow it either way.
+func WithNamePrefix(prefix string) ProjectOption {
+	return func(spec *projectSpec) { spec.name = prefix }
+}
+
+// NewProject creates a private project initialized with a README on
+// DefaultBranch, waits until that branch is readable, and registers its
+// permanent deletion on the Env.
+//
+// The name carries the run ID and the test's name, so a sweep can tell whose
+// it is; the creation is retried on the failures CreateRetryable names.
+func NewProject(e *harness.Env, opts ...ProjectOption) Project {
+	e.T.Helper()
+	armSweep(e)
+
+	spec := projectSpec{name: "proj", description: "e2e: " + e.T.Name(), visibility: gl.PrivateVisibility, readme: true}
+	for _, opt := range opts {
+		opt(&spec)
+	}
+
+	project, err := createProject(e, spec, func() string { return e.Name(spec.name) })
+	if err != nil {
+		e.T.Fatalf("creating the project fixture: %v", err)
+	}
+	e.Defer("project "+project.Path, func(ctx context.Context) error {
+		return DeleteProject(ctx, e.Client(), project.ID, project.Path)
+	})
+
+	if spec.readme {
+		waitForDefaultBranch(e, project)
+	}
+	return project
+}
+
+// createProject asks GitLab for a project under a fresh name on every
+// attempt, since a name refused as taken must not be offered again.
+func createProject(e *harness.Env, spec projectSpec, nextName func() string) (Project, error) {
+	e.T.Helper()
+
+	enterprise := e.Runtime().Tier.IsEnterprise()
+	return retryWhen(e, "create project", createRetries,
+		func(err error) bool { return CreateRetryable(err, enterprise) },
+		func() (Project, error) {
+			name := nextName()
+			opts := &gl.CreateProjectOptions{
+				Name:                 new(name),
+				Description:          new(spec.description),
+				Visibility:           new(spec.visibility),
+				InitializeWithReadme: new(spec.readme),
+			}
+			if spec.readme {
+				opts.DefaultBranch = new(DefaultBranch)
+			}
+			if spec.namespaceID != 0 {
+				opts.NamespaceID = new(spec.namespaceID)
+			}
+			created, _, err := e.Client().GL().Projects.CreateProject(opts, gl.WithContext(e.Ctx))
+			if err != nil {
+				return Project{}, err
+			}
+			return projectOf(created), nil
+		})
+}
+
+// projectOf reads what a test needs out of what GitLab returned.
+func projectOf(p *gl.Project) Project {
+	project := Project{
+		ID:            p.ID,
+		Path:          p.PathWithNamespace,
+		Name:          p.Name,
+		DefaultBranch: p.DefaultBranch,
+		HTTPURLToRepo: p.HTTPURLToRepo,
+	}
+	if p.Namespace != nil {
+		project.NamespaceID = p.Namespace.ID
+	}
+	return project
+}
+
+// waitForDefaultBranch holds the test until the project's default branch is
+// readable, failing it when the branch never appears.
+//
+// GitLab initializes the README in a background job, so the project exists
+// before its branch does. Under parallel load (around sixty projects at once)
+// that job can take well over thirty seconds, so the budget is long and the
+// Sidekiq queue is drained first, since the branch cannot appear before the
+// job that writes it has run.
+func waitForDefaultBranch(e *harness.Env, project Project) {
+	e.T.Helper()
+
+	DrainSidekiq(e.Ctx, e.Client())
+	if err := waitForBranch(e.Ctx, e.Client(), project.ID, project.DefaultBranch, budget(e, branchWait, enterpriseBranchWait)); err != nil {
+		e.T.Fatalf("waiting for branch %q of project %d: %v", project.DefaultBranch, project.ID, err)
+	}
+}
+
+// The waits a branch may take to become readable.
+const (
+	branchWait           = 90 * time.Second
+	enterpriseBranchWait = 240 * time.Second
+	branchPollInterval   = 500 * time.Millisecond
+)
+
+// waitForBranch polls until the branch is readable or the budget is spent. A
+// 404, a 429 and every 5xx keep it polling, because each is what GitLab
+// answers while it converges; any other answer is a failure of its own.
+func waitForBranch(ctx context.Context, client *gitlabclient.Client, projectID int64, branch string, wait time.Duration) error {
+	pollCtx, cancel := context.WithTimeout(ctx, wait)
+	defer cancel()
+
+	return harness.Poll(pollCtx, branchPollInterval, wait, func() (bool, string, error) {
+		_, resp, err := client.GL().Branches.GetBranch(projectID, branch, gl.WithContext(pollCtx))
+		if err == nil {
+			return true, fmt.Sprintf("branch %q readable in project %d", branch, projectID), nil
+		}
+		state := fmt.Sprintf("branch %q in project %d: %v", branch, projectID, err)
+		if resp != nil {
+			state = fmt.Sprintf("branch %q in project %d: HTTP %d", branch, projectID, resp.StatusCode)
+		}
+		if resp == nil && !IsTransientNetwork(err) {
+			return false, state, fmt.Errorf("reading branch %q of project %d: %w", branch, projectID, err)
+		}
+		if resp != nil && !convergingStatus(resp.StatusCode) {
+			return false, state, fmt.Errorf("reading branch %q of project %d: %w", branch, projectID, err)
+		}
+		return false, state, nil
+	})
+}
+
+// convergingStatus reports whether an HTTP status is one GitLab answers while
+// an object it has just been told about is still being written.
+func convergingStatus(status int) bool {
+	return status == http.StatusNotFound || status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
+}
+
+// DeleteProject removes a project permanently, whatever state it is in.
+//
+// It is two steps because GitLab CE with delayed deletion refuses a permanent
+// removal of a project that is not yet marked for deletion, and renames the
+// path of one that is (appending -deletion_scheduled-<ID>), so the second
+// request has to name the path the first one produced. A project already
+// marked, or already gone, is not an error: the point is that it ends up
+// gone.
+//
+//nolint:dupl // DeleteGroup is this step for step on a service of its own, and the shared part is deletePermanently
+func DeleteProject(ctx context.Context, client *gitlabclient.Client, projectID int64, path string) error {
+	projects := client.GL().Projects
+	return deletePermanently(ctx, "project", projectID, path, deletionSteps{
+		mark: func(ctx context.Context) error {
+			_, err := projects.DeleteProject(projectID, nil, gl.WithContext(ctx))
+			return err
+		},
+		currentPath: func(ctx context.Context) (string, error) {
+			current, _, err := projects.GetProject(projectID, nil, gl.WithContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			return current.PathWithNamespace, nil
+		},
+		remove: func(ctx context.Context, path string) error {
+			_, err := projects.DeleteProject(projectID, &gl.DeleteProjectOptions{
+				PermanentlyRemove: new(true),
+				FullPath:          new(path),
+			}, gl.WithContext(ctx))
+			return err
+		},
+	})
+}
+
+// deletionSteps are the three requests a permanent deletion is made of, for
+// the one function that orders them.
+type deletionSteps struct {
+	// mark is the plain DELETE, which marks the object on an instance with
+	// delayed deletion and removes it on one without.
+	mark func(ctx context.Context) error
+	// currentPath re-reads the object, whose path GitLab renamed when it
+	// marked it.
+	currentPath func(ctx context.Context) (string, error)
+	// remove is the permanent DELETE under the path currentPath found.
+	remove func(ctx context.Context, path string) error
+}
+
+// deletePermanently is the two-step dance both projects and groups go
+// through, written once: mark, tolerating an object already marked; re-read
+// the path; remove permanently under it. An object that is gone at any step
+// is a success, because gone is what was asked for.
+func deletePermanently(ctx context.Context, kind string, id int64, path string, steps deletionSteps) error {
+	ctx, cancel := withCleanupTimeout(ctx)
+	defer cancel()
+
+	if err := steps.mark(ctx); err != nil {
+		if IsStatus(err, http.StatusNotFound) {
+			return nil
+		}
+		if !toolutil.ContainsAny(err, "already being deleted", "marked for deletion") {
+			return fmt.Errorf("marking %s %d (%s) for deletion: %w", kind, id, path, err)
+		}
+	}
+
+	current, err := steps.currentPath(ctx)
+	switch {
+	case err == nil:
+		path = current
+	case IsStatus(err, http.StatusNotFound):
+		return nil
+	}
+
+	if removeErr := steps.remove(ctx, path); removeErr != nil && !IsStatus(removeErr, http.StatusNotFound) {
+		return fmt.Errorf("permanently deleting %s %d (%s): %w", kind, id, path, removeErr)
+	}
+	return nil
+}
+
+// UnprotectBranch removes the protection rule from a branch and waits until
+// it is really gone, so the commits a test pushes next are not refused.
+//
+// The one-shot form of this was racy: under Docker load the unprotect call
+// returned without error while the rule was still observable afterwards,
+// because the change propagates through a background job, and the next
+// commit failed with 403 "You are not allowed to push into this branch". So
+// the call is made (it is idempotent), the Sidekiq queue is drained, and the
+// rule is polled until GitLab answers 404 for it. A rule that never goes away
+// is logged rather than failed, so the test's own assertion produces the
+// message that names what it was trying to do.
+func UnprotectBranch(e *harness.Env, project Project, branch string) {
+	e.T.Helper()
+
+	client := e.Client()
+	if _, err := client.GL().ProtectedBranches.UnprotectRepositoryBranches(project.ID, branch, gl.WithContext(e.Ctx)); err != nil {
+		e.T.Logf("unprotecting %q (idempotent, may already be unprotected): %v", branch, err)
+	}
+	DrainSidekiq(e.Ctx, client)
+
+	wait := budget(e, unprotectWait, enterpriseUnprotectWait)
+	pollCtx, cancel := context.WithTimeout(e.Ctx, wait)
+	defer cancel()
+
+	err := harness.Poll(pollCtx, branchPollInterval, wait, func() (bool, string, error) {
+		_, resp, getErr := client.GL().ProtectedBranches.GetProtectedBranch(project.ID, branch, gl.WithContext(pollCtx))
+		if getErr == nil {
+			return false, fmt.Sprintf("branch %q still protected in project %d", branch, project.ID), nil
+		}
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return true, fmt.Sprintf("branch %q unprotected in project %d", branch, project.ID), nil
+		}
+		if resp == nil || resp.StatusCode >= http.StatusInternalServerError {
+			return false, fmt.Sprintf("reading the protection of %q in project %d: %v", branch, project.ID, getErr), nil
+		}
+		return false, fmt.Sprintf("reading the protection of %q in project %d: HTTP %d", branch, project.ID, resp.StatusCode),
+			fmt.Errorf("reading the protection of %q: %w", branch, getErr)
+	})
+	if err != nil {
+		e.T.Logf("unprotecting %q did not converge within %s (not fatal): %v", branch, wait, err)
+	}
+}
+
+// The waits a branch protection rule may take to disappear.
+const (
+	unprotectWait           = 30 * time.Second
+	enterpriseUnprotectWait = 60 * time.Second
+)
+
+// The Sidekiq drain's bounds.
+const (
+	sidekiqDrainWait     = 15 * time.Second
+	sidekiqDrainInterval = 250 * time.Millisecond
+)
+
+// DrainSidekiq waits until GitLab's background job queues are empty, or
+// fifteen seconds have passed, or the context ends.
+//
+// Most of what a test waits for afterwards (a branch, a merge check, a
+// pipeline, a search index) is written by one of those jobs, so an empty
+// queue is the cheapest possible readiness signal and the wait is shorter for
+// it. It is best effort: the metrics API needs an administrator, and a token
+// that cannot read it simply returns at once.
+func DrainSidekiq(ctx context.Context, client *gitlabclient.Client) {
+	deadline := time.Now().Add(sidekiqDrainWait)
+	for time.Now().Before(deadline) {
+		stats, _, err := client.GL().Sidekiq.GetJobStats(gl.WithContext(ctx))
+		if err != nil || stats == nil || stats.Jobs.Enqueued == 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(sidekiqDrainInterval):
+		}
+	}
+	log.Printf("e2e: Sidekiq still had jobs enqueued after %s; continuing", sidekiqDrainWait)
+}

--- a/test/e2e/internal/fixture/project_test.go
+++ b/test/e2e/internal/fixture/project_test.go
@@ -1,0 +1,174 @@
+//go:build e2e
+
+// project_test.go drives the project's pure halves against the stub: the
+// two-step permanent delete, the branch readiness wait and the Sidekiq
+// drain.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestDeleteProject_Unmarked_MarksThenRemovesUnderTheRenamedPath checks the
+// dance a delayed-deletion instance demands: mark, re-read the renamed path,
+// remove permanently under it.
+func TestDeleteProject_Unmarked_MarksThenRemovesUnderTheRenamedPath(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addProject(7, "e2e-proj", "user/e2e-proj")
+
+	if err := DeleteProject(context.Background(), client, 7, "user/e2e-proj"); err != nil {
+		t.Fatalf("DeleteProject() error = %v, want nil", err)
+	}
+
+	want := []string{
+		"project 7 ",
+		"project 7 full_path=user%2Fe2e-proj-deletion_scheduled-7&permanently_remove=true",
+	}
+	if got := stub.recordedDeletes(); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("deletes = %q, want %q", got, want)
+	}
+	if projects, _ := stub.remaining(); len(projects) != 0 {
+		t.Errorf("projects left = %v, want none", projects)
+	}
+}
+
+// TestDeleteProject_AlreadyMarked_StillRemovesIt checks that a project a
+// test already marked (its own delete scenario, say) is removed rather than
+// refused on the first step's "already marked" answer.
+func TestDeleteProject_AlreadyMarked_StillRemovesIt(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addProject(8, "e2e-marked", "user/e2e-marked")
+	if _, err := client.GL().Projects.DeleteProject(int64(8), nil); err != nil {
+		t.Fatalf("marking through the client: %v", err)
+	}
+
+	if err := DeleteProject(context.Background(), client, 8, "user/e2e-marked"); err != nil {
+		t.Fatalf("DeleteProject() error = %v, want nil", err)
+	}
+	if projects, _ := stub.remaining(); len(projects) != 0 {
+		t.Errorf("projects left = %v, want none", projects)
+	}
+}
+
+// TestDeleteProject_Gone_IsNotAnError checks that a project nothing can find
+// counts as deleted, which is what a test that deleted its own fixture leaves
+// for the ledger.
+func TestDeleteProject_Gone_IsNotAnError(t *testing.T) {
+	stub, client := newStubGitLab(t)
+
+	if err := DeleteProject(context.Background(), client, 9, "user/never"); err != nil {
+		t.Fatalf("DeleteProject() error = %v, want nil for a project that is gone", err)
+	}
+	if got := stub.recordedDeletes(); len(got) != 1 {
+		t.Errorf("deletes = %q, want only the first step", got)
+	}
+}
+
+// TestWaitForBranch_NotVisibleYet_KeepsPollingUntilItIs checks that the
+// 404 a branch answers while GitLab writes it is waited through.
+func TestWaitForBranch_NotVisibleYet_KeepsPollingUntilItIs(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addProject(1, "p", "user/p")
+	stub.configure(func() { stub.branchMisses = 2 })
+
+	if err := waitForBranch(context.Background(), client, 1, "main", 5*time.Second); err != nil {
+		t.Fatalf("waitForBranch() error = %v, want nil once the branch appears", err)
+	}
+}
+
+// TestWaitForBranch_NeverVisible_ReportsTheTimeoutWithTheLastState checks
+// the failure names what was last seen, since "timed out" alone is nothing a
+// reader can act on.
+func TestWaitForBranch_NeverVisible_ReportsTheTimeoutWithTheLastState(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addProject(1, "p", "user/p")
+	stub.configure(func() { stub.branchMisses = 1 << 20 })
+
+	err := waitForBranch(context.Background(), client, 1, "main", 300*time.Millisecond)
+	if !errors.Is(err, harness.ErrPollTimeout) {
+		t.Fatalf("waitForBranch() error = %v, want a poll timeout", err)
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("timeout error = %q, want it to carry the last HTTP status seen", err)
+	}
+}
+
+// TestConvergingStatus_Codes_NamesWhatIsWaitedThrough pins which answers a
+// readiness wait polls through and which end it.
+func TestConvergingStatus_Codes_NamesWhatIsWaitedThrough(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		want   bool
+	}{
+		{name: "not found", status: http.StatusNotFound, want: true},
+		{name: "rate limited", status: http.StatusTooManyRequests, want: true},
+		{name: "server error", status: http.StatusBadGateway, want: true},
+		{name: "forbidden", status: http.StatusForbidden, want: false},
+		{name: "ok", status: http.StatusOK, want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := convergingStatus(testCase.status); got != testCase.want {
+				t.Errorf("convergingStatus(%d) = %t, want %t", testCase.status, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestDrainSidekiq_Queue_ReturnsOnceEmpty checks that the drain reads the
+// stats until nothing is enqueued and then stops asking.
+func TestDrainSidekiq_Queue_ReturnsOnceEmpty(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() { stub.enqueued = 3 })
+
+	start := time.Now()
+	DrainSidekiq(context.Background(), client)
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("DrainSidekiq took %s, want a few polls", elapsed)
+	}
+	var left int64
+	stub.configure(func() { left = stub.enqueued })
+	if left != 0 {
+		t.Errorf("enqueued after the drain = %d, want 0", left)
+	}
+}
+
+// TestDrainSidekiq_ContextEnded_ReturnsAtOnce checks that a drain does not
+// outlive the test that asked for it.
+func TestDrainSidekiq_ContextEnded_ReturnsAtOnce(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() { stub.enqueued = 1 << 20 })
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	DrainSidekiq(ctx, client)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("DrainSidekiq took %s with a cancelled context, want an immediate return", elapsed)
+	}
+}
+
+// TestProjectOf_Namespace_ReadsTheNamespaceID checks the one field that is
+// read through a pointer and would be silently zero if it were not.
+func TestProjectOf_Namespace_ReadsTheNamespaceID(t *testing.T) {
+	got := projectOf(&gl.Project{ID: 5, Name: "n", PathWithNamespace: "g/n", DefaultBranch: "main", HTTPURLToRepo: "http://x/g/n.git", Namespace: &gl.ProjectNamespace{ID: 42}})
+	want := Project{ID: 5, Path: "g/n", Name: "n", DefaultBranch: "main", HTTPURLToRepo: "http://x/g/n.git", NamespaceID: 42}
+	if got != want {
+		t.Errorf("projectOf() = %+v, want %+v", got, want)
+	}
+	if bare := projectOf(&gl.Project{ID: 6}); bare.NamespaceID != 0 {
+		t.Errorf("projectOf(no namespace).NamespaceID = %d, want 0", bare.NamespaceID)
+	}
+}

--- a/test/e2e/internal/fixture/repository.go
+++ b/test/e2e/internal/fixture/repository.go
@@ -1,0 +1,223 @@
+//go:build e2e
+
+// repository.go builds what lives inside a project's repository: branches,
+// commits, and the bytes a test needs to upload.
+//
+// A commit is the one write GitLab is slowest to admit it is ready for. A
+// branch the API has just created is not yet one the commits API will write
+// to, and the refusal it gives ("you can only create or edit files when you
+// are on a branch") is answered here by naming a start branch and trying
+// again, which is what the suite this replaces learned to do.
+
+package fixture
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/png"
+	"strings"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Branch is a branch a builder created.
+type Branch struct {
+	// Name is the branch name.
+	Name string
+	// SHA is the commit it pointed at when it was created.
+	SHA string
+}
+
+// Commit is a commit a builder made, with the file it wrote.
+type Commit struct {
+	// SHA is the full commit identifier.
+	SHA string
+	// ShortID is the abbreviated identifier GitLab shows.
+	ShortID string
+	// Branch is the branch it was made on.
+	Branch string
+	// FilePath is the file it wrote.
+	FilePath string
+}
+
+// NewBranch creates a branch from the project's default branch and registers
+// nothing: the branch goes with the project.
+func NewBranch(e *harness.Env, project Project, name string) Branch {
+	e.T.Helper()
+	return NewBranchFrom(e, project, name, project.DefaultBranch)
+}
+
+// NewBranchFrom creates a branch from ref, retrying while the ref it starts
+// from is still becoming visible.
+func NewBranchFrom(e *harness.Env, project Project, name, ref string) Branch {
+	e.T.Helper()
+
+	branch, err := retryTransient(e, "create branch "+name, createRetries, func() (Branch, error) {
+		created, _, err := e.Client().GL().Branches.CreateBranch(project.ID, &gl.CreateBranchOptions{
+			Branch: new(name),
+			Ref:    new(ref),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Branch{}, err
+		}
+		return branchOf(created), nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating branch %q from %q in project %d: %v", name, ref, project.ID, err)
+	}
+	return branch
+}
+
+// branchOf reads what a test needs out of what GitLab returned.
+func branchOf(b *gl.Branch) Branch {
+	branch := Branch{Name: b.Name}
+	if b.Commit != nil {
+		branch.SHA = b.Commit.ID
+	}
+	return branch
+}
+
+// CommitFile writes content to path on branch, creating the file or updating
+// it, and returns the commit. A file that already holds exactly that content
+// returns the commit that wrote it rather than an empty one.
+//
+// Create-or-update rather than create, because the same fixture is asked for
+// by more than one test against the World, and because GitLab refuses an
+// update that changes nothing ("has not been changed") just as it refuses a
+// create of a file that exists.
+func CommitFile(e *harness.Env, project Project, branch, path, content, message string) Commit {
+	e.T.Helper()
+
+	commit, err := commitAction(e, project, branch, path, content, message, gl.FileCreate)
+	if err == nil {
+		return commit
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "already exists") {
+		e.T.Fatalf("committing %s on %q in project %d: %v", path, branch, project.ID, err)
+	}
+
+	existing, existingContent, err := readFile(e, project, branch, path)
+	if err != nil {
+		e.T.Fatalf("reading the existing %s on %q in project %d: %v", path, branch, project.ID, err)
+	}
+	if existingContent == content {
+		return existing
+	}
+
+	commit, err = commitAction(e, project, branch, path, content, message, gl.FileUpdate)
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "not been changed") {
+		return existing
+	}
+	if err != nil {
+		e.T.Fatalf("updating %s on %q in project %d: %v", path, branch, project.ID, err)
+	}
+	return commit
+}
+
+// commitAction makes one commit carrying one file action, retrying the two
+// answers GitLab gives while a branch is still settling.
+//
+// The first, "only create or edit files when you are on a branch", means the
+// commits API cannot see the branch yet; naming the default branch as the
+// start branch gets the commit accepted, and is dropped again on the next
+// attempt if GitLab then answers that the branch "already exists", which is
+// its way of saying the start branch is no longer needed.
+func commitAction(e *harness.Env, project Project, branch, path, content, message string, action gl.FileActionValue) (Commit, error) {
+	e.T.Helper()
+
+	needStartBranch := false
+	return harness.Retry(e.Ctx, e.T, "commit "+path, commitRetries, retryBaseDelay, func(int) (Commit, bool, string, error) {
+		opts := &gl.CreateCommitOptions{
+			Branch:        new(branch),
+			CommitMessage: new(message),
+			Actions: []*gl.CommitActionOptions{
+				{Action: new(action), FilePath: new(path), Content: new(content)},
+			},
+		}
+		if needStartBranch && branch != project.DefaultBranch {
+			opts.StartBranch = new(project.DefaultBranch)
+		}
+		created, _, err := e.Client().GL().Commits.CreateCommit(project.ID, opts, gl.WithContext(e.Ctx))
+		if err == nil {
+			return Commit{SHA: created.ID, ShortID: created.ShortID, Branch: branch, FilePath: path}, false, "", nil
+		}
+		return Commit{}, commitRetryable(err, &needStartBranch), commitRetryReason(err, needStartBranch), err
+	})
+}
+
+// commitRetryable classifies a commit failure and flips the start-branch
+// switch the next attempt reads.
+func commitRetryable(err error, needStartBranch *bool) bool {
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "only create or edit files when you are on a branch"):
+		*needStartBranch = true
+		return true
+	case *needStartBranch && strings.Contains(message, "already exists"):
+		*needStartBranch = false
+		return true
+	default:
+		return IsTransientNetwork(err)
+	}
+}
+
+// commitRetryReason names a retried commit failure for the log.
+func commitRetryReason(err error, needStartBranch bool) string {
+	switch {
+	case strings.Contains(err.Error(), "only create or edit files when you are on a branch"):
+		return "branch not ready, naming a start branch"
+	case needStartBranch:
+		return "branch exists now, dropping the start branch"
+	default:
+		return "transient network error"
+	}
+}
+
+// readFile returns the commit that last wrote path on branch and the file's
+// decoded content.
+func readFile(e *harness.Env, project Project, branch, path string) (Commit, string, error) {
+	e.T.Helper()
+
+	file, _, err := e.Client().GL().RepositoryFiles.GetFile(project.ID, path, &gl.GetFileOptions{Ref: new(branch)}, gl.WithContext(e.Ctx))
+	if err != nil {
+		return Commit{}, "", err
+	}
+	content, err := base64.StdEncoding.DecodeString(file.Content)
+	if err != nil {
+		return Commit{}, "", fmt.Errorf("decoding %s: %w", path, err)
+	}
+	return Commit{SHA: file.LastCommitID, ShortID: ShortSHA(file.LastCommitID), Branch: branch, FilePath: path}, string(content), nil
+}
+
+// ShortSHA abbreviates a commit identifier the way GitLab's short_id does.
+func ShortSHA(sha string) string {
+	if len(sha) <= 8 {
+		return sha
+	}
+	return sha[:8]
+}
+
+// PNG returns a freshly encoded 1x1 PNG, for an avatar or an upload, so no
+// binary fixture has to live on disk.
+func PNG() ([]byte, error) {
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 1, 1))); err != nil {
+		return nil, fmt.Errorf("encoding a 1x1 png: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// PNGBase64 is PNG encoded for a content_base64 input, failing the test if
+// the encoder ever refuses a 1x1 image.
+func PNGBase64(e *harness.Env) string {
+	e.T.Helper()
+	data, err := PNG()
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	return base64.StdEncoding.EncodeToString(data)
+}

--- a/test/e2e/internal/fixture/repository_test.go
+++ b/test/e2e/internal/fixture/repository_test.go
@@ -1,0 +1,109 @@
+//go:build e2e
+
+// repository_test.go pins the commit retry rules and the content helpers.
+
+package fixture
+
+import (
+	"bytes"
+	"errors"
+	"image/png"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+)
+
+// TestCommitRetryable_BranchNotReady_NamesAStartBranchThenDropsIt walks the
+// two-step dance a commit on a fresh branch goes through: the first refusal
+// turns the start branch on, the "already exists" that follows turns it off,
+// and a file that already exists with the start branch off is not retried at
+// all, since that is the create-or-update fallback's signal.
+func TestCommitRetryable_BranchNotReady_NamesAStartBranchThenDropsIt(t *testing.T) {
+	needStartBranch := false
+
+	if !commitRetryable(errors.New("you can only create or edit files when you are on a branch"), &needStartBranch) || !needStartBranch {
+		t.Fatalf("the branch-not-ready refusal should be retried with a start branch; need=%t", needStartBranch)
+	}
+	if !commitRetryable(errors.New("a branch with this name already exists"), &needStartBranch) || needStartBranch {
+		t.Fatalf("the branch-exists answer should be retried without the start branch; need=%t", needStartBranch)
+	}
+	if commitRetryable(errors.New("a file with this name already exists"), &needStartBranch) {
+		t.Fatal("a file that already exists is the fallback's signal, not a retry")
+	}
+	if !commitRetryable(errors.New("connection reset by peer"), &needStartBranch) {
+		t.Fatal("a transient network error is retried")
+	}
+	if commitRetryable(errors.New("403 Forbidden"), &needStartBranch) {
+		t.Fatal("a refusal is not retried")
+	}
+}
+
+// TestCommitRetryReason_ByClass_NamesTheStep checks the log line each retry
+// carries.
+func TestCommitRetryReason_ByClass_NamesTheStep(t *testing.T) {
+	cases := []struct {
+		name            string
+		err             error
+		needStartBranch bool
+		want            string
+	}{
+		{name: "not ready", err: errors.New("only create or edit files when you are on a branch"), want: "branch not ready, naming a start branch"},
+		{name: "exists with start branch", err: errors.New("already exists"), needStartBranch: true, want: "branch exists now, dropping the start branch"},
+		{name: "network", err: errors.New("EOF"), want: "transient network error"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := commitRetryReason(testCase.err, testCase.needStartBranch); got != testCase.want {
+				t.Errorf("commitRetryReason() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestShortSHA_Lengths_AbbreviatesLikeGitLab checks the eight-character
+// short id and that a short input is left alone.
+func TestShortSHA_Lengths_AbbreviatesLikeGitLab(t *testing.T) {
+	cases := []struct {
+		sha  string
+		want string
+	}{
+		{sha: "0123456789abcdef0123456789abcdef01234567", want: "01234567"},
+		{sha: "abc", want: "abc"},
+		{sha: "", want: ""},
+	}
+	for _, testCase := range cases {
+		t.Run("sha "+testCase.sha, func(t *testing.T) {
+			if got := ShortSHA(testCase.sha); got != testCase.want {
+				t.Errorf("ShortSHA(%q) = %q, want %q", testCase.sha, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestPNG_Encoded_DecodesAsAOneByOneImage checks the bytes are a PNG of the
+// promised size, since GitLab validates an avatar before storing it.
+func TestPNG_Encoded_DecodesAsAOneByOneImage(t *testing.T) {
+	data, err := PNG()
+	if err != nil {
+		t.Fatalf("PNG() error = %v", err)
+	}
+	decoded, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("the bytes do not decode as a PNG: %v", err)
+	}
+	if bounds := decoded.Bounds(); bounds.Dx() != 1 || bounds.Dy() != 1 {
+		t.Errorf("image is %dx%d, want 1x1", bounds.Dx(), bounds.Dy())
+	}
+}
+
+// TestBranchOf_Commit_ReadsTheSHAThroughThePointer checks the one field a
+// branch is read through a pointer for.
+func TestBranchOf_Commit_ReadsTheSHAThroughThePointer(t *testing.T) {
+	got := branchOf(&gl.Branch{Name: "feature", Commit: &gl.Commit{ID: "abc"}})
+	if got != (Branch{Name: "feature", SHA: "abc"}) {
+		t.Errorf("branchOf() = %+v, want feature at abc", got)
+	}
+	if bare := branchOf(&gl.Branch{Name: "bare"}); bare.SHA != "" {
+		t.Errorf("branchOf(no commit).SHA = %q, want empty", bare.SHA)
+	}
+}

--- a/test/e2e/internal/fixture/retry.go
+++ b/test/e2e/internal/fixture/retry.go
@@ -1,0 +1,199 @@
+//go:build e2e
+
+// retry.go decides which failures are worth a second attempt.
+//
+// A GitLab under the load of a parallel suite drops connections, answers 429
+// and 5xx, and reports state it has not finished writing yet. Every class
+// here was met by the suite this replaces, and each is named so that a retry
+// in the log says what it retried and a failure that is not retried says why
+// not. The classification is a plain function of the error so it can be
+// tested without a GitLab.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The retry budgets. Each is the number of attempts, not of retries.
+const (
+	// createRetries is how often a project or group creation is attempted.
+	// GitLab CE races itself when many projects are created concurrently:
+	// spurious "has already been taken" on a name nothing else holds, and
+	// transient connection resets while nginx and puma settle.
+	createRetries = 5
+	// commitRetries is how often a commit is attempted while a fresh branch
+	// is still becoming visible to the commits API.
+	commitRetries = 8
+	// retryBaseDelay is the delay after the first failed attempt; each later
+	// wait grows by one more of it.
+	retryBaseDelay = time.Second
+)
+
+// IsTransientNetwork reports whether err is the kind of connection failure a
+// GitLab under heavy parallel load produces when nginx or puma drops a
+// connection: EOF, a reset, a broken pipe, a refused connection. These are
+// retried everywhere, because nothing about the request was wrong.
+func IsTransientNetwork(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "EOF") ||
+		strings.Contains(message, "connection reset by peer") ||
+		strings.Contains(message, "broken pipe") ||
+		strings.Contains(message, "connection refused")
+}
+
+// IsRetryable reports whether err is likely transient and worth another
+// attempt: a network failure, a rate limit, a server error, or one of GitLab's
+// eventual-consistency answers about an object it has only just created.
+//
+// The status is read from the structured error client-go returns, never from
+// a bare number in the message: "404" appears inside project IDs, commit SHAs
+// and resource names, and matching it as text retried failures that were
+// never going to succeed.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if IsTransientNetwork(err) {
+		return true
+	}
+	switch {
+	case toolutil.IsHTTPStatus(err, http.StatusTooManyRequests),
+		toolutil.IsHTTPStatus(err, http.StatusInternalServerError),
+		toolutil.IsHTTPStatus(err, http.StatusBadGateway),
+		toolutil.IsHTTPStatus(err, http.StatusServiceUnavailable):
+		return true
+	// A newly created ref is not yet visible to the API that was told about
+	// it, which GitLab reports as a 404 for a few hundred milliseconds.
+	case toolutil.IsHTTPStatus(err, http.StatusNotFound):
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	// The commits API refuses to write to a branch it cannot see yet.
+	if strings.Contains(message, "only create or edit files when you are on a branch") {
+		return true
+	}
+	// GitLab's NotificationSetting row is created inside a read with
+	// find_or_initialize_by, so two concurrent readers both insert and the
+	// loser is refused with a uniqueness error on a request that only read.
+	return strings.Contains(message, "already exists in source")
+}
+
+// CreateRetryable reports whether a project or group creation failed for a
+// reason a second attempt can fix.
+//
+// "has already been taken" is the one that looks least like it: it is what
+// GitLab CE answers when two concurrent creations race inside its own
+// namespace validation, and the name it names is free. On a licensed instance
+// two more appear, both from the repository side: "Failed to create
+// repository" and an "Internal API error (502)" from Gitaly while the instance
+// is under load. They are retried only on an enterprise instance because that
+// is the only place they have been seen, and a Free instance answering them
+// would be saying something new.
+func CreateRetryable(err error, enterprise bool) bool {
+	if err == nil {
+		return false
+	}
+	if IsTransientNetwork(err) || strings.Contains(err.Error(), "already been taken") {
+		return true
+	}
+	if !enterprise {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "Failed to create repository") ||
+		strings.Contains(message, "Internal API error (502)")
+}
+
+// IsStatus reports whether err is GitLab answering with the given HTTP status.
+// It reads the structured error client-go returns, which every call in this
+// package makes directly, so there is no text to parse.
+func IsStatus(err error, code int) bool {
+	return toolutil.IsHTTPStatus(err, code)
+}
+
+// statusOf returns the HTTP status an error carries, and zero when it carries
+// none: a network failure, a cancelled context, an error of this package's
+// own.
+func statusOf(err error) int {
+	var response *gl.ErrorResponse
+	if errors.As(err, &response) && response.Response != nil {
+		return response.Response.StatusCode
+	}
+	return 0
+}
+
+// retryTransient runs op until it succeeds or fails for a reason IsRetryable
+// does not cover, within attempts. It is the shape every builder's create
+// takes; the classification is what differs per builder, and a builder that
+// needs another passes its own.
+func retryTransient[O any](e *harness.Env, label string, attempts int, op func() (O, error)) (O, error) {
+	e.T.Helper()
+	return retryWhen(e, label, attempts, IsRetryable, op)
+}
+
+// retryWhen runs op until it succeeds, fails for a reason retryable does not
+// accept, or runs out of attempts, waiting a little longer after each failure.
+func retryWhen[O any](e *harness.Env, label string, attempts int, retryable func(error) bool, op func() (O, error)) (O, error) {
+	e.T.Helper()
+	return harness.Retry(e.Ctx, e.T, label, attempts, retryBaseDelay, func(int) (O, bool, string, error) {
+		out, err := op()
+		if err == nil {
+			return out, false, "", nil
+		}
+		return out, retryable(err), describeRetry(err), err
+	})
+}
+
+// describeRetry names the class of a retried failure for the log line, so a
+// retried run reads as a story rather than as the same error three times.
+func describeRetry(err error) string {
+	switch {
+	case IsTransientNetwork(err):
+		return "transient network error"
+	case statusOf(err) == http.StatusTooManyRequests:
+		return "rate limited"
+	case statusOf(err) >= http.StatusInternalServerError:
+		return "server error"
+	case statusOf(err) == http.StatusNotFound:
+		return "not visible yet"
+	case strings.Contains(err.Error(), "already been taken"):
+		return "name collision inside GitLab's own validation"
+	default:
+		return "retryable error"
+	}
+}
+
+// budget returns the wait a step is allowed, larger on a licensed instance,
+// where every write does more work and takes measurably longer.
+func budget(e *harness.Env, base, enterprise time.Duration) time.Duration {
+	if e.Runtime().Tier.IsEnterprise() && enterprise > base {
+		return enterprise
+	}
+	return base
+}
+
+// cleanupContextTimeout bounds one cleanup's own context when the ledger's
+// context is already gone, which a hook that runs after the tests uses.
+const cleanupContextTimeout = 60 * time.Second
+
+// withCleanupTimeout returns ctx bounded by the cleanup budget when ctx
+// carries no deadline of its own.
+func withCleanupTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, has := ctx.Deadline(); has {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, cleanupContextTimeout)
+}

--- a/test/e2e/internal/fixture/retry_test.go
+++ b/test/e2e/internal/fixture/retry_test.go
@@ -1,0 +1,173 @@
+//go:build e2e
+
+// retry_test.go pins the retry classification: which failures a builder
+// tries again and which it reports at once.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestIsTransientNetwork_KnownMessages_AreTransient checks the four
+// connection failures a loaded GitLab produces are recognized, and that an
+// ordinary error is not.
+func TestIsTransientNetwork_KnownMessages_AreTransient(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "EOF", err: errors.New("read tcp 127.0.0.1:8929: EOF"), want: true},
+		{name: "reset", err: errors.New("read: connection reset by peer"), want: true},
+		{name: "broken pipe", err: errors.New("write: broken pipe"), want: true},
+		{name: "refused", err: errors.New("dial tcp: connection refused"), want: true},
+		{name: "ordinary", err: errors.New("name has already been taken"), want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := IsTransientNetwork(testCase.err); got != testCase.want {
+				t.Errorf("IsTransientNetwork(%v) = %t, want %t", testCase.err, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestIsRetryable_ByClass_MatchesTheDocumentedSet checks each class the
+// classification names, through the structured error client-go returns
+// rather than through a number in a message.
+func TestIsRetryable_ByClass_MatchesTheDocumentedSet(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "network", err: errors.New("unexpected EOF"), want: true},
+		{name: "rate limited", err: statusError(http.StatusTooManyRequests, "Retry later"), want: true},
+		{name: "server error", err: statusError(http.StatusInternalServerError, "boom"), want: true},
+		{name: "bad gateway", err: statusError(http.StatusBadGateway, "nginx"), want: true},
+		{name: "unavailable", err: statusError(http.StatusServiceUnavailable, "maintenance"), want: true},
+		{name: "not visible yet", err: statusError(http.StatusNotFound, "404 Branch Not Found"), want: true},
+		{name: "branch not ready", err: statusError(http.StatusBadRequest, "You can only create or edit files when you are on a branch"), want: true},
+		{name: "notification row race", err: statusError(http.StatusBadRequest, "Key (user_id) already exists in source"), want: true},
+		{name: "forbidden", err: statusError(http.StatusForbidden, "403 Forbidden"), want: false},
+		{name: "validation", err: statusError(http.StatusBadRequest, "name is invalid"), want: false},
+		{name: "a 404 spelled inside an ID", err: errors.New("project 404123 refused"), want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := IsRetryable(testCase.err); got != testCase.want {
+				t.Errorf("IsRetryable(%v) = %t, want %t", testCase.err, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestCreateRetryable_ByEdition_KeepsTheEnterpriseClassesToEnterprise checks
+// that the name collision is retried everywhere and the two repository-side
+// failures only where they have been seen.
+func TestCreateRetryable_ByEdition_KeepsTheEnterpriseClassesToEnterprise(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		enterprise bool
+		want       bool
+	}{
+		{name: "nil", err: nil, enterprise: true, want: false},
+		{name: "taken on free", err: statusError(http.StatusBadRequest, "name has already been taken"), enterprise: false, want: true},
+		{name: "taken on enterprise", err: statusError(http.StatusBadRequest, "path has already been taken"), enterprise: true, want: true},
+		{name: "network on free", err: errors.New("connection reset by peer"), enterprise: false, want: true},
+		{name: "repository on free", err: statusError(http.StatusBadRequest, "Failed to create repository"), enterprise: false, want: false},
+		{name: "repository on enterprise", err: statusError(http.StatusBadRequest, "Failed to create repository"), enterprise: true, want: true},
+		{name: "gitaly on enterprise", err: statusError(http.StatusBadRequest, "Internal API error (502)"), enterprise: true, want: true},
+		{name: "forbidden on enterprise", err: statusError(http.StatusForbidden, "403 Forbidden"), enterprise: true, want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := CreateRetryable(testCase.err, testCase.enterprise); got != testCase.want {
+				t.Errorf("CreateRetryable(%v, enterprise=%t) = %t, want %t", testCase.err, testCase.enterprise, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestStatusOf_Errors_ReadsTheStructuredStatus checks the status reader
+// behind the classification and the log descriptions.
+func TestStatusOf_Errors_ReadsTheStructuredStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: 0},
+		{name: "plain", err: errors.New("EOF"), want: 0},
+		{name: "structured", err: statusError(http.StatusConflict, "conflict"), want: http.StatusConflict},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := statusOf(testCase.err); got != testCase.want {
+				t.Errorf("statusOf(%v) = %d, want %d", testCase.err, got, testCase.want)
+			}
+			if testCase.want != 0 && !IsStatus(testCase.err, testCase.want) {
+				t.Errorf("IsStatus(%v, %d) = false, want true", testCase.err, testCase.want)
+			}
+		})
+	}
+}
+
+// TestDescribeRetry_ByClass_NamesTheReason checks the log line each retried
+// class produces, since a retried run is read afterwards through those.
+func TestDescribeRetry_ByClass_NamesTheReason(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "network", err: errors.New("broken pipe"), want: "transient network error"},
+		{name: "rate limited", err: statusError(http.StatusTooManyRequests, ""), want: "rate limited"},
+		{name: "server error", err: statusError(http.StatusBadGateway, ""), want: "server error"},
+		{name: "not visible yet", err: statusError(http.StatusNotFound, ""), want: "not visible yet"},
+		{name: "taken", err: statusError(http.StatusBadRequest, "name has already been taken"), want: "name collision inside GitLab's own validation"},
+		{name: "other", err: statusError(http.StatusBadRequest, "already exists in source"), want: "retryable error"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := describeRetry(testCase.err); got != testCase.want {
+				t.Errorf("describeRetry(%v) = %q, want %q", testCase.err, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestWithCleanupTimeout_Deadline_IsAddedOnlyWhenMissing checks that a
+// cleanup context the ledger bounded keeps its bound and one from an exit
+// hook gets the package's own.
+func TestWithCleanupTimeout_Deadline_IsAddedOnlyWhenMissing(t *testing.T) {
+	t.Run("unbounded context is bounded", func(t *testing.T) {
+		ctx, cancel := withCleanupTimeout(context.Background())
+		defer cancel()
+		deadline, has := ctx.Deadline()
+		if !has {
+			t.Fatal("withCleanupTimeout(Background) carries no deadline")
+		}
+		if remaining := time.Until(deadline); remaining > cleanupContextTimeout || remaining < cleanupContextTimeout/2 {
+			t.Errorf("deadline in %s, want about %s", remaining, cleanupContextTimeout)
+		}
+	})
+	t.Run("bounded context keeps its bound", func(t *testing.T) {
+		parent, parentCancel := context.WithTimeout(context.Background(), time.Second)
+		defer parentCancel()
+		ctx, cancel := withCleanupTimeout(parent)
+		defer cancel()
+		want, _ := parent.Deadline()
+		if got, _ := ctx.Deadline(); !got.Equal(want) {
+			t.Errorf("deadline = %s, want the parent's %s", got, want)
+		}
+	})
+}

--- a/test/e2e/internal/fixture/seeds.go
+++ b/test/e2e/internal/fixture/seeds.go
@@ -1,0 +1,140 @@
+//go:build e2e
+
+// seeds.go reads the state setup-gitlab.sh provisioned before the run: the
+// objects a test consumes and cannot make for itself.
+//
+// A seed is provisioned per consumer, one copy for each package and surface
+// that eats it, because a destructive scenario consumes its seed: a registry
+// tag deleted on the individual surface is not there for the meta run, and
+// whichever ran second would have to skip. The consumer slot is therefore
+// part of the variable name, and a test reads its own copy by naming the
+// surface it runs on. The one seed that cannot be multiplied, the pending
+// schema migration, has no slot and is used on one surface only.
+
+package fixture
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Seed names a per-consumer seed, as the variable name it is provisioned
+// under before the consumer suffix.
+type Seed string
+
+// The per-consumer seeds setup-gitlab.sh provisions.
+const (
+	// SeedRegistryProject is the path of a project whose container registry
+	// holds the tags seed-a and seed-b.
+	SeedRegistryProject Seed = "E2E_REGISTRY_PROJECT"
+	// SeedPendingApproveUserID is the ID of a user in the
+	// blocked_pending_approval state, for the approve scenario to approve.
+	SeedPendingApproveUserID Seed = "E2E_PENDING_APPROVE_USER_ID"
+	// SeedPendingRejectUserID is its sibling, for the reject scenario.
+	SeedPendingRejectUserID Seed = "E2E_PENDING_REJECT_USER_ID"
+)
+
+// The seeds provisioned once per instance rather than per consumer.
+const (
+	// SettingDBMigrationVersion is the version of a schema migration the
+	// setup script made pending, for the db_migration_mark happy path. An
+	// instance has one schema_migrations table, so there is one of these,
+	// and its scenario runs on one surface with OnSurfaces and this reason.
+	SettingDBMigrationVersion = "E2E_DB_MIGRATION_VERSION"
+	// SettingRootToken is the root user's token the setup script created,
+	// for a scenario that needs an administrator other than the run's own.
+	SettingRootToken = "E2E_ROOT_TOKEN" //nolint:gosec // G101: the name of the setting that holds a token, not a token
+)
+
+// SeedValue returns the value provisioned for seed, for this package on the
+// given surface, and whether it was provisioned at all.
+func SeedValue(e *harness.Env, seed Seed, surface harness.Surface) (string, bool) {
+	value := e.Setting(seedKey(seed, e.Package(), surface))
+	return value, value != ""
+}
+
+// RequireSeed returns the value provisioned for seed on the given surface,
+// skipping the test with the variable's name when there is none: a seed the
+// provisioning script could not create is reported as absent rather than as
+// a failure of the action that would have consumed it.
+func RequireSeed(e *harness.Env, seed Seed, surface harness.Surface) string {
+	e.T.Helper()
+
+	value, provisioned := SeedValue(e, seed, surface)
+	if !provisioned {
+		e.Skipf("seed %s is not provisioned for this run; setup-gitlab.sh writes it into test/e2e/.env.docker", seedKey(seed, e.Package(), surface))
+	}
+	return value
+}
+
+// seedKey builds the variable name one consumer slot reads a seed from:
+// the seed, the package and the surface, uppercased and joined with
+// underscores, which is what setup-gitlab.sh's seed_slot_suffix produces
+// for a "package:surface" slot.
+func seedKey(seed Seed, pkg string, surface harness.Surface) string {
+	return string(seed) + "_" + slotSuffix(pkg) + "_" + slotSuffix(surface.String())
+}
+
+// slotSuffix spells one half of a consumer slot the way the shell does: in
+// upper case, with every separator turned into an underscore.
+func slotSuffix(part string) string {
+	replacer := strings.NewReplacer(":", "_", "-", "_")
+	return strings.ToUpper(replacer.Replace(part))
+}
+
+// RegistryProject returns the path of the registry seed project provisioned
+// for this package on surface, skipping the test when there is none.
+func RegistryProject(e *harness.Env, surface harness.Surface) string {
+	e.T.Helper()
+	return RequireSeed(e, SeedRegistryProject, surface)
+}
+
+// PendingApprovalUsers returns the IDs of the two users seeded in the
+// pending-approval state for this package on surface: one to approve, one to
+// reject. The test is skipped when either is missing, since the pair is
+// provisioned together.
+func PendingApprovalUsers(e *harness.Env, surface harness.Surface) (approveID, rejectID int64) {
+	e.T.Helper()
+
+	approveID = seedID(e, SeedPendingApproveUserID, surface)
+	rejectID = seedID(e, SeedPendingRejectUserID, surface)
+	return approveID, rejectID
+}
+
+// seedID reads a seed that must be a numeric identifier.
+func seedID(e *harness.Env, seed Seed, surface harness.Surface) int64 {
+	e.T.Helper()
+
+	value := RequireSeed(e, seed, surface)
+	id, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		e.T.Fatalf("seed %s is %q, and the provisioning script writes a numeric user ID there", seedKey(seed, e.Package(), surface), value)
+	}
+	return id
+}
+
+// DBMigrationVersion returns the version of the schema migration the setup
+// script made pending, skipping the test when it could not.
+func DBMigrationVersion(e *harness.Env) string {
+	e.T.Helper()
+
+	version := e.Setting(SettingDBMigrationVersion)
+	if version == "" {
+		e.Skipf("%s is not set: the setup script could not seed a pending schema migration", SettingDBMigrationVersion)
+	}
+	return version
+}
+
+// RootToken returns the root user's token the setup script recorded,
+// skipping the test when the run has none.
+func RootToken(e *harness.Env) string {
+	e.T.Helper()
+
+	token := e.Setting(SettingRootToken)
+	if token == "" {
+		e.Skipf("%s is not set: only the Docker setup script records one", SettingRootToken)
+	}
+	return token
+}

--- a/test/e2e/internal/fixture/seeds_test.go
+++ b/test/e2e/internal/fixture/seeds_test.go
@@ -1,0 +1,48 @@
+//go:build e2e
+
+// seeds_test.go pins the variable name a consumer slot reads its seed from,
+// which has to agree with what setup-gitlab.sh writes.
+
+package fixture
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestSeedKey_Slots_SpellTheShellSuffix checks that the key for a package
+// and surface is what the script's seed_slot_suffix produces for the slot
+// "package:surface": upper case, separators to underscores.
+func TestSeedKey_Slots_SpellTheShellSuffix(t *testing.T) {
+	cases := []struct {
+		name    string
+		seed    Seed
+		pkg     string
+		surface harness.Surface
+		want    string
+	}{
+		{name: "registry on common individual", seed: SeedRegistryProject, pkg: "common", surface: harness.SurfaceIndividual, want: "E2E_REGISTRY_PROJECT_COMMON_INDIVIDUAL"},
+		{name: "approve on common meta", seed: SeedPendingApproveUserID, pkg: "common", surface: harness.SurfaceMeta, want: "E2E_PENDING_APPROVE_USER_ID_COMMON_META"},
+		{name: "reject on common dynamic", seed: SeedPendingRejectUserID, pkg: "common", surface: harness.SurfaceDynamic, want: "E2E_PENDING_REJECT_USER_ID_COMMON_DYNAMIC"},
+		{name: "a package with a dash", seed: SeedRegistryProject, pkg: "ee-extra", surface: harness.SurfaceMeta, want: "E2E_REGISTRY_PROJECT_EE_EXTRA_META"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := seedKey(testCase.seed, testCase.pkg, testCase.surface); got != testCase.want {
+				t.Errorf("seedKey() = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestSlotSuffix_Separators_BecomeUnderscores checks the shell's tr on its
+// own: colons and dashes both become underscores, and the case is upper.
+func TestSlotSuffix_Separators_BecomeUnderscores(t *testing.T) {
+	if got, want := slotSuffix("common:individual"), "COMMON_INDIVIDUAL"; got != want {
+		t.Errorf("slotSuffix(common:individual) = %q, want %q", got, want)
+	}
+	if got, want := slotSuffix("read-only"), "READ_ONLY"; got != want {
+		t.Errorf("slotSuffix(read-only) = %q, want %q", got, want)
+	}
+}

--- a/test/e2e/internal/fixture/stub_test.go
+++ b/test/e2e/internal/fixture/stub_test.go
@@ -1,0 +1,415 @@
+//go:build e2e
+
+// stub_test.go is the GitLab the fixture tests run against: an httptest
+// server answering the handful of endpoints the builders' pure halves call,
+// with the delayed-deletion dance and the eventual-consistency answers a real
+// one gives. It exists so the two-step delete, the waits and the sweep can be
+// driven without a GitLab, on every push.
+
+package fixture
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+)
+
+// stubToken is the credential the stub client sends; the stub never checks
+// it.
+const stubToken = "glpat-fixture-stub"
+
+// deletionSuffix is what GitLab appends to the path of an object it has
+// marked for deletion.
+const deletionSuffix = "-deletion_scheduled-"
+
+// stubObject is a project or a group as the stub keeps it.
+type stubObject struct {
+	ID     int64
+	Name   string
+	Path   string
+	Marked bool
+}
+
+// stubGitLab is the in-memory instance one test drives.
+type stubGitLab struct {
+	t *testing.T
+
+	mu       sync.Mutex
+	projects map[int64]*stubObject
+	groups   map[int64]*stubObject
+	users    map[int64]string
+	// deletes records every DELETE the stub answered, as "kind id params".
+	deletes []string
+	// branchMisses is how many branch reads answer 404 before the branch
+	// appears, which is how a stub says "not yet".
+	branchMisses int
+	// mergeStatuses and pipelineStatuses are answered one per read, the
+	// last repeating.
+	mergeStatuses    []string
+	pipelineStatuses []string
+	// pipelineFailures is how many pipeline reads answer 502 first.
+	pipelineFailures int
+	// enqueued is what the Sidekiq stats report, decremented per read.
+	enqueued int64
+	// runners is what the runner listing answers.
+	runners []*gl.Runner
+	// state is what the World's readers see, keyed by the request path.
+	state map[string]any
+
+	server *httptest.Server
+}
+
+// newStubGitLab starts a stub and returns it beside a client pointed at it.
+func newStubGitLab(t *testing.T) (*stubGitLab, *gitlabclient.Client) {
+	t.Helper()
+
+	stub := &stubGitLab{
+		t:        t,
+		projects: map[int64]*stubObject{},
+		groups:   map[int64]*stubObject{},
+		users:    map[int64]string{},
+		state:    map[string]any{},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects", stub.listProjects)
+	mux.HandleFunc("/api/v4/projects/{id}", stub.project)
+	mux.HandleFunc("/api/v4/groups", stub.listGroups)
+	mux.HandleFunc("/api/v4/groups/{id}", stub.group)
+	mux.HandleFunc("/api/v4/users", stub.listUsers)
+	mux.HandleFunc("/api/v4/users/{id}", stub.user)
+	mux.HandleFunc("/api/v4/sidekiq/job_stats", stub.sidekiq)
+	mux.HandleFunc("/api/v4/runners/all", stub.listRunners)
+	mux.HandleFunc("/api/v4/projects/{id}/repository/branches/{branch...}", stub.branch)
+	mux.HandleFunc("/api/v4/projects/{id}/merge_requests/{iid}", stub.mergeRequest)
+	mux.HandleFunc("/api/v4/projects/{id}/pipelines/{pipeline}", stub.pipeline)
+	mux.HandleFunc("/api/v4/projects/{id}/issues/{iid}", stub.stateAnswer)
+	mux.HandleFunc("/api/v4/projects/{id}/labels/{label}", stub.stateAnswer)
+	mux.HandleFunc("/api/v4/projects/{id}/milestones/{milestone}", stub.stateAnswer)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("stub GitLab: unexpected %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	})
+	stub.server = httptest.NewServer(mux)
+	t.Cleanup(stub.server.Close)
+
+	client, err := gitlabclient.NewClientWithTokenRetries(stub.server.URL, stubToken, false, true)
+	if err != nil {
+		t.Fatalf("building a client for the stub: %v", err)
+	}
+	return stub, client
+}
+
+// configure changes the stub's answers under its lock, so a test's setup
+// and the handlers that read it are ordered the way the race detector can
+// see.
+func (s *stubGitLab) configure(fn func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fn()
+}
+
+// addProject registers a project with the stub.
+func (s *stubGitLab) addProject(id int64, name, path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.projects[id] = &stubObject{ID: id, Name: name, Path: path}
+}
+
+// addGroup registers a group with the stub.
+func (s *stubGitLab) addGroup(id int64, name, path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.groups[id] = &stubObject{ID: id, Name: name, Path: path}
+}
+
+// addUser registers a user with the stub.
+func (s *stubGitLab) addUser(id int64, username string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.users[id] = username
+}
+
+// recordedDeletes returns what the stub was asked to delete, in order.
+func (s *stubGitLab) recordedDeletes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deletes...)
+}
+
+// remaining returns the paths of the projects and groups still there.
+func (s *stubGitLab) remaining() (projects, groups []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, p := range s.projects {
+		projects = append(projects, p.Path)
+	}
+	for _, g := range s.groups {
+		groups = append(groups, g.Path)
+	}
+	return projects, groups
+}
+
+// writeJSON answers with a JSON body. A body that does not encode is a bug in
+// the stub, answered as a 500 so the calling test sees it as an error.
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		http.Error(w, "stub: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
+}
+
+// writeError answers the way GitLab refuses something.
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"message": message})
+}
+
+// pathID reads a numeric path value.
+func pathID(r *http.Request, name string) int64 {
+	id, _ := strconv.ParseInt(r.PathValue(name), 10, 64)
+	return id
+}
+
+// projectJSON is a project as the stub serializes it.
+func projectJSON(p *stubObject) map[string]any {
+	return map[string]any{
+		"id": p.ID, "name": p.Name, "path_with_namespace": p.Path, "path": lastSegment(p.Path),
+		"default_branch": "main", "visibility": "private", "description": "", "archived": false,
+	}
+}
+
+// groupJSON is a group as the stub serializes it.
+func groupJSON(g *stubObject) map[string]any {
+	return map[string]any{"id": g.ID, "name": g.Name, "full_path": g.Path, "path": lastSegment(g.Path), "visibility": "private"}
+}
+
+// listProjects answers the project listing, filtered by search.
+func (s *stubGitLab) listProjects(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	search := r.URL.Query().Get("search")
+	var out []map[string]any
+	for _, p := range s.projects {
+		if strings.Contains(p.Name, search) || strings.Contains(p.Path, search) {
+			out = append(out, projectJSON(p))
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// listGroups answers the group listing, filtered by search.
+func (s *stubGitLab) listGroups(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	search := r.URL.Query().Get("search")
+	var out []map[string]any
+	for _, g := range s.groups {
+		if strings.Contains(g.Name, search) || strings.Contains(g.Path, search) {
+			out = append(out, groupJSON(g))
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// listUsers answers the user listing, filtered by search.
+func (s *stubGitLab) listUsers(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	search := r.URL.Query().Get("search")
+	var out []map[string]any
+	for id, username := range s.users {
+		if strings.Contains(username, search) {
+			out = append(out, map[string]any{"id": id, "username": username, "name": username})
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// user answers a user's deletion.
+func (s *stubGitLab) user(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := pathID(r, "id")
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "stub: only DELETE is answered for users")
+		return
+	}
+	if _, ok := s.users[id]; !ok {
+		writeError(w, http.StatusNotFound, "404 User Not Found")
+		return
+	}
+	delete(s.users, id)
+	s.deletes = append(s.deletes, "user "+strconv.FormatInt(id, 10))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// project answers reads and the two deletion steps for one project.
+func (s *stubGitLab) project(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.object(w, r, "project", s.projects, projectJSON)
+}
+
+// group answers reads and the two deletion steps for one group.
+func (s *stubGitLab) group(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.object(w, r, "group", s.groups, groupJSON)
+}
+
+// object is the delayed-deletion dance a real GitLab does: a plain DELETE
+// marks and renames, a second plain DELETE is refused as already marked, and
+// a permanent DELETE needs the renamed path.
+func (s *stubGitLab) object(w http.ResponseWriter, r *http.Request, kind string, objects map[int64]*stubObject, serialize func(*stubObject) map[string]any) {
+	id := pathID(r, "id")
+	query := r.URL.Query()
+	if r.Method == http.MethodDelete {
+		s.deletes = append(s.deletes, fmt.Sprintf("%s %d %s", kind, id, query.Encode()))
+	}
+	obj, ok := objects[id]
+	if !ok {
+		writeError(w, http.StatusNotFound, "404 "+kind+" Not Found")
+		return
+	}
+	if r.Method == http.MethodGet {
+		writeJSON(w, http.StatusOK, serialize(obj))
+		return
+	}
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "stub: unexpected method")
+		return
+	}
+	if query.Get("permanently_remove") != "true" {
+		if obj.Marked {
+			writeError(w, http.StatusBadRequest, "Project has been already marked for deletion")
+			return
+		}
+		obj.Marked = true
+		obj.Path += deletionSuffix + strconv.FormatInt(id, 10)
+		writeJSON(w, http.StatusAccepted, map[string]string{"message": "202 Accepted"})
+		return
+	}
+	if !obj.Marked {
+		writeError(w, http.StatusBadRequest, kind+" must be marked for deletion first")
+		return
+	}
+	if query.Get("full_path") != obj.Path {
+		writeError(w, http.StatusBadRequest, "full_path is incorrect")
+		return
+	}
+	delete(objects, id)
+	writeJSON(w, http.StatusAccepted, map[string]string{"message": "202 Accepted"})
+}
+
+// sidekiq answers the job stats, with one fewer job enqueued per read.
+func (s *stubGitLab) sidekiq(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	enqueued := s.enqueued
+	if s.enqueued > 0 {
+		s.enqueued--
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"jobs": map[string]any{"processed": 1, "failed": 0, "enqueued": enqueued}})
+}
+
+// listRunners answers the instance runner listing.
+func (s *stubGitLab) listRunners(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if got := r.URL.Query().Get("type"); got != "instance_type" {
+		s.t.Errorf("runner listing asked for type %q, want instance_type", got)
+	}
+	writeJSON(w, http.StatusOK, s.runners)
+}
+
+// branch answers 404 until the configured misses are spent, then the
+// branch.
+func (s *stubGitLab) branch(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	name, _ := url.PathUnescape(r.PathValue("branch"))
+	if s.branchMisses > 0 {
+		s.branchMisses--
+		writeError(w, http.StatusNotFound, "404 Branch Not Found")
+		return
+	}
+	if answer, ok := s.state[r.URL.Path]; ok {
+		writeJSON(w, http.StatusOK, answer)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"name": name, "protected": false, "commit": map[string]any{"id": "abc123"}})
+}
+
+// mergeRequest answers the next merge status, the last repeating.
+func (s *stubGitLab) mergeRequest(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if answer, ok := s.state[r.URL.Path]; ok {
+		writeJSON(w, http.StatusOK, answer)
+		return
+	}
+	status := nextStatus(&s.mergeStatuses)
+	if status == "" {
+		writeError(w, http.StatusNotFound, "404 Not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"iid": pathID(r, "iid"), "detailed_merge_status": status})
+}
+
+// pipeline answers the configured failures, then the next status.
+func (s *stubGitLab) pipeline(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pipelineFailures > 0 {
+		s.pipelineFailures--
+		writeError(w, http.StatusBadGateway, "502 Bad Gateway")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"id": pathID(r, "pipeline"), "status": nextStatus(&s.pipelineStatuses)})
+}
+
+// stateAnswer answers whatever the test put under the request path.
+func (s *stubGitLab) stateAnswer(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if answer, ok := s.state[r.URL.Path]; ok {
+		writeJSON(w, http.StatusOK, answer)
+		return
+	}
+	writeError(w, http.StatusNotFound, "404 Not Found")
+}
+
+// nextStatus pops the next status of a sequence, keeping the last one.
+func nextStatus(statuses *[]string) string {
+	if len(*statuses) == 0 {
+		return ""
+	}
+	status := (*statuses)[0]
+	if len(*statuses) > 1 {
+		*statuses = (*statuses)[1:]
+	}
+	return status
+}
+
+// statusError builds the structured error client-go returns for an HTTP
+// refusal, with the request a real one carries so its message formats.
+func statusError(code int, message string) error {
+	request, _ := http.NewRequest(http.MethodGet, "https://gitlab.example/api/v4/projects/1", http.NoBody) //nolint:noctx // a fixture error needs a request shape, not a live request
+	return &gl.ErrorResponse{
+		Response: &http.Response{StatusCode: code, Request: request},
+		Message:  message,
+	}
+}

--- a/test/e2e/internal/fixture/sweep.go
+++ b/test/e2e/internal/fixture/sweep.go
@@ -1,0 +1,288 @@
+//go:build e2e
+
+// sweep.go deletes what a run left behind, and only what this run left
+// behind.
+//
+// Every name a builder hands out carries the run ID, so a sweep can recognize
+// its own leftovers on an instance three packages share and other people use.
+// The suite this replaces matched a prefix alone, which on a shared instance
+// deleted another package's live projects; the prefix-wide sweep still exists
+// for an explicit target a person runs on purpose, and nothing runs it by
+// itself.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The sweep's bounds.
+const (
+	sweepBudget   = 5 * time.Minute
+	sweepPageSize = 100
+)
+
+// SweepReport says what a sweep found and what it could not remove.
+type SweepReport struct {
+	// Projects, Groups and Users name what was deleted.
+	Projects []string
+	Groups   []string
+	Users    []string
+	// Errors holds every deletion that failed and every listing that could
+	// not be read.
+	Errors []error
+}
+
+// Found reports whether the sweep had anything to delete.
+func (r SweepReport) Found() bool {
+	return len(r.Projects)+len(r.Groups)+len(r.Users) > 0
+}
+
+// Err folds the failures into one error, nil when there were none.
+func (r SweepReport) Err() error {
+	return errors.Join(r.Errors...)
+}
+
+// String summarizes the report for a log line.
+func (r SweepReport) String() string {
+	return fmt.Sprintf("%d project(s), %d group(s), %d user(s) removed; %d error(s)",
+		len(r.Projects), len(r.Groups), len(r.Users), len(r.Errors))
+}
+
+// matcher decides whether an object the listing returned is one to delete.
+type matcher func(name, path string) bool
+
+// belongsToRun reports whether an object's name or path carries runID, which
+// every name a builder hands out does.
+func belongsToRun(name, path, runID string) bool {
+	if runID == "" {
+		return false
+	}
+	return strings.Contains(name, runID) || strings.Contains(path, runID)
+}
+
+// hasPrefix reports whether an object's name, or the last segment of its
+// path, opens with prefix.
+func hasPrefix(name, path, prefix string) bool {
+	if prefix == "" {
+		return false
+	}
+	return strings.HasPrefix(name, prefix) || strings.HasPrefix(lastSegment(path), prefix)
+}
+
+// lastSegment returns the part of a path after its last slash.
+func lastSegment(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// SweepRun permanently deletes every project, group and, with an
+// administrator's token, every user whose name carries runID. It is what the
+// exit hook runs; a person runs SweepPrefix instead.
+func SweepRun(ctx context.Context, client *gitlabclient.Client, runID string, admin bool) SweepReport {
+	if runID == "" {
+		return SweepReport{Errors: []error{errors.New("a sweep needs a run ID to scope itself to")}}
+	}
+	return sweep(ctx, client, runID, func(name, path string) bool { return belongsToRun(name, path, runID) }, admin)
+}
+
+// SweepPrefix permanently deletes every owned project and group, and with an
+// administrator's token every user, whose name opens with prefix, whatever
+// run made it. It is for an explicit target run by hand after a run that
+// could not clean up, never for a run's own exit.
+func SweepPrefix(ctx context.Context, client *gitlabclient.Client, prefix string, admin bool) SweepReport {
+	if prefix == "" {
+		return SweepReport{Errors: []error{errors.New("a prefix sweep needs a prefix, or it would delete everything the token owns")}}
+	}
+	return sweep(ctx, client, prefix, func(name, path string) bool { return hasPrefix(name, path, prefix) }, admin)
+}
+
+// sweep lists what search finds and deletes what match accepts: projects
+// first, since the ones under a group go with it either way and a project
+// that fails to delete then says so on its own line; then groups; then
+// users, which only an administrator can list or delete.
+func sweep(ctx context.Context, client *gitlabclient.Client, search string, match matcher, admin bool) SweepReport {
+	var report SweepReport
+	report.Projects, report.Errors = sweepKind(ctx, projectTarget(client, search), match, report.Errors)
+	report.Groups, report.Errors = sweepKind(ctx, groupTarget(client, search), match, report.Errors)
+	if admin {
+		report.Users, report.Errors = sweepKind(ctx, userTarget(client, search), match, report.Errors)
+	}
+	return report
+}
+
+// sweepItem is one object a listing returned, as the matcher and the
+// report see it.
+type sweepItem struct {
+	id   int64
+	name string
+	path string
+}
+
+// sweepTarget is one kind of object a sweep lists page by page and deletes.
+type sweepTarget struct {
+	// kind names the objects in an error.
+	kind string
+	// list returns one page and the number of the next, zero at the end.
+	list func(ctx context.Context, page int64) ([]sweepItem, int64, error)
+	// remove deletes one object permanently.
+	remove func(ctx context.Context, item sweepItem) error
+}
+
+// sweepKind walks every page of one target, deletes what match accepts, and
+// returns the paths removed beside the errors, appended to those given.
+func sweepKind(ctx context.Context, target sweepTarget, match matcher, errs []error) (removed []string, failures []error) {
+	failures = errs
+	var page int64 = 1
+	for page != 0 {
+		items, next, err := target.list(ctx, page)
+		if err != nil {
+			return removed, append(failures, fmt.Errorf("listing %ss (page %d): %w", target.kind, page, err))
+		}
+		for _, item := range items {
+			if !match(item.name, item.path) {
+				continue
+			}
+			if removeErr := target.remove(ctx, item); removeErr != nil {
+				failures = append(failures, removeErr)
+				continue
+			}
+			removed = append(removed, item.path)
+		}
+		page = next
+	}
+	return removed, failures
+}
+
+// projectTarget lists the owned projects search finds, pending deletion
+// included since a project marked and never removed is the most common
+// leftover, and removes them through DeleteProject.
+func projectTarget(client *gitlabclient.Client, search string) sweepTarget {
+	return sweepTarget{
+		kind: "project",
+		list: func(ctx context.Context, page int64) ([]sweepItem, int64, error) {
+			opts := &gl.ListProjectsOptions{Owned: new(true), IncludePendingDelete: new(true), Search: new(search)}
+			opts.Page = page
+			opts.PerPage = sweepPageSize
+			projects, resp, err := client.GL().Projects.ListProjects(opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, 0, err
+			}
+			items := make([]sweepItem, 0, len(projects))
+			for _, project := range projects {
+				items = append(items, sweepItem{id: project.ID, name: project.Name, path: project.PathWithNamespace})
+			}
+			return items, resp.NextPage, nil
+		},
+		remove: func(ctx context.Context, item sweepItem) error {
+			return DeleteProject(ctx, client, item.id, item.path)
+		},
+	}
+}
+
+// groupTarget lists the owned groups search finds and removes them through
+// DeleteGroup. A subgroup goes with its parent, and deleting it first is
+// harmless.
+func groupTarget(client *gitlabclient.Client, search string) sweepTarget {
+	return sweepTarget{
+		kind: "group",
+		list: func(ctx context.Context, page int64) ([]sweepItem, int64, error) {
+			opts := &gl.ListGroupsOptions{Owned: new(true), Search: new(search)}
+			opts.Page = page
+			opts.PerPage = sweepPageSize
+			groups, resp, err := client.GL().Groups.ListGroups(opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, 0, err
+			}
+			items := make([]sweepItem, 0, len(groups))
+			for _, group := range groups {
+				items = append(items, sweepItem{id: group.ID, name: group.Name, path: group.FullPath})
+			}
+			return items, resp.NextPage, nil
+		},
+		remove: func(ctx context.Context, item sweepItem) error {
+			return DeleteGroup(ctx, client, item.id, item.path)
+		},
+	}
+}
+
+// userTarget lists the users search finds, matching on the username since a
+// user has no path, and hard-deletes them.
+func userTarget(client *gitlabclient.Client, search string) sweepTarget {
+	return sweepTarget{
+		kind: "user",
+		list: func(ctx context.Context, page int64) ([]sweepItem, int64, error) {
+			opts := &gl.ListUsersOptions{Search: new(search)}
+			opts.Page = page
+			opts.PerPage = sweepPageSize
+			users, resp, err := client.GL().Users.ListUsers(opts, gl.WithContext(ctx))
+			if err != nil {
+				return nil, 0, err
+			}
+			items := make([]sweepItem, 0, len(users))
+			for _, user := range users {
+				items = append(items, sweepItem{id: user.ID, name: user.Username, path: user.Username})
+			}
+			return items, resp.NextPage, nil
+		},
+		remove: func(ctx context.Context, item sweepItem) error {
+			_, err := client.GL().Users.DeleteUser(item.id, gl.WithContext(ctx))
+			if err != nil && !IsStatus(err, http.StatusNotFound) {
+				return fmt.Errorf("deleting user %d (%s): %w", item.id, item.name, err)
+			}
+			return nil
+		},
+	}
+}
+
+// sweepOnce arms the run's exit sweep the first time a builder creates
+// something that outlives a request.
+var sweepOnce sync.Once
+
+// armSweep registers the run-scoped sweep as an exit hook, once per process.
+//
+// It runs after every test's own cleanup, so what it finds is what a cleanup
+// failed to remove; that is logged as a leak, and the run is failed only when
+// the sweep could not remove it either, since a leak the sweep removed is a
+// cleanup defect the log now names and not a resource left on the instance.
+func armSweep(e *harness.Env) {
+	sweepOnce.Do(func() {
+		client, runID, admin := e.Client(), e.RunID(), e.Runtime().Admin
+		harness.AtExit(func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), sweepBudget)
+			defer cancel()
+
+			report := SweepRun(ctx, client, runID, admin)
+			if report.Found() {
+				log.Printf("e2e: sweep for run %s removed leftovers a cleanup did not: %s", runID, report)
+				for _, path := range report.Projects {
+					log.Printf("e2e: sweep removed project %s", path)
+				}
+				for _, path := range report.Groups {
+					log.Printf("e2e: sweep removed group %s", path)
+				}
+				for _, username := range report.Users {
+					log.Printf("e2e: sweep removed user %s", username)
+				}
+			}
+			if err := report.Err(); err != nil {
+				return fmt.Errorf("sweep for run %s: %w", runID, err)
+			}
+			return nil
+		})
+	})
+}

--- a/test/e2e/internal/fixture/sweep_test.go
+++ b/test/e2e/internal/fixture/sweep_test.go
@@ -1,0 +1,182 @@
+//go:build e2e
+
+// sweep_test.go checks that a sweep deletes exactly what belongs to it: the
+// run's own leftovers and nothing another run, or another person, owns.
+
+package fixture
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+// TestBelongsToRun_Names_MatchOnlyTheRunID pins the scoping rule: a name or
+// a path carrying the run ID belongs to the run, a prefix alone does not,
+// and an empty run ID matches nothing rather than everything.
+func TestBelongsToRun_Names_MatchOnlyTheRunID(t *testing.T) {
+	const runID = "20260912t101500z-0123456789-common"
+	cases := []struct {
+		name  string
+		obj   string
+		path  string
+		runID string
+		want  bool
+	}{
+		{name: "name carries it", obj: "proj-x-" + runID + "-abc-1", path: "user/other", runID: runID, want: true},
+		{name: "path carries it", obj: "Display Name", path: "user/proj-" + runID, runID: runID, want: true},
+		{name: "another run", obj: "proj-x-20260911t000000z-ffffffffff-common-1", path: "user/x", runID: runID, want: false},
+		{name: "same prefix only", obj: "proj-x", path: "user/proj-x", runID: runID, want: false},
+		{name: "empty run ID", obj: "anything", path: "anything", runID: "", want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := belongsToRun(testCase.obj, testCase.path, testCase.runID); got != testCase.want {
+				t.Errorf("belongsToRun(%q, %q, %q) = %t, want %t", testCase.obj, testCase.path, testCase.runID, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestHasPrefix_Names_MatchTheNameOrTheLastPathSegment pins the explicit
+// sweep's rule, which is wider on purpose and only ever run by hand.
+func TestHasPrefix_Names_MatchTheNameOrTheLastPathSegment(t *testing.T) {
+	cases := []struct {
+		name   string
+		obj    string
+		path   string
+		prefix string
+		want   bool
+	}{
+		{name: "name", obj: "e2e-proj", path: "user/renamed", prefix: "e2e-", want: true},
+		{name: "last segment", obj: "Proj", path: "group/e2e-proj", prefix: "e2e-", want: true},
+		{name: "namespace only", obj: "proj", path: "e2e-group/proj", prefix: "e2e-", want: false},
+		{name: "empty prefix", obj: "e2e-proj", path: "e2e-proj", prefix: "", want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := hasPrefix(testCase.obj, testCase.path, testCase.prefix); got != testCase.want {
+				t.Errorf("hasPrefix(%q, %q, %q) = %t, want %t", testCase.obj, testCase.path, testCase.prefix, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestSweepRun_MixedInstance_RemovesOnlyThisRunsObjects drives a sweep over
+// a stub holding this run's leftovers beside another run's and a person's,
+// and checks the report and what is left.
+func TestSweepRun_MixedInstance_RemovesOnlyThisRunsObjects(t *testing.T) {
+	const runID = "20260912t101500z-0123456789-common"
+	const otherRun = "20260911t090000z-9999999999-common"
+	stub, client := newStubGitLab(t)
+	stub.addProject(1, "proj-"+runID+"-1", "user/proj-"+runID+"-1")
+	stub.addProject(2, "proj-"+otherRun+"-1", "user/proj-"+otherRun+"-1")
+	stub.addProject(3, "real work", "user/real-work")
+	stub.addGroup(10, "grp-"+runID+"-2", "grp-"+runID+"-2")
+	stub.addGroup(11, "grp-"+otherRun+"-2", "grp-"+otherRun+"-2")
+	stub.addUser(20, "usr-"+runID+"-3")
+	stub.addUser(21, "alice")
+
+	report := SweepRun(context.Background(), client, runID, true)
+
+	if err := report.Err(); err != nil {
+		t.Fatalf("SweepRun() errors = %v, want none", err)
+	}
+	if !report.Found() {
+		t.Fatal("SweepRun() found nothing, want this run's three leftovers")
+	}
+	if got, want := report.Projects, []string{"user/proj-" + runID + "-1"}; !slices.Equal(got, want) {
+		t.Errorf("projects removed = %v, want %v", got, want)
+	}
+	if got, want := report.Groups, []string{"grp-" + runID + "-2"}; !slices.Equal(got, want) {
+		t.Errorf("groups removed = %v, want %v", got, want)
+	}
+	if got, want := report.Users, []string{"usr-" + runID + "-3"}; !slices.Equal(got, want) {
+		t.Errorf("users removed = %v, want %v", got, want)
+	}
+
+	projects, groups := stub.remaining()
+	slices.Sort(projects)
+	slices.Sort(groups)
+	if want := []string{"user/proj-" + otherRun + "-1", "user/real-work"}; !slices.Equal(projects, want) {
+		t.Errorf("projects left = %v, want %v", projects, want)
+	}
+	if want := []string{"grp-" + otherRun + "-2"}; !slices.Equal(groups, want) {
+		t.Errorf("groups left = %v, want %v", groups, want)
+	}
+	if got, want := report.String(), "1 project(s), 1 group(s), 1 user(s) removed; 0 error(s)"; got != want {
+		t.Errorf("report = %q, want %q", got, want)
+	}
+}
+
+// TestSweepRun_NotAdmin_LeavesUsersAlone checks that a token that cannot
+// list users is not asked to, since the listing would be refused and would
+// count as an error of the sweep.
+func TestSweepRun_NotAdmin_LeavesUsersAlone(t *testing.T) {
+	const runID = "20260912t101500z-0123456789-common"
+	stub, client := newStubGitLab(t)
+	stub.addUser(20, "usr-"+runID+"-3")
+
+	report := SweepRun(context.Background(), client, runID, false)
+	if err := report.Err(); err != nil {
+		t.Fatalf("SweepRun() errors = %v, want none", err)
+	}
+	if len(report.Users) != 0 || report.Found() {
+		t.Errorf("report = %s, want nothing touched without admin", report)
+	}
+	if got := stub.recordedDeletes(); len(got) != 0 {
+		t.Errorf("deletes = %q, want none", got)
+	}
+}
+
+// TestSweep_EmptyScope_IsRefused checks the two guards: a sweep with no run
+// ID and a prefix sweep with no prefix would each delete everything the
+// token owns, and answer with an error instead.
+func TestSweep_EmptyScope_IsRefused(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addProject(1, "anything", "user/anything")
+
+	cases := []struct {
+		name   string
+		report SweepReport
+	}{
+		{name: "run without an ID", report: SweepRun(context.Background(), client, "", true)},
+		{name: "prefix without a prefix", report: SweepPrefix(context.Background(), client, "", true)},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.report.Err() == nil || testCase.report.Found() {
+				t.Errorf("report = %s, want a refusal that touched nothing", testCase.report)
+			}
+		})
+	}
+	if got := stub.recordedDeletes(); len(got) != 0 {
+		t.Errorf("deletes = %q, want none", got)
+	}
+}
+
+// TestSweepPrefix_Objects_RemovesEveryRunsLeftoversUnderThePrefix checks the
+// explicit sweep reaches across runs and still leaves what does not carry
+// the prefix.
+func TestSweepPrefix_Objects_RemovesEveryRunsLeftoversUnderThePrefix(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addProject(1, "e2e-proj-run1", "user/e2e-proj-run1")
+	stub.addProject(2, "e2e-proj-run2", "user/e2e-proj-run2")
+	stub.addProject(3, "keep", "user/keep")
+	stub.addGroup(10, "e2e-grp", "e2e-grp")
+
+	report := SweepPrefix(context.Background(), client, "e2e-", false)
+	if err := report.Err(); err != nil {
+		t.Fatalf("SweepPrefix() errors = %v, want none", err)
+	}
+	slices.Sort(report.Projects)
+	if want := []string{"user/e2e-proj-run1", "user/e2e-proj-run2"}; !slices.Equal(report.Projects, want) {
+		t.Errorf("projects removed = %v, want %v", report.Projects, want)
+	}
+	if want := []string{"e2e-grp"}; !slices.Equal(report.Groups, want) {
+		t.Errorf("groups removed = %v, want %v", report.Groups, want)
+	}
+	if projects, _ := stub.remaining(); !slices.Equal(projects, []string{"user/keep"}) {
+		t.Errorf("projects left = %v, want only user/keep", projects)
+	}
+}

--- a/test/e2e/internal/fixture/user.go
+++ b/test/e2e/internal/fixture/user.go
@@ -1,0 +1,239 @@
+//go:build e2e
+
+// user.go builds the objects that need an administrator: a disposable user,
+// a personal access token for one, and an SSH key. A test that drives an
+// action against "another user" cannot use the run's own account for it, and
+// a test of token operations must never run them against the credential the
+// whole run depends on.
+
+package fixture
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+	"golang.org/x/crypto/ssh"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// User is a disposable user a builder created through the admin API.
+type User struct {
+	// ID is the numeric identifier every user-scoped action takes.
+	ID int64
+	// Username is the login name, scoped to the run.
+	Username string
+	// Email is the address it was registered with, on a domain that delivers
+	// nowhere.
+	Email string
+	// Password is the random password it was created with, for a test that
+	// signs in as it. Nothing else ever uses it.
+	Password string
+}
+
+// Token is a personal access token a builder minted for a user.
+type Token struct {
+	// ID is what the revocation and rotation actions take.
+	ID int64
+	// Value is the secret itself, shown once at creation.
+	Value string
+	// UserID is the user it belongs to.
+	UserID int64
+	// Name is what it was created as.
+	Name string
+}
+
+// SSHKey is an SSH key a builder added to a user.
+type SSHKey struct {
+	// ID is what the key actions take.
+	ID int64
+	// Title is what it was added as.
+	Title string
+	// PublicKey is the authorized_keys form of it.
+	PublicKey string
+}
+
+// UserOption adjusts one user builder.
+type UserOption func(*gl.CreateUserOptions)
+
+// AsAdmin creates the user as an instance administrator.
+func AsAdmin() UserOption {
+	return func(opts *gl.CreateUserOptions) { opts.Admin = new(true) }
+}
+
+// AsExternal creates the user as an external user, which cannot see internal
+// projects.
+func AsExternal() UserOption {
+	return func(opts *gl.CreateUserOptions) { opts.External = new(true) }
+}
+
+// userEmailDomain is a domain that resolves nowhere, so a confirmation mail
+// GitLab might still try to send has nowhere to go.
+const userEmailDomain = "@e2e-test.invalid"
+
+// NewUser creates a confirmed user with a random password through the admin
+// API and registers its hard deletion on the Env. A run whose token is not an
+// administrator's cannot create one, and the test is skipped with that
+// reason; declare harness.Needs(harness.NeedAdmin) to say so up front.
+func NewUser(e *harness.Env, prefix string, opts ...UserOption) User {
+	e.T.Helper()
+	requireAdmin(e, "creating a user")
+	armSweep(e)
+
+	username := e.Name(prefix)
+	password := "Pw-" + rand.Text()
+	createOpts := &gl.CreateUserOptions{
+		Email:            new(username + userEmailDomain),
+		Name:             new("E2E " + username),
+		Username:         new(username),
+		Password:         new(password),
+		SkipConfirmation: new(true),
+	}
+	for _, opt := range opts {
+		opt(createOpts)
+	}
+
+	user, err := retryTransient(e, "create user "+username, createRetries, func() (User, error) {
+		created, _, err := e.Client().GL().Users.CreateUser(createOpts, gl.WithContext(e.Ctx))
+		if err != nil {
+			return User{}, err
+		}
+		return User{ID: created.ID, Username: created.Username, Email: created.Email, Password: password}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating user %q: %v", username, err)
+	}
+
+	e.Defer("user "+user.Username, func(ctx context.Context) error {
+		return DeleteUser(ctx, e.Client(), user.ID)
+	})
+	return user
+}
+
+// DeleteUser hard-deletes a user. One that is already gone, which a test that
+// rejected or deleted it leaves behind, is not an error.
+func DeleteUser(ctx context.Context, client *gitlabclient.Client, userID int64) error {
+	ctx, cancel := withCleanupTimeout(ctx)
+	defer cancel()
+
+	_, err := client.GL().Users.DeleteUser(userID, gl.WithContext(ctx))
+	if err != nil && !IsStatus(err, http.StatusNotFound) {
+		return fmt.Errorf("deleting user %d: %w", userID, err)
+	}
+	return nil
+}
+
+// tokenLifetime is how long a fixture token stays valid. A day is longer
+// than any run and shorter than any policy an instance enforces.
+const tokenLifetime = 24 * time.Hour
+
+// NewToken mints a personal access token for user with the given scopes
+// through the admin API and registers its revocation on the Env. With no
+// scopes, "api" is assumed.
+func NewToken(e *harness.Env, user User, scopes ...string) Token {
+	e.T.Helper()
+	requireAdmin(e, "minting a token for another user")
+
+	if len(scopes) == 0 {
+		scopes = []string{"api"}
+	}
+	name := e.Name("tok")
+	expiry := gl.ISOTime(time.Now().Add(tokenLifetime))
+
+	token, err := retryTransient(e, "create token "+name, createRetries, func() (Token, error) {
+		created, _, err := e.Client().GL().Users.CreatePersonalAccessToken(user.ID, &gl.CreatePersonalAccessTokenOptions{
+			Name:      new(name),
+			Scopes:    &scopes,
+			ExpiresAt: &expiry,
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Token{}, err
+		}
+		if created.Token == "" {
+			return Token{}, fmt.Errorf("token %q was created without a value", name)
+		}
+		return Token{ID: created.ID, Value: created.Token, UserID: user.ID, Name: created.Name}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("minting a token for user %d: %v", user.ID, err)
+	}
+
+	e.Defer("token "+token.Name, func(ctx context.Context) error {
+		ctx, cancel := withCleanupTimeout(ctx)
+		defer cancel()
+		_, revokeErr := e.Client().GL().PersonalAccessTokens.RevokePersonalAccessTokenByID(token.ID, gl.WithContext(ctx))
+		if revokeErr != nil && !IsStatus(revokeErr, http.StatusNotFound) {
+			return fmt.Errorf("revoking token %d: %w", token.ID, revokeErr)
+		}
+		return nil
+	})
+	return token
+}
+
+// SSHPublicKey generates a fresh ED25519 key pair and returns the public half
+// in authorized_keys form, for a deploy key or a user key. The private half
+// is discarded: nothing in a test ever connects with it.
+func SSHPublicKey() (string, error) {
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("generating an ed25519 key: %w", err)
+	}
+	sshPublic, err := ssh.NewPublicKey(public)
+	if err != nil {
+		return "", fmt.Errorf("converting the key to SSH form: %w", err)
+	}
+	return string(ssh.MarshalAuthorizedKey(sshPublic)), nil
+}
+
+// NewSSHKey generates a key and adds it to user through the admin API,
+// registering its removal on the Env.
+func NewSSHKey(e *harness.Env, user User) SSHKey {
+	e.T.Helper()
+	requireAdmin(e, "adding a key to another user")
+
+	publicKey, keyErr := SSHPublicKey()
+	if keyErr != nil {
+		e.T.Fatal(keyErr)
+	}
+	title := e.Name("key")
+
+	key, addErr := retryTransient(e, "add ssh key "+title, createRetries, func() (SSHKey, error) {
+		added, _, err := e.Client().GL().Users.AddSSHKeyForUser(user.ID, &gl.AddSSHKeyOptions{
+			Title: new(title),
+			Key:   new(publicKey),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return SSHKey{}, err
+		}
+		return SSHKey{ID: added.ID, Title: added.Title, PublicKey: publicKey}, nil
+	})
+	if addErr != nil {
+		e.T.Fatalf("adding an SSH key to user %d: %v", user.ID, addErr)
+	}
+
+	e.Defer("ssh key "+key.Title, func(ctx context.Context) error {
+		ctx, cancel := withCleanupTimeout(ctx)
+		defer cancel()
+		_, deleteErr := e.Client().GL().Users.DeleteSSHKeyForUser(user.ID, key.ID, gl.WithContext(ctx))
+		if deleteErr != nil && !IsStatus(deleteErr, http.StatusNotFound) {
+			return fmt.Errorf("deleting ssh key %d of user %d: %w", key.ID, user.ID, deleteErr)
+		}
+		return nil
+	})
+	return key
+}
+
+// requireAdmin skips a test whose fixture needs an administrator the run does
+// not have, naming what it was about to do.
+func requireAdmin(e *harness.Env, what string) {
+	e.T.Helper()
+	if !e.Runtime().Admin {
+		e.Skipf("%s needs an administrator token, and this run's is not one; declare harness.Needs(harness.NeedAdmin)", what)
+	}
+}

--- a/test/e2e/internal/fixture/user_test.go
+++ b/test/e2e/internal/fixture/user_test.go
@@ -1,0 +1,67 @@
+//go:build e2e
+
+// user_test.go pins the key generation and the user deletion's tolerance.
+
+package fixture
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// TestSSHPublicKey_Generated_ParsesAsAnEd25519AuthorizedKey checks the key
+// is in the form GitLab accepts, and that two calls give two keys, since an
+// instance refuses a fingerprint it already holds.
+func TestSSHPublicKey_Generated_ParsesAsAnEd25519AuthorizedKey(t *testing.T) {
+	first, err := SSHPublicKey()
+	if err != nil {
+		t.Fatalf("SSHPublicKey() error = %v", err)
+	}
+	parsed, _, _, _, err := ssh.ParseAuthorizedKey([]byte(first))
+	if err != nil {
+		t.Fatalf("the key does not parse as an authorized key: %v", err)
+	}
+	if got := parsed.Type(); got != ssh.KeyAlgoED25519 {
+		t.Errorf("key type = %q, want %q", got, ssh.KeyAlgoED25519)
+	}
+	if !strings.HasSuffix(first, "\n") {
+		t.Errorf("key %q does not end with the newline authorized_keys carries", first)
+	}
+
+	second, err := SSHPublicKey()
+	if err != nil {
+		t.Fatalf("second SSHPublicKey() error = %v", err)
+	}
+	if first == second {
+		t.Errorf("two generated keys are identical")
+	}
+}
+
+// TestDeleteUser_States_DeletesAndToleratesGone checks that a user is hard
+// deleted and that one already gone is not an error, which is the state a
+// rejected or deleted user is left in.
+func TestDeleteUser_States_DeletesAndToleratesGone(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addUser(30, "disposable")
+
+	if err := DeleteUser(context.Background(), client, 30); err != nil {
+		t.Fatalf("DeleteUser() error = %v, want nil", err)
+	}
+	if err := DeleteUser(context.Background(), client, 30); err != nil {
+		t.Errorf("DeleteUser(gone) error = %v, want nil", err)
+	}
+	if got := stub.recordedDeletes(); len(got) != 1 || got[0] != "user 30" {
+		t.Errorf("deletes = %q, want one deletion of user 30", got)
+	}
+}
+
+// TestUserEmailDomain_Reserved_DeliversNowhere pins the address domain to
+// one RFC 2606 reserves, so a confirmation mail can never reach anyone.
+func TestUserEmailDomain_Reserved_DeliversNowhere(t *testing.T) {
+	if !strings.HasSuffix(userEmailDomain, ".invalid") {
+		t.Errorf("userEmailDomain = %q, want a .invalid domain", userEmailDomain)
+	}
+}

--- a/test/e2e/internal/fixture/world.go
+++ b/test/e2e/internal/fixture/world.go
@@ -1,0 +1,437 @@
+//go:build e2e
+
+// world.go builds the state every read-only test shares, once per process,
+// and checks at the end that nobody wrote to it.
+//
+// A read sweep over a thousand actions cannot build a project for each of
+// them, so the reads share one World: a group with a project in it, a branch
+// with a commit, a merge request, an issue, a label, a milestone. The World is
+// read-only by contract, and the contract is enforced after the fact: a
+// digest of everything a test could change is taken when the World is built
+// and again when it is torn down, and a difference fails the run and names
+// the field. A test that mutates the World by mistake breaks unrelated read
+// tests in ways that are hard to see; the digest turns that into one line.
+
+package fixture
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// World is the read-only state a package's tests share.
+type World struct {
+	// Group is a top-level group; Project lives in it.
+	Group Group
+	// Project is a private project with a README on its default branch.
+	Project Project
+	// Branch is a feature branch of Project carrying Commit.
+	Branch Branch
+	// Commit is the one commit Branch has that the default branch does not.
+	Commit Commit
+	// MergeRequest merges Branch into the default branch, and is mergeable.
+	MergeRequest MergeRequest
+	// Issue is an open issue of Project.
+	Issue Issue
+	// Label is a label of Project.
+	Label Label
+	// Milestone is an active milestone of Project.
+	Milestone Milestone
+	// Username and UserID identify the run's own user, for user-scoped reads.
+	Username string
+	UserID   int64
+
+	// baseline is every mutable field as it read when the World was built,
+	// and digest is its hash: the digest decides, the baseline explains.
+	baseline map[string]string
+	digest   string
+}
+
+// The names the World's objects are created under. Each carries the run ID
+// through worldName, so the sweep recognizes them.
+const (
+	worldGroupPrefix     = "e2e-world-group"
+	worldProjectPrefix   = "e2e-world-project"
+	worldBranch          = "feature/world"
+	worldFilePath        = "docs/world.md"
+	worldFileContent     = "# World\n\nThe shared read-only fixture of one e2e run.\n"
+	worldCommitMessage   = "docs: add the World file"
+	worldMergeTitle      = "World merge request"
+	worldIssueTitle      = "World issue"
+	worldLabelPrefix     = "world-label"
+	worldMilestonePrefix = "world-milestone"
+)
+
+// worldName scopes one World object's name to the run.
+func worldName(runID, prefix string) string {
+	return prefix + "-" + runID
+}
+
+// worldNames hands a creation retry a fresh name each time it asks: the plain
+// World name first, then the same with an attempt number, since a name GitLab
+// refused as taken must not be offered again.
+func worldNames(runID, prefix string) func() string {
+	attempt := 0
+	return func() string {
+		attempt++
+		if attempt == 1 {
+			return worldName(runID, prefix)
+		}
+		return fmt.Sprintf("%s-%d", worldName(runID, prefix), attempt)
+	}
+}
+
+// errWorldAborted is what a World whose build did not finish is reported as
+// to every later caller. The test that built it carries the real failure.
+var errWorldAborted = errors.New("the shared World was not built: the test that first asked for it failed while building it")
+
+// shared is this process's World, built at most once.
+var shared struct {
+	once  sync.Once
+	world *World
+	err   error
+	// builder names the test that built it, for the message a later caller
+	// gets when the build failed.
+	builder string
+}
+
+// SharedWorld returns the process's World, building it on the first call.
+//
+// The first caller's Env supplies the client and the test the build reports
+// to. Whatever the build creates is torn down by an exit hook rather than by
+// that test's ledger, since every later test stands on it too. A build that
+// fails fails the test that asked first, and every later caller with a
+// pointer to it.
+func SharedWorld(e *harness.Env) *World {
+	e.T.Helper()
+
+	shared.once.Do(func() {
+		shared.builder = e.T.Name()
+		shared.err = errWorldAborted
+		armSweep(e)
+
+		world := &World{Username: e.Runtime().Username, UserID: e.Runtime().UserID}
+		shared.world = world
+		// Registered before anything is created, so a build that fails
+		// halfway still has its group deleted at exit.
+		harness.AtExit(func() error { return teardownWorld(e.Client(), world) })
+
+		buildWorld(e, world)
+		shared.err = nil
+	})
+
+	if shared.err != nil {
+		e.T.Fatalf("%v (built by %s)", shared.err, shared.builder)
+	}
+	return shared.world
+}
+
+// buildWorld creates every object of the World in dependency order, filling
+// in the fields as it goes so a build that fails leaves the created ones
+// recorded, and takes the digest last.
+func buildWorld(e *harness.Env, world *World) {
+	e.T.Helper()
+
+	runID := e.RunID()
+	group, err := createGroup(e, groupSpec{visibility: gl.PrivateVisibility}, worldNames(runID, worldGroupPrefix))
+	if err != nil {
+		e.T.Fatalf("building the World: creating its group: %v", err)
+	}
+	world.Group = group
+
+	spec := projectSpec{description: "The shared read-only World of run " + runID, visibility: gl.PrivateVisibility, readme: true, namespaceID: group.ID}
+	project, err := createProject(e, spec, worldNames(runID, worldProjectPrefix))
+	if err != nil {
+		e.T.Fatalf("building the World: creating its project: %v", err)
+	}
+	world.Project = project
+	waitForDefaultBranch(e, project)
+
+	world.Branch = NewBranch(e, project, worldBranch)
+	world.Commit = CommitFile(e, project, worldBranch, worldFilePath, worldFileContent, worldCommitMessage)
+	world.MergeRequest = NewMergeRequest(e, project, worldBranch, project.DefaultBranch, worldMergeTitle)
+	world.Issue = NewIssue(e, project, worldIssueTitle)
+	world.Label = createLabel(e, project, worldName(runID, worldLabelPrefix))
+	world.Milestone = createMilestone(e, project, worldName(runID, worldMilestonePrefix))
+
+	state, err := worldState(e.Ctx, e.Client(), world)
+	if err != nil {
+		e.T.Fatalf("building the World: reading it back for its digest: %v", err)
+	}
+	world.baseline = state
+	world.digest = Digest(state)
+	log.Printf("e2e: World built: group %s, project %s, digest %s", group.Path, project.Path, world.digest)
+}
+
+// worldTeardownBudget bounds the teardown, digest read included.
+const worldTeardownBudget = 3 * time.Minute
+
+// teardownWorld re-reads the World, compares it with what was built, and
+// deletes it. It fails on a difference and on a deletion that did not
+// happen, and does both halves whatever the first found: a changed World is
+// still deleted, and a World that could not be read is still torn down.
+func teardownWorld(client *gitlabclient.Client, world *World) error {
+	ctx, cancel := context.WithTimeout(context.Background(), worldTeardownBudget)
+	defer cancel()
+
+	var failures []error
+	if world.digest != "" {
+		if err := verifyWorld(ctx, client, world); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	if world.Group.ID != 0 {
+		if err := DeleteGroup(ctx, client, world.Group.ID, world.Group.Path); err != nil {
+			failures = append(failures, fmt.Errorf("tearing down the World: %w", err))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// verifyWorld reports what changed between the World's build and now.
+func verifyWorld(ctx context.Context, client *gitlabclient.Client, world *World) error {
+	now, err := worldState(ctx, client, world)
+	if err != nil {
+		return fmt.Errorf("re-reading the World for its digest: %w", err)
+	}
+	return compareWorld(world.baseline, world.digest, now)
+}
+
+// compareWorld is the verdict over two readings: nil when the digests agree,
+// and otherwise an error naming every field that differs.
+func compareWorld(baseline map[string]string, digest string, now map[string]string) error {
+	if Digest(now) == digest {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", errWorldChanged, strings.Join(worldStateDiff(baseline, now), "; "))
+}
+
+// errWorldChanged is the failure a run whose read-only World was written to
+// ends with.
+var errWorldChanged = errors.New("the shared World was changed during the run")
+
+// Digest hashes a World's mutable state: every field, sorted by name, so two
+// readings of an unchanged World hash the same whatever order the map was
+// filled in. Each key and value is written with its length in front, so a
+// separator inside a value cannot make two different states hash the same.
+func Digest(state map[string]string) string {
+	keys := make([]string, 0, len(state))
+	for key := range state {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	hash := sha256.New()
+	for _, key := range keys {
+		fmt.Fprintf(hash, "%d:%s=%d:%s\n", len(key), key, len(state[key]), state[key])
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// worldStateDiff names every field that differs between two readings, in
+// field order, as "field: before -> after".
+func worldStateDiff(before, after map[string]string) []string {
+	keys := make(map[string]struct{}, len(before)+len(after))
+	for key := range before {
+		keys[key] = struct{}{}
+	}
+	for key := range after {
+		keys[key] = struct{}{}
+	}
+
+	var changes []string
+	for key := range keys {
+		was, had := before[key]
+		now, has := after[key]
+		switch {
+		case had && !has:
+			changes = append(changes, fmt.Sprintf("%s: %q -> (gone)", key, was))
+		case !had && has:
+			changes = append(changes, fmt.Sprintf("%s: (absent) -> %q", key, now))
+		case was != now:
+			changes = append(changes, fmt.Sprintf("%s: %q -> %q", key, was, now))
+		}
+	}
+	slices.Sort(changes)
+	return changes
+}
+
+// worldState reads every field of the World a test could change and returns
+// them keyed by object and field.
+func worldState(ctx context.Context, client *gitlabclient.Client, world *World) (map[string]string, error) {
+	state := map[string]string{}
+	readers := []func() error{
+		func() error { return readGroupState(ctx, client, world.Group, state) },
+		func() error { return readProjectState(ctx, client, world.Project, state) },
+		func() error { return readBranchState(ctx, client, world, state) },
+		func() error { return readMergeRequestState(ctx, client, world, state) },
+		func() error { return readIssueState(ctx, client, world, state) },
+		func() error { return readLabelState(ctx, client, world, state) },
+		func() error { return readMilestoneState(ctx, client, world, state) },
+	}
+	for _, read := range readers {
+		if err := read(); err != nil {
+			return nil, err
+		}
+	}
+	return state, nil
+}
+
+// readGroupState records the group's name, path and visibility.
+func readGroupState(ctx context.Context, client *gitlabclient.Client, group Group, state map[string]string) error {
+	got, _, err := client.GL().Groups.GetGroup(group.ID, nil, gl.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("reading group %d: %w", group.ID, err)
+	}
+	state["group.name"] = got.Name
+	state["group.full_path"] = got.FullPath
+	state["group.visibility"] = string(got.Visibility)
+	state["group.description"] = got.Description
+	return nil
+}
+
+// readProjectState records the project's identity and settings.
+func readProjectState(ctx context.Context, client *gitlabclient.Client, project Project, state map[string]string) error {
+	got, _, err := client.GL().Projects.GetProject(project.ID, nil, gl.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("reading project %d: %w", project.ID, err)
+	}
+	state["project.name"] = got.Name
+	state["project.path_with_namespace"] = got.PathWithNamespace
+	state["project.default_branch"] = got.DefaultBranch
+	state["project.visibility"] = string(got.Visibility)
+	state["project.description"] = got.Description
+	state["project.archived"] = strconv.FormatBool(got.Archived)
+	state["project.topics"] = strings.Join(sortedCopy(got.Topics), ",")
+	return nil
+}
+
+// readBranchState records where the two branches point.
+//
+// Whether a branch is protected is deliberately not recorded: an instance
+// with default branch protection applies it in a background job after the
+// project is created, and a digest taken before that job ran would report
+// the instance's own work as a change some test made.
+func readBranchState(ctx context.Context, client *gitlabclient.Client, world *World, state map[string]string) error {
+	for _, name := range []string{world.Project.DefaultBranch, world.Branch.Name} {
+		got, _, err := client.GL().Branches.GetBranch(world.Project.ID, name, gl.WithContext(ctx))
+		if err != nil {
+			return fmt.Errorf("reading branch %q of project %d: %w", name, world.Project.ID, err)
+		}
+		sha := ""
+		if got.Commit != nil {
+			sha = got.Commit.ID
+		}
+		state["branch."+name+".sha"] = sha
+	}
+	return nil
+}
+
+// readMergeRequestState records the merge request's identity and state.
+func readMergeRequestState(ctx context.Context, client *gitlabclient.Client, world *World, state map[string]string) error {
+	got, _, err := client.GL().MergeRequests.GetMergeRequest(world.Project.ID, world.MergeRequest.IID, nil, gl.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("reading merge request !%d of project %d: %w", world.MergeRequest.IID, world.Project.ID, err)
+	}
+	state["merge_request.title"] = got.Title
+	state["merge_request.state"] = got.State
+	state["merge_request.description"] = got.Description
+	state["merge_request.source_branch"] = got.SourceBranch
+	state["merge_request.target_branch"] = got.TargetBranch
+	state["merge_request.labels"] = strings.Join(sortedCopy(got.Labels), ",")
+	return nil
+}
+
+// readIssueState records the issue's identity and state.
+func readIssueState(ctx context.Context, client *gitlabclient.Client, world *World, state map[string]string) error {
+	got, _, err := client.GL().Issues.GetIssue(world.Project.ID, world.Issue.IID, gl.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("reading issue #%d of project %d: %w", world.Issue.IID, world.Project.ID, err)
+	}
+	state["issue.title"] = got.Title
+	state["issue.state"] = got.State
+	state["issue.description"] = got.Description
+	state["issue.labels"] = strings.Join(sortedCopy(got.Labels), ",")
+	state["issue.confidential"] = strconv.FormatBool(got.Confidential)
+	return nil
+}
+
+// readLabelState records the label's name, color and description.
+func readLabelState(ctx context.Context, client *gitlabclient.Client, world *World, state map[string]string) error {
+	got, _, err := client.GL().Labels.GetLabel(world.Project.ID, world.Label.ID, gl.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("reading label %d of project %d: %w", world.Label.ID, world.Project.ID, err)
+	}
+	state["label.name"] = got.Name
+	state["label.color"] = got.Color
+	state["label.description"] = got.Description
+	return nil
+}
+
+// readMilestoneState records the milestone's title and state.
+func readMilestoneState(ctx context.Context, client *gitlabclient.Client, world *World, state map[string]string) error {
+	got, _, err := client.GL().Milestones.GetMilestone(world.Project.ID, world.Milestone.ID, gl.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("reading milestone %d of project %d: %w", world.Milestone.ID, world.Project.ID, err)
+	}
+	state["milestone.title"] = got.Title
+	state["milestone.state"] = got.State
+	state["milestone.description"] = got.Description
+	return nil
+}
+
+// sortedCopy returns a sorted copy of a list, so a set GitLab returns in no
+// particular order digests the same every time.
+func sortedCopy(values []string) []string {
+	sorted := slices.Clone(values)
+	slices.Sort(sorted)
+	return sorted
+}
+
+// Bindings returns every parameter the World can bind, by the name a
+// catalog action's schema gives it. It is what a read sweep binds required
+// parameters from, and a parameter it does not carry is one the sweep names
+// as unbound.
+func (w *World) Bindings() map[string]any {
+	return map[string]any{
+		"project_id":        w.Project.ID,
+		"group_id":          w.Group.ID,
+		"namespace_id":      w.Group.ID,
+		"issue_iid":         w.Issue.IID,
+		"issue_id":          w.Issue.ID,
+		"merge_request_iid": w.MergeRequest.IID,
+		"mr_iid":            w.MergeRequest.IID,
+		"branch":            w.Branch.Name,
+		"branch_name":       w.Branch.Name,
+		"ref":               w.Project.DefaultBranch,
+		"sha":               w.Commit.SHA,
+		"commit_sha":        w.Commit.SHA,
+		"commit_id":         w.Commit.SHA,
+		"file_path":         w.Commit.FilePath,
+		"label_id":          w.Label.ID,
+		"milestone_id":      w.Milestone.ID,
+		"user_id":           w.UserID,
+		"username":          w.Username,
+	}
+}
+
+// Bind returns the World's value for one parameter name, and whether it has
+// one.
+func (w *World) Bind(param string) (any, bool) {
+	value, ok := w.Bindings()[param]
+	return value, ok
+}

--- a/test/e2e/internal/fixture/world_test.go
+++ b/test/e2e/internal/fixture/world_test.go
@@ -1,0 +1,283 @@
+//go:build e2e
+
+// world_test.go pins the World's digest, the diff that explains a changed
+// one, the bindings a read sweep takes from it, and the teardown that reads
+// it back and deletes it, all against the stub.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestDigest_SameStateAnyOrder_HashesTheSame checks the digest is a
+// function of the state and not of the order the map was filled in, and
+// that any one field changing changes it.
+func TestDigest_SameStateAnyOrder_HashesTheSame(t *testing.T) {
+	first := map[string]string{"project.name": "p", "issue.state": "opened", "label.color": "#428BCA"}
+	second := map[string]string{"label.color": "#428BCA", "issue.state": "opened", "project.name": "p"}
+	if Digest(first) != Digest(second) {
+		t.Errorf("Digest() differs for the same state in another order")
+	}
+	if got := Digest(map[string]string{}); len(got) != 64 {
+		t.Errorf("Digest(empty) = %q, want 64 hex characters", got)
+	}
+
+	changed := map[string]string{"project.name": "p", "issue.state": "closed", "label.color": "#428BCA"}
+	if Digest(first) == Digest(changed) {
+		t.Errorf("Digest() did not change with issue.state")
+	}
+	// A key moved into a value must not hash the same as the key itself.
+	if Digest(map[string]string{"a": "b=c"}) == Digest(map[string]string{"a=b": "c"}) {
+		t.Errorf("Digest() confuses a key with a value")
+	}
+}
+
+// TestWorldStateDiff_Readings_NamesEveryDifference checks the explanation
+// a changed World produces: changed, gone and new fields, in field order.
+func TestWorldStateDiff_Readings_NamesEveryDifference(t *testing.T) {
+	before := map[string]string{"issue.state": "opened", "label.name": "l", "project.name": "p"}
+	after := map[string]string{"issue.state": "closed", "project.name": "p", "milestone.title": "m"}
+
+	got := worldStateDiff(before, after)
+	want := []string{
+		`issue.state: "opened" -> "closed"`,
+		`label.name: "l" -> (gone)`,
+		`milestone.title: (absent) -> "m"`,
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("worldStateDiff() = %q, want %q", got, want)
+	}
+	if diff := worldStateDiff(before, before); len(diff) != 0 {
+		t.Errorf("worldStateDiff(same) = %q, want none", diff)
+	}
+}
+
+// TestCompareWorld_Readings_FailsOnlyWhenTheDigestMoved checks the verdict
+// names the field, and passes an unchanged World.
+func TestCompareWorld_Readings_FailsOnlyWhenTheDigestMoved(t *testing.T) {
+	baseline := map[string]string{"issue.state": "opened"}
+	if err := compareWorld(baseline, Digest(baseline), map[string]string{"issue.state": "opened"}); err != nil {
+		t.Errorf("compareWorld(unchanged) = %v, want nil", err)
+	}
+
+	err := compareWorld(baseline, Digest(baseline), map[string]string{"issue.state": "closed"})
+	if !errors.Is(err, errWorldChanged) {
+		t.Fatalf("compareWorld(changed) = %v, want errWorldChanged", err)
+	}
+	if want := `the shared World was changed during the run: issue.state: "opened" -> "closed"`; err.Error() != want {
+		t.Errorf("error = %q, want %q", err, want)
+	}
+}
+
+// TestWorldName_RunID_ScopesEveryObject checks a World object's name carries
+// the run ID, so the sweep recognizes it.
+func TestWorldName_RunID_ScopesEveryObject(t *testing.T) {
+	const runID = "20260912t101500z-0123456789-common"
+	name := worldName(runID, worldProjectPrefix)
+	if want := "e2e-world-project-" + runID; name != want {
+		t.Errorf("worldName() = %q, want %q", name, want)
+	}
+	if !belongsToRun(name, "", runID) {
+		t.Errorf("worldName() %q is not recognized as the run's own", name)
+	}
+
+	next := worldNames(runID, worldGroupPrefix)
+	first, second, third := next(), next(), next()
+	if first != "e2e-world-group-"+runID || second != first+"-2" || third != first+"-3" {
+		t.Errorf("worldNames() = %q, %q, %q, want the plain name and then numbered ones", first, second, third)
+	}
+	for _, name := range []string{first, second, third} {
+		t.Run(name, func(t *testing.T) {
+			if !belongsToRun(name, "", runID) {
+				t.Errorf("worldNames() %q is not recognized as the run's own", name)
+			}
+		})
+	}
+}
+
+// TestWorldBindings_Parameters_ComeFromTheObjects checks every binding a
+// read sweep takes maps to the object it names, and that Bind says no for a
+// parameter the World does not carry.
+func TestWorldBindings_Parameters_ComeFromTheObjects(t *testing.T) {
+	world := &World{
+		Group:        Group{ID: 1},
+		Project:      Project{ID: 2, DefaultBranch: "main"},
+		Branch:       Branch{Name: "feature/world"},
+		Commit:       Commit{SHA: "abc", FilePath: "docs/world.md"},
+		MergeRequest: MergeRequest{IID: 3},
+		Issue:        Issue{IID: 4, ID: 40},
+		Label:        Label{ID: 5},
+		Milestone:    Milestone{ID: 6},
+		Username:     "e2e",
+		UserID:       7,
+	}
+	cases := []struct {
+		param string
+		want  any
+	}{
+		{param: "project_id", want: int64(2)},
+		{param: "group_id", want: int64(1)},
+		{param: "namespace_id", want: int64(1)},
+		{param: "issue_iid", want: int64(4)},
+		{param: "issue_id", want: int64(40)},
+		{param: "merge_request_iid", want: int64(3)},
+		{param: "mr_iid", want: int64(3)},
+		{param: "branch", want: "feature/world"},
+		{param: "branch_name", want: "feature/world"},
+		{param: "ref", want: "main"},
+		{param: "sha", want: "abc"},
+		{param: "commit_sha", want: "abc"},
+		{param: "commit_id", want: "abc"},
+		{param: "file_path", want: "docs/world.md"},
+		{param: "label_id", want: int64(5)},
+		{param: "milestone_id", want: int64(6)},
+		{param: "user_id", want: int64(7)},
+		{param: "username", want: "e2e"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.param, func(t *testing.T) {
+			got, ok := world.Bind(testCase.param)
+			if !ok || got != testCase.want {
+				t.Errorf("Bind(%q) = (%v, %t), want (%v, true)", testCase.param, got, ok, testCase.want)
+			}
+		})
+	}
+	if _, ok := world.Bind("pipeline_id"); ok {
+		t.Errorf("Bind(pipeline_id) = true, want false for a parameter the World does not carry")
+	}
+	if got, want := len(world.Bindings()), len(cases); got != want {
+		t.Errorf("Bindings() has %d entries, want the %d this test names", got, want)
+	}
+}
+
+// stubWorld puts a World's objects into the stub and returns the World that
+// names them, with the state the readers will find.
+func stubWorld(stub *stubGitLab) *World {
+	stub.addGroup(1, "World group", "e2e-world-group-run")
+	stub.addProject(2, "World project", "e2e-world-group-run/e2e-world-project-run")
+	stub.configure(func() {
+		stub.state["/api/v4/projects/2/repository/branches/main"] = map[string]any{"name": "main", "protected": true, "commit": map[string]any{"id": "main-sha"}}
+		stub.state["/api/v4/projects/2/repository/branches/feature/world"] = map[string]any{"name": "feature/world", "protected": false, "commit": map[string]any{"id": "feature-sha"}}
+		stub.state["/api/v4/projects/2/merge_requests/3"] = map[string]any{"iid": 3, "title": "World merge request", "state": "opened", "source_branch": "feature/world", "target_branch": "main", "labels": []string{"b", "a"}}
+		stub.state["/api/v4/projects/2/issues/4"] = map[string]any{"iid": 4, "title": "World issue", "state": "opened", "labels": []string{}, "confidential": false}
+		stub.state["/api/v4/projects/2/labels/5"] = map[string]any{"id": 5, "name": "world-label", "color": "#428BCA"}
+		stub.state["/api/v4/projects/2/milestones/6"] = map[string]any{"id": 6, "title": "world-milestone", "state": "active"}
+	})
+	return &World{
+		Group:        Group{ID: 1, Path: "e2e-world-group-run"},
+		Project:      Project{ID: 2, DefaultBranch: "main"},
+		Branch:       Branch{Name: "feature/world"},
+		MergeRequest: MergeRequest{IID: 3},
+		Issue:        Issue{IID: 4},
+		Label:        Label{ID: 5},
+		Milestone:    Milestone{ID: 6},
+	}
+}
+
+// TestWorldState_Stub_ReadsEveryMutableField checks the readers against the
+// stub: every field the digest covers is read, and a set comes back sorted.
+func TestWorldState_Stub_ReadsEveryMutableField(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	world := stubWorld(stub)
+
+	state, err := worldState(context.Background(), client, world)
+	if err != nil {
+		t.Fatalf("worldState() error = %v", err)
+	}
+	want := map[string]string{
+		"group.name": "World group", "group.full_path": "e2e-world-group-run", "group.visibility": "private", "group.description": "",
+		"project.name": "World project", "project.path_with_namespace": "e2e-world-group-run/e2e-world-project-run",
+		"project.default_branch": "main", "project.visibility": "private", "project.description": "", "project.archived": "false", "project.topics": "",
+		"branch.main.sha": "main-sha", "branch.feature/world.sha": "feature-sha",
+		"merge_request.title": "World merge request", "merge_request.state": "opened", "merge_request.description": "",
+		"merge_request.source_branch": "feature/world", "merge_request.target_branch": "main", "merge_request.labels": "a,b",
+		"issue.title": "World issue", "issue.state": "opened", "issue.description": "", "issue.labels": "", "issue.confidential": "false",
+		"label.name": "world-label", "label.color": "#428BCA", "label.description": "",
+		"milestone.title": "world-milestone", "milestone.state": "active", "milestone.description": "",
+	}
+	if diff := worldStateDiff(want, state); len(diff) != 0 {
+		t.Errorf("worldState() differs from what the stub holds:\n  %s", strings.Join(diff, "\n  "))
+	}
+}
+
+// TestWorldState_MissingObject_ReportsWhichRead checks that a World object
+// nothing can find fails the read naming it, since a digest over a partial
+// read would compare two incomplete things.
+func TestWorldState_MissingObject_ReportsWhichRead(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	world := stubWorld(stub)
+	stub.configure(func() { delete(stub.state, "/api/v4/projects/2/labels/5") })
+
+	_, err := worldState(context.Background(), client, world)
+	if err == nil || !strings.Contains(err.Error(), "reading label 5") {
+		t.Errorf("worldState() error = %v, want it to name the label read", err)
+	}
+}
+
+// TestTeardownWorld_Unchanged_DeletesAndPasses checks the exit hook's happy
+// path: the digest still matches and the group is removed with everything
+// under it.
+func TestTeardownWorld_Unchanged_DeletesAndPasses(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	world := stubWorld(stub)
+	state, err := worldState(context.Background(), client, world)
+	if err != nil {
+		t.Fatalf("worldState() error = %v", err)
+	}
+	world.baseline, world.digest = state, Digest(state)
+
+	if err = teardownWorld(client, world); err != nil {
+		t.Fatalf("teardownWorld() error = %v, want nil", err)
+	}
+	if _, groups := stub.remaining(); len(groups) != 0 {
+		t.Errorf("groups left = %v, want none", groups)
+	}
+}
+
+// TestTeardownWorld_Changed_FailsAndStillDeletes checks that a World a test
+// wrote to fails the run naming the field, and is deleted anyway.
+func TestTeardownWorld_Changed_FailsAndStillDeletes(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	world := stubWorld(stub)
+	state, err := worldState(context.Background(), client, world)
+	if err != nil {
+		t.Fatalf("worldState() error = %v", err)
+	}
+	world.baseline, world.digest = state, Digest(state)
+	stub.configure(func() {
+		stub.state["/api/v4/projects/2/issues/4"] = map[string]any{"iid": 4, "title": "World issue", "state": "closed", "labels": []string{}, "confidential": false}
+	})
+
+	err = teardownWorld(client, world)
+	if !errors.Is(err, errWorldChanged) {
+		t.Fatalf("teardownWorld() error = %v, want errWorldChanged", err)
+	}
+	if !strings.Contains(err.Error(), `issue.state: "opened" -> "closed"`) {
+		t.Errorf("error = %q, want it to name the changed field", err)
+	}
+	if _, groups := stub.remaining(); len(groups) != 0 {
+		t.Errorf("groups left = %v, want the World deleted even though it changed", groups)
+	}
+}
+
+// TestTeardownWorld_PartialBuild_DeletesWhatExists checks the hook a build
+// that failed halfway leaves behind: no digest to compare, and a group to
+// remove.
+func TestTeardownWorld_PartialBuild_DeletesWhatExists(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addGroup(1, "World group", "e2e-world-group-run")
+
+	if err := teardownWorld(client, &World{Group: Group{ID: 1, Path: "e2e-world-group-run"}}); err != nil {
+		t.Fatalf("teardownWorld(partial) error = %v, want nil", err)
+	}
+	if _, groups := stub.remaining(); len(groups) != 0 {
+		t.Errorf("groups left = %v, want none", groups)
+	}
+	if err := teardownWorld(client, &World{}); err != nil {
+		t.Errorf("teardownWorld(nothing built) error = %v, want nil", err)
+	}
+}

--- a/test/e2e/internal/harness/access.go
+++ b/test/e2e/internal/harness/access.go
@@ -1,0 +1,158 @@
+//go:build e2e
+
+// access.go is what the fixture library sees of an Env: the client the
+// harness probed the instance with, what the probe learned, the run's
+// configuration, and a moment after the last test.
+//
+// The fixture library builds GitLab state through client-go rather than
+// through the server under test, so it needs the client and not a session.
+// The state it builds once per process, the shared World, outlives every test,
+// so it needs a moment after m.Run to check that nothing changed it and to
+// tear it down; and the sweep of what a failed test left behind needs the same
+// moment. None of that is the harness's business, which knows nothing about
+// projects or merge requests, and all of it needs something only the harness
+// holds. This file hands those things over and nothing else.
+
+package harness
+
+import (
+	"errors"
+	"log"
+	"slices"
+	"sync"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+)
+
+// Runtime is what the probe learned about the instance under test, as a test
+// or a fixture may read it.
+//
+// It mirrors the harness's own record field for field, and Env.Runtime
+// converts one into the other, so a field added to one and not the other is a
+// compile error rather than a silently empty value.
+type Runtime struct {
+	// URL is the instance the run is pointed at.
+	URL string
+	// Version is what GET /api/v4/version reported.
+	Version string
+	// Enterprise is that endpoint's own edition flag: an EE image reports
+	// true whether or not a license is installed, which is why it is kept
+	// apart from Tier.
+	Enterprise bool
+	// Tier is what the license resolves to, Free when there is none.
+	Tier edition.Tier
+	// TierConfirmed says the tier came from a license rather than from the
+	// fallback.
+	TierConfirmed bool
+	// Admin says the token's user is an instance administrator.
+	Admin bool
+	// Username and UserID identify that user.
+	Username string
+	UserID   int64
+	// Scopes are the token's own, nil when the instance would not say.
+	Scopes []string
+}
+
+// Client returns the GitLab client the harness probed the instance with, its
+// tier already set.
+//
+// It is how the fixture library reaches GitLab beside the server under test:
+// state built through client-go never counts as coverage, and a broken tool
+// then fails only its own test rather than every test that needs a project.
+func (e *Env) Client() *gitlabclient.Client { return e.inst.client }
+
+// Runtime returns what the probe learned about the instance this test runs
+// on. The scopes are copied, so a caller cannot change what the harness holds.
+func (e *Env) Runtime() Runtime {
+	facts := Runtime(e.inst.facts)
+	facts.Scopes = slices.Clone(facts.Scopes)
+	return facts
+}
+
+// Setting returns one value of the run's configuration, or the empty string.
+//
+// It reads the map Main resolved and never the process environment: a value a
+// dotenv file set is visible here and nowhere else in this process, which is
+// what keeps a file this run reads from configuring the harness's own
+// environment by accident.
+func (e *Env) Setting(key string) string { return e.inst.settings.get(key) }
+
+// DockerMode reports whether the run is against the ephemeral Docker stack,
+// which is disposable and provisions fixtures of its own.
+func (e *Env) DockerMode() bool { return e.inst.dockerMode() }
+
+// Package returns the name of the package under test, which is the first half
+// of the consumer slot a per-consumer seed is provisioned for.
+func (e *Env) Package() string { return e.inst.pkg }
+
+// HasRunner reports whether a CI runner can pick a job up, asking GitLab once
+// per process. It is the same answer NeedRunner gives, offered to a fixture
+// that would otherwise wait a whole budget for a pipeline nothing will run.
+func (e *Env) HasRunner() bool { return e.inst.hasRunner() }
+
+// exitHooks is what runs after the last test of the package and before Main
+// returns.
+type exitHooks struct {
+	mu   sync.Mutex
+	fns  []func() error
+	done bool
+}
+
+// hooks is this test binary's registry.
+var hooks exitHooks
+
+// AtExit registers fn to run once every test of the package has ended, before
+// the sessions close and before Main returns. Hooks run last-registered
+// first, like a cleanup ledger, and an error from any of them fails the run.
+//
+// It exists for state that outlives a test: the shared World the fixture
+// library builds once per process, and the sweep of what a failed test left
+// behind. A t.Cleanup would run them at the end of the first test that asked,
+// which is exactly when the next test still needs them.
+func AtExit(fn func() error) {
+	hooks.mu.Lock()
+	defer hooks.mu.Unlock()
+
+	if hooks.done {
+		log.Println("e2e: an exit hook was registered after the exit hooks ran, and will never run")
+		return
+	}
+	hooks.fns = append(hooks.fns, fn)
+}
+
+// runExitHooks runs every registered hook once, last-registered first, and
+// returns what failed. A second call runs nothing.
+func runExitHooks() []error {
+	hooks.mu.Lock()
+	if hooks.done {
+		hooks.mu.Unlock()
+		return nil
+	}
+	hooks.done = true
+	fns := slices.Clone(hooks.fns)
+	hooks.mu.Unlock()
+
+	var failures []error
+	for _, fn := range slices.Backward(fns) {
+		if err := fn(); err != nil {
+			log.Printf("e2e: exit hook failed: %v", err)
+			failures = append(failures, err)
+		}
+	}
+	return failures
+}
+
+// errExitHooks is what a run whose exit hooks failed is failed with, so the
+// cause reads as one thing in the log rather than as a bare exit code.
+var errExitHooks = errors.New("an exit hook failed")
+
+// exitCodeAfterHooks folds the hooks' outcome into the tests' verdict: a
+// failed hook fails a passing run and leaves a failing one as it was.
+func exitCodeAfterHooks(code int, failures []error) int {
+	if len(failures) > 0 && code == 0 {
+		log.Printf("e2e: %v; the run is failed", errExitHooks)
+		return 1
+	}
+	return code
+}

--- a/test/e2e/internal/harness/access_test.go
+++ b/test/e2e/internal/harness/access_test.go
@@ -1,0 +1,168 @@
+//go:build e2e
+
+// access_test.go covers what the fixture library is handed: the accessors on
+// Env and the exit hooks Main runs after the last test.
+
+package harness
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+)
+
+// TestEnvAccessors_StubInstance_HandOverWhatTheProbeFound checks that an Env
+// exposes the client, the facts and the configuration the bootstrap resolved,
+// which is everything a fixture built through client-go needs.
+//
+// It drives the real probe against a stub GitLab, so the facts are what a run
+// would see rather than a literal the test wrote into the struct.
+func TestEnvAccessors_StubInstance_HandOverWhatTheProbeFound(t *testing.T) {
+	inst := stubInstance(t)
+	inst.settings = inst.settings.with("E2E_FIXTURE_URL", "http://e2e-fixture:8080")
+	inst.settings = inst.settings.with(envMode, "docker")
+	env := newEnv(t, inst)
+
+	if env.Client() != inst.client {
+		t.Errorf("Client() is not the instance's client")
+	}
+	if got := env.Setting("E2E_FIXTURE_URL"); got != "http://e2e-fixture:8080" {
+		t.Errorf("Setting(E2E_FIXTURE_URL) = %q, want the configured value", got)
+	}
+	if got := env.Setting("E2E_NOT_SET"); got != "" {
+		t.Errorf("Setting(unset) = %q, want empty", got)
+	}
+	if !env.DockerMode() {
+		t.Errorf("DockerMode() = false, want true with %s=docker", envMode)
+	}
+	if got := env.Package(); got != "harness" {
+		t.Errorf("Package() = %q, want harness", got)
+	}
+	if !env.HasRunner() {
+		t.Errorf("HasRunner() = false, want true in Docker mode")
+	}
+
+	runtime := env.Runtime()
+	if runtime.URL != inst.facts.URL || runtime.Username != inst.facts.Username || runtime.UserID != inst.facts.UserID {
+		t.Errorf("Runtime() = %+v, want the probed facts %+v", runtime, inst.facts)
+	}
+	if runtime.Tier != edition.Free || runtime.TierConfirmed {
+		t.Errorf("Runtime().Tier = %s (confirmed=%t), want Free from a stub with no license", runtime.Tier, runtime.TierConfirmed)
+	}
+}
+
+// TestEnvRuntime_Scopes_AreACopy checks that a caller changing the scopes it
+// was handed does not change what the harness holds, since the served-set
+// check reads the harness's own copy.
+func TestEnvRuntime_Scopes_AreACopy(t *testing.T) {
+	inst := stubInstance(t)
+	inst.facts.Scopes = []string{"api", "read_user"}
+	env := newEnv(t, inst)
+
+	scopes := env.Runtime().Scopes
+	if len(scopes) != 2 {
+		t.Fatalf("Runtime().Scopes = %v, want the two probed scopes", scopes)
+	}
+	scopes[0] = "changed"
+
+	if got := inst.facts.Scopes[0]; got != "api" {
+		t.Errorf("the harness's scopes were changed through the copy: %q", got)
+	}
+}
+
+// TestExitHooks_Registered_RunOnceLastFirst checks the two properties a
+// cleanup registry needs: the hooks run in reverse order, so the World's
+// teardown runs before the sweep that would find its leftovers, and a second
+// run runs nothing.
+func TestExitHooks_Registered_RunOnceLastFirst(t *testing.T) {
+	resetExitHooks(t)
+
+	var order []string
+	AtExit(func() error { order = append(order, "sweep"); return nil })
+	AtExit(func() error { order = append(order, "world"); return nil })
+
+	if failures := runExitHooks(); len(failures) != 0 {
+		t.Fatalf("runExitHooks() failures = %v, want none", failures)
+	}
+	if got, want := strings.Join(order, ","), "world,sweep"; got != want {
+		t.Errorf("hook order = %q, want %q", got, want)
+	}
+
+	order = nil
+	if failures := runExitHooks(); len(failures) != 0 || len(order) != 0 {
+		t.Errorf("second runExitHooks() ran %v with failures %v, want nothing", order, failures)
+	}
+}
+
+// TestExitHooks_LateRegistration_IsDropped checks that a hook registered after
+// the hooks ran is not kept for a run that will never happen.
+func TestExitHooks_LateRegistration_IsDropped(t *testing.T) {
+	resetExitHooks(t)
+	runExitHooks()
+
+	ran := false
+	AtExit(func() error { ran = true; return nil })
+
+	hooks.mu.Lock()
+	kept := len(hooks.fns)
+	hooks.mu.Unlock()
+	if kept != 0 || ran {
+		t.Errorf("late hook kept=%d ran=%t, want dropped", kept, ran)
+	}
+}
+
+// TestExitHooks_Failure_FailsAPassingRun checks that a hook's error reaches
+// the exit code: a World somebody mutated, or a sweep that could not delete,
+// must not leave a run looking green.
+func TestExitHooks_Failure_FailsAPassingRun(t *testing.T) {
+	resetExitHooks(t)
+
+	AtExit(func() error { return nil })
+	AtExit(func() error { return errors.New("the World was changed") })
+	AtExit(func() error { return nil })
+
+	failures := runExitHooks()
+	if len(failures) != 1 {
+		t.Fatalf("runExitHooks() failures = %v, want exactly the one hook that failed", failures)
+	}
+
+	cases := []struct {
+		name string
+		code int
+		want int
+	}{
+		{name: "passing run is failed", code: 0, want: 1},
+		{name: "failing run keeps its code", code: 1, want: 1},
+		{name: "refused run keeps its code", code: 2, want: 2},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := exitCodeAfterHooks(testCase.code, failures); got != testCase.want {
+				t.Errorf("exitCodeAfterHooks(%d, one failure) = %d, want %d", testCase.code, got, testCase.want)
+			}
+		})
+	}
+	if got := exitCodeAfterHooks(0, nil); got != 0 {
+		t.Errorf("exitCodeAfterHooks(0, none) = %d, want 0", got)
+	}
+}
+
+// resetExitHooks gives a test an empty registry and puts the package's own
+// back afterwards, so the harness's real hooks are neither run nor lost.
+func resetExitHooks(t *testing.T) {
+	t.Helper()
+	hooks.mu.Lock()
+	saved := hooks.fns
+	savedDone := hooks.done
+	hooks.fns = nil
+	hooks.done = false
+	hooks.mu.Unlock()
+	t.Cleanup(func() {
+		hooks.mu.Lock()
+		hooks.fns = saved
+		hooks.done = savedDone
+		hooks.mu.Unlock()
+	})
+}

--- a/test/e2e/internal/harness/main.go
+++ b/test/e2e/internal/harness/main.go
@@ -132,6 +132,11 @@ func Main(m *testing.M, req Requirement) int {
 
 	code := m.Run()
 
+	// Before anything is closed: a hook tears down state that outlived the
+	// tests and sweeps what they left behind, through the client rather than
+	// through a session, and a hook that fails fails the run.
+	code = exitCodeAfterHooks(code, runExitHooks())
+
 	// While the sessions are still alive, so a session line can say what it
 	// served and whether its dispatch was ever observed.
 	flushRunRecords()


### PR DESCRIPTION
Step S10 of the e2e rebuild (issue 704): `test/e2e/internal/fixture`, the library every new test builds its GitLab objects with, tagged e2e with an untagged `doc.go`.

Builders go through client-go and register their undo on `Env.Defer`: project, group and subgroup, branch, commit, merge request (waiting until it leaves the preparing states), issue, label, milestone, user, personal access token, SSH key, PNG, CI YAML, and pipeline, which skips with a reason when no runner is registered and fails on timeout naming the last status, unlike the old suite's wait. The shared read-only `World` is built once per process in a group of its own and torn down through `harness.AtExit`, which re-reads every mutable field, compares the digest with the one taken at build time, and fails the run naming each field a test changed; a build that fails halfway still has its group removed.

One `InternalGitLabURL` replaces the three resolvers the old suite kept, `DockerRunnerID` replaces its two copies of the runner lookup, and the per-consumer seed accessors are keyed exactly as `setup-gitlab.sh` spells the slots. The orphan sweep is scoped to this process's run id and fails the run only for a leftover it could not delete, since GitLab's own delayed deletion can leave a marked object listable for a moment. The GitLab behavior the old suite learned the hard way is ported with its comments: create retries, the two-step permanent delete, the Sidekiq drain, the readiness waits and the GitLab 19 facts; the retry classification reads client-go's structured error rather than matching status codes as text, so a 404 spelled inside an id is no longer retried.

Two harness files outside the step's list are touched, because the fixture package could not reach the client, the probed facts or the run's settings any other way. The package is verified without a GitLab: the pure parts are unit-tested, and the builders compile and vet under the e2e tag on linux, windows and darwin.

The generated counts are refreshed here, at the top of the stack.
