### PR TITLE
test(server): assert what a narrowed read_api token is served, and spell the module path once

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,10 +467,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,275 |     282,263 |
-| Unit tests (`_test.go`)  |       778 |     465,581 |
+| Source (`.go`, non-test) |     1,275 |     282,280 |
+| Unit tests (`_test.go`)  |       778 |     465,606 |
 | End-to-end tests         |       316 |      82,942 |
-| **Total**                | **2,369** | **830,786** |
+| **Total**                | **2,369** | **830,828** |
 
 ### Functions
 
@@ -490,14 +490,14 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.65× more tests than code |
 | Average source file length         |                 ~221 lines |
 | Average test file length           |                 ~598 lines |
-| Comment lines in source            |  56,043 (~19.9% of source) |
+| Comment lines in source            |  56,055 (~19.9% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 8,514 |
+| `if err != nil` checks             | 8,513 |
 | `defer` statements                 | 1,469 |
 | `struct` types defined             | 3,322 |
 | `//nolint` suppressions            |   358 |
@@ -516,14 +516,14 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Record              | File                                    |
 | ------------------- | --------------------------------------- |
 | Longest source file | `cmd/server/main.go`. 4,773 lines       |
-| Longest test file   | `cmd/server/main_test.go`. 10,837 lines |
+| Longest test file   | `cmd/server/main_test.go`. 10,862 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~5,132 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 15,398 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 15,397 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_md_escaping/program.go
+++ b/cmd/audit_md_escaping/program.go
@@ -10,14 +10,13 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/cmd/internal/goprogram"
 )
 
-// modulePath is this repository's module path, trimmed off an import path so a
-// report names a package the way the repository does.
-const modulePath = "github.com/jmrplens/gitlab-mcp-server/v3"
-
-// toolutilPath is the import path of the package that owns the escaping
-// helpers. Resolution keys on the path rather than on the package name so an
-// import alias cannot fool it.
-const toolutilPath = modulePath + "/internal/toolutil"
+// modulePath and toolutilPath are the gates' shared spellings, kept under the
+// names this package reads them by: the path is written once, in
+// [goprogram.ModulePath], so a module move lands in every gate at once.
+const (
+	modulePath   = goprogram.ModulePath
+	toolutilPath = goprogram.ToolutilPath
+)
 
 // program is the loaded, indexed source the audit reasons over.
 type program struct {

--- a/cmd/audit_readonly_graphql/program.go
+++ b/cmd/audit_readonly_graphql/program.go
@@ -13,10 +13,11 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/cmd/internal/graphqldocs"
 )
 
-// toolutilPath is the import path of the package that owns ActionSpec, the
-// route constructors, and the shared GraphQL executors. Resolution keys on the
-// path rather than on the package name so an import alias cannot fool it.
-const toolutilPath = "github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+// toolutilPath is the gates' shared spelling of the package that owns
+// ActionSpec, the route constructors and the shared GraphQL executors, kept
+// under the name this package reads it by: the path is written once, in
+// [goprogram.ToolutilPath], so a module move lands in every gate at once.
+const toolutilPath = goprogram.ToolutilPath
 
 // program is the loaded, indexed source the audit reasons over.
 type program struct {

--- a/cmd/internal/goprogram/load.go
+++ b/cmd/internal/goprogram/load.go
@@ -7,6 +7,23 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+// ModulePath is this repository's module path, the prefix every gate trims off
+// an import path so a report names a package the way the repository does, and
+// the prefix it resolves the shared packages under.
+//
+// It is spelled here once. Two gates used to carry their own copy, one built
+// from a module constant and one written out in full, and a module path that
+// moves (it did, at v3) is a change that has to land in every copy at once or
+// a gate goes on resolving a package that no longer exists.
+const ModulePath = "github.com/jmrplens/gitlab-mcp-server/v3"
+
+// ToolutilPath is the import path of the package that owns the escaping
+// helpers, ActionSpec, the route constructors and the shared GraphQL
+// executors: the one package every gate resolves calls into. Resolution keys
+// on the path rather than on the package name so an import alias cannot fool
+// it.
+const ToolutilPath = ModulePath + "/internal/toolutil"
+
 // LoadMode is what the gates need from the loader: syntax to walk, types so an
 // identifier resolves to the object it names and a constant expression folds to
 // the one string it denotes, and imports so an object has one identity across

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2302,21 +2302,46 @@ func TestCreateServer_ToolManifestRoutesAreServerScoped(t *testing.T) {
 // TestCreateServer_FilteringModes verifies that createServer exercises the
 // request-scoped scope filtering and safe-mode wrapping branches used by HTTP
 // server-pool entries.
+//
+// The read_api half asserts what a read_api token is actually served, built
+// the way both transports build it: the scopes are narrowed into the
+// configuration first, by gitlabclient.NarrowToTokenScope, which the HTTP pool
+// applies per entry and stdio once at startup, and createServer then builds
+// the read-only catalog that configuration names (ADR-0018). createServer
+// narrows nothing on its own, so a configuration handed to it with read_api
+// and no narrowing keeps every write tool, and that is the control below.
+//
+// This test used to look for gitlab_create_project on an unnarrowed server, a
+// name nothing registers, so the loop matched nothing and the test passed
+// whatever the server did. Both halves of the premise were wrong, and the
+// never-registered name is what kept either from being noticed.
 func TestCreateServer_FilteringModes(t *testing.T) {
 	client := newMockGitLabClient(t)
 
-	readAPIServer := mustCreateServer(t, client, &config.ServerConfig{
+	readAPICfg := &config.ServerConfig{
+		ToolSurface: config.ToolSurfaceIndividual,
+		TokenScopes: []string{"read_api"},
+	}
+	if !gitlabclient.NarrowToTokenScope(readAPICfg) {
+		t.Fatal("NarrowToTokenScope did not narrow a read_api token, so the assertions below would be about the wrong configuration")
+	}
+	readAPINames := listedToolNames(t, client, readAPICfg)
+	if _, listed := readAPINames["gitlab_project_create"]; listed {
+		t.Error("a narrowed read_api configuration lists gitlab_project_create, the mutating project creation tool")
+	}
+	if _, listed := readAPINames["gitlab_project_get"]; !listed {
+		t.Error("a narrowed read_api configuration does not list gitlab_project_get, so the absence above proves nothing")
+	}
+
+	// The control: the same scopes with no narrowing keep the write tool,
+	// which is what says the removal above came from the narrowing and not
+	// from a name that was never registered.
+	unnarrowed := listedToolNames(t, client, &config.ServerConfig{
 		ToolSurface: config.ToolSurfaceIndividual,
 		TokenScopes: []string{"read_api"},
 	})
-	readAPITools, err := listRegisteredTools(readAPIServer, "read-api-filter-test")
-	if err != nil {
-		t.Fatalf("list read-api tools: %v", err)
-	}
-	for _, tool := range readAPITools {
-		if tool.Name == "gitlab_create_project" {
-			t.Fatal("read_api scope should remove mutating project creation tool")
-		}
+	if _, listed := unnarrowed["gitlab_project_create"]; !listed {
+		t.Error("an unnarrowed read_api configuration does not list gitlab_project_create either, so the removal proves nothing")
 	}
 
 	safeModeServer := mustCreateServer(t, client, &config.ServerConfig{ToolSurface: config.ToolSurfaceIndividual, SafeMode: true})


### PR DESCRIPTION
Two of the small items from the 3.1.0 triage, each closing its issue on merge.

**The filtering-mode test passed for the wrong reason, twice over.** It looked for `gitlab_create_project` on a server built straight from a `read_api` configuration. Nothing registers that name, so the loop matched nothing. And the premise underneath was wrong as well: `createServer` narrows nothing on its own. The HTTP pool narrows per entry and stdio once at startup, both through `NarrowToTokenScope`, and only then build the read-only catalog (ADR-0018). Corrected to the declared name alone, the test failed, which is what showed the second half. It now narrows the configuration the way both transports do, asserts `gitlab_project_create` is gone and `gitlab_project_get` is there, and keeps the unnarrowed configuration as the control that says the removal came from the narrowing.

**One import path, two spellings.** The two gates that resolve `internal/toolutil` each carried their own copy of its path, one built from a module constant and one written out in full. A module path that moves, and it did at v3, has to land in every copy at once or a gate goes on resolving a package that no longer exists. The path is now spelled once, `goprogram.ModulePath` and `goprogram.ToolutilPath` in `cmd/internal/goprogram`, and both gates read it from there under the names they already use, so no call site changes.

Closes #675
Closes #636
