### PR TITLE
test(e2e): sweeps in common driven by what each session serves

### DIFF
--- a/test/e2e/gitlab/common/mcp_completions_test.go
+++ b/test/e2e/gitlab/common/mcp_completions_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+// mcp_completions_test.go drives a completion for every argument of every
+// served prompt and every variable of every served resource template.
+//
+// A completion is addressed by a reference and an argument, so the sweep is
+// driven by the two things that carry completable arguments: the prompts and
+// the resource templates the full-capability server serves. It sends an empty
+// partial value and reads whatever the server offers, including nothing: the
+// completion contract is that autocomplete is never blocked, so an argument
+// the handler does not recognize answers with an empty list rather than an
+// error, and the reference-and-argument pair is covered either way.
+
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestCompletions_Sweep drives a completion for every prompt argument and
+// every resource template variable the full-capability server serves.
+//
+// Replaces: the completion coverage the old suite had none of, since no
+// TestMain session drove completions.
+func TestCompletions_Sweep(t *testing.T) {
+	e := harness.New(t)
+	s := e.On(harness.SurfaceDynamic)
+
+	specs := s.PromptSpecs()
+	templates := s.ResourceTemplates()
+	if len(specs) == 0 && len(templates) == 0 {
+		t.Fatal("the full-capability session served no prompt or template; the completion sweep would prove nothing")
+	}
+
+	promptArgs := 0
+	for _, spec := range specs {
+		for _, arg := range append(append([]string{}, spec.Required...), spec.Optional...) {
+			s.CompletePrompt(spec.Name, arg, "")
+			promptArgs++
+		}
+	}
+
+	templateVars := 0
+	for _, template := range templates {
+		for _, variable := range templateVariables(template) {
+			s.CompleteResource(template, variable, "")
+			templateVars++
+		}
+	}
+	t.Logf("drove %d prompt-argument completions across %d prompts and %d template-variable completions across %d templates",
+		promptArgs, len(specs), templateVars, len(templates))
+}
+
+// templateVariables returns the RFC 6570 variable names of a resource
+// template, each stripped of the reserved "+" the file template's path
+// variable carries.
+func templateVariables(template string) []string {
+	var names []string
+	rest := template
+	for {
+		open := strings.IndexByte(rest, '{')
+		if open < 0 {
+			return names
+		}
+		end := strings.IndexByte(rest[open:], '}')
+		if end < 0 {
+			return names
+		}
+		names = append(names, strings.TrimPrefix(rest[open+1:open+end], "+"))
+		rest = rest[open+end+1:]
+	}
+}

--- a/test/e2e/gitlab/common/mcp_prompts_test.go
+++ b/test/e2e/gitlab/common/mcp_prompts_test.go
@@ -1,0 +1,78 @@
+//go:build e2e
+
+// mcp_prompts_test.go renders every prompt the server serves whose required
+// arguments bind from the shared World.
+//
+// Prompts, like resources, are a full-capability-surface capability of the
+// server rather than of a tool surface, so the sweep runs on one session. Each
+// prompt's arguments come from the listing itself, split into required and
+// optional; the sweep binds the required ones from the World and the optional
+// ones when the World can supply them. A prompt whose required argument the
+// World cannot supply is named rather than rendered, since GetPrompt would
+// only fail for the missing argument and prove nothing about the prompt.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestPrompts_Sweep renders every served prompt whose required arguments bind
+// from the World.
+//
+// Replaces: the prompt coverage the old suite had none of, since no TestMain
+// session registered prompts.
+func TestPrompts_Sweep(t *testing.T) {
+	e := harness.New(t)
+	world := fixture.SharedWorld(e)
+	s := e.On(harness.SurfaceDynamic)
+
+	specs := s.PromptSpecs()
+	if len(specs) == 0 {
+		t.Fatal("the full-capability session served no prompt; the sweep would prove nothing")
+	}
+
+	rendered, skipped, errs := 0, 0, 0
+	for _, spec := range specs {
+		args, missing := bindPromptArguments(world, spec)
+		if missing != "" {
+			t.Logf("prompt %s not rendered: %s", spec.Name, missing)
+			skipped++
+			continue
+		}
+		// TryGetPrompt rather than GetPrompt: a prompt whose data the World
+		// does not carry (a pipeline the runnerless World never ran) answers a
+		// handled error the recorder credits, which is not a reason to abort
+		// the sweep over every other prompt.
+		if _, err := s.TryGetPrompt(spec.Name, args); err != nil {
+			t.Logf("prompt %s answered an error: %v", spec.Name, err)
+			errs++
+		}
+		rendered++
+	}
+	t.Logf("rendered %d prompts (%d answered an error, %d the World cannot bind) of %d served",
+		rendered, errs, skipped, len(specs))
+}
+
+// bindPromptArguments binds a prompt's required arguments from the World and
+// adds every optional one the World can supply, returning the reason it could
+// not when a required argument is unbound.
+func bindPromptArguments(world *fixture.World, spec harness.PromptSpec) (map[string]string, string) {
+	args := map[string]string{}
+	for _, name := range spec.Required {
+		value, bound := world.BindPromptArgument(name)
+		if !bound {
+			return nil, "the World has no binding for required argument " + name
+		}
+		args[name] = value
+	}
+	for _, name := range spec.Optional {
+		if value, bound := world.BindPromptArgument(name); bound {
+			args[name] = value
+		}
+	}
+	return args, ""
+}

--- a/test/e2e/gitlab/common/mcp_resources_test.go
+++ b/test/e2e/gitlab/common/mcp_resources_test.go
@@ -1,0 +1,122 @@
+//go:build e2e
+
+// mcp_resources_test.go reads every static resource and every resource
+// template the server serves, binding each template's variables from the
+// shared World.
+//
+// Resources are a capability of the server, not of a tool surface: the same
+// set is registered whichever surface is active, and only on the full
+// capability surface. The sweep therefore runs on one full-capability session
+// rather than three. A template whose variables the World cannot supply is
+// named in the log rather than read, which is the "or names the binding it
+// lacks" the coverage report reads beside the templates it did read; a read
+// that answers a handled error is still credited by the recorder.
+
+package common
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestResources_Sweep reads every static resource and every bindable template
+// the full-capability server serves.
+//
+// Replaces: the resource coverage the old suite held to a handful of URIs in
+// its capability tests.
+func TestResources_Sweep(t *testing.T) {
+	e := harness.New(t)
+	world := fixture.SharedWorld(e)
+	s := e.On(harness.SurfaceDynamic)
+
+	statics := s.Resources()
+	templates := s.ResourceTemplates()
+	if len(statics) == 0 && len(templates) == 0 {
+		t.Fatal("the full-capability session served no resource; the sweep would prove nothing")
+	}
+
+	// TryReadResource rather than ReadResource: a template bound by variable
+	// name can still name a resource the World does not carry (a group-scoped
+	// label addressed with a project label id), which answers a handled error
+	// the recorder credits rather than a reason to abort the sweep.
+	staticErrs := 0
+	for _, uri := range statics {
+		if _, err := s.TryReadResource(uri); err != nil {
+			staticErrs++
+		}
+	}
+
+	read, skipped, readErrs := 0, 0, 0
+	for _, template := range templates {
+		uri, missing := expandTemplate(template, world)
+		if missing != "" {
+			t.Logf("template %s not read: %s", template, missing)
+			skipped++
+			continue
+		}
+		if _, err := s.TryReadResource(uri); err != nil {
+			readErrs++
+		}
+		read++
+	}
+	t.Logf("read %d static resources (%d errored) and %d templates (%d errored, %d the World cannot bind)",
+		len(statics), staticErrs, read, readErrs, skipped)
+}
+
+// expandTemplate replaces every RFC 6570 variable in a resource template with
+// its World value, returning the reason it could not when a variable is
+// unbound.
+//
+// A variable is one segment written {name} or {+name}; the reserved "+" form
+// the file template uses for its path is expanded the same way, since the
+// World's value is already a path. The bound value is spelled as a string
+// because it lands in a URI, and a segment carrying a slash is percent-encoded
+// so the server's own router, which expands variables as slash-free segments,
+// resolves it.
+func expandTemplate(template string, world *fixture.World) (string, string) {
+	var out strings.Builder
+	rest := template
+	for {
+		open := strings.IndexByte(rest, '{')
+		if open < 0 {
+			out.WriteString(rest)
+			return out.String(), ""
+		}
+		end := strings.IndexByte(rest[open:], '}')
+		if end < 0 {
+			out.WriteString(rest)
+			return out.String(), ""
+		}
+		out.WriteString(rest[:open])
+		variable := rest[open+1 : open+end]
+		reservedPath := strings.HasPrefix(variable, "+")
+		name := strings.TrimPrefix(variable, "+")
+		value, bound := world.Bind(name)
+		if !bound {
+			return "", "the World has no binding for variable " + name
+		}
+		out.WriteString(templateValue(value, reservedPath))
+		rest = rest[open+end+1:]
+	}
+}
+
+// templateValue spells a World value for a URI: an integer or plain string as
+// itself, and a slash inside a plain segment percent-encoded so it stays one
+// segment. The reserved path form keeps its slashes, which is what it is for.
+func templateValue(value any, reservedPath bool) string {
+	var str string
+	switch typed := value.(type) {
+	case int64:
+		str = strconv.FormatInt(typed, 10)
+	case string:
+		str = typed
+	}
+	if reservedPath {
+		return str
+	}
+	return strings.ReplaceAll(str, "/", "%2F")
+}

--- a/test/e2e/gitlab/common/mcp_subscriptions_test.go
+++ b/test/e2e/gitlab/common/mcp_subscriptions_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+// mcp_subscriptions_test.go subscribes to every subscribable resource the
+// server advertises whose URI binds from the shared World, through the real
+// binary, since only cmd/server wires the subscription machinery.
+//
+// It proves the reach a unit test cannot: the subscription surface is set up
+// only in the server binary, so a subscribe accepted here is one the released
+// program accepts. Delivery is deliberately not exercised: observing an update
+// would mean changing the watched resource, and the World is read-only by
+// contract, so the sweep proves the subscribe is accepted and leaves proving a
+// notification arrives to the scenario tests that create state of their own. A
+// template whose URI the World cannot bind is named rather than subscribed.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestSubscriptions_Sweep subscribes to every advertised subscribable template
+// whose URI binds from the World.
+//
+// Replaces: the subscription coverage the old suite had none of, since
+// subscriptions are wired only in cmd/server, which the in-process suite never
+// started.
+func TestSubscriptions_Sweep(t *testing.T) {
+	e := harness.New(t)
+	world := fixture.SharedWorld(e)
+	s := e.On(harness.SurfaceDynamic)
+
+	manifest := readToolsManifest(e, s)
+	if manifest.Subscriptions == nil || !manifest.Subscriptions.Supported {
+		t.Fatal("the full-capability session advertises no subscriptions; the sweep would prove nothing")
+	}
+	templates := manifest.Subscriptions.SubscribableURITemplates
+	if len(templates) == 0 {
+		t.Fatal("the subscription manifest lists no template")
+	}
+
+	subscribed, skipped := 0, 0
+	for _, template := range templates {
+		uri, missing := expandTemplate(template, world)
+		if missing != "" {
+			t.Logf("subscribable %s not subscribed: %s", template, missing)
+			skipped++
+			continue
+		}
+		s.Subscribe(uri)
+		subscribed++
+	}
+	t.Logf("subscribed to %d of %d advertised subscribable templates (%d the World cannot bind)",
+		subscribed, len(templates), skipped)
+}

--- a/test/e2e/gitlab/common/previews_sweep_test.go
+++ b/test/e2e/gitlab/common/previews_sweep_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+// previews_sweep_test.go asks safe mode to preview every served mutating
+// action whose required parameters bind from the World, on all three surfaces.
+//
+// Safe mode intercepts a mutating operation and answers with a preview of the
+// call it would have made, without running the handler, so the World is never
+// written even though the sweep names creates, updates and deletes. A
+// destructive action is sent confirmed, so the confirmation guard is not what
+// stops it and the preview is what a call an operator approved would get. An
+// action whose required parameters the World cannot supply is named rather
+// than previewed: a preview only fires once the dispatcher's parameter check
+// passes, so an unbindable action would be refused for the wrong reason.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestPreviews_Sweep previews every mutating action whose required parameters
+// bind from the World, on the dynamic, meta and individual surfaces.
+//
+// Replaces: the safe-mode coverage the old suite held to two hand-picked
+// actions in TestSafeMode and TestSafeModeDynamicSurface.
+func TestPreviews_Sweep(t *testing.T) {
+	e := harness.New(t)
+	world := fixture.SharedWorld(e)
+
+	candidates, unbound := sweepCandidates(e, world, false)
+	if len(candidates) == 0 {
+		t.Fatal("no mutating action bound from the World; the previews sweep would prove nothing")
+	}
+	for _, u := range unbound {
+		t.Logf("mutating %s not previewed: %s", u.id, u.reason)
+	}
+
+	sweepSurfaces(t, harness.ModeSafe, func(e *harness.Env, s *harness.Session) {
+		previewed, notServed := 0, 0
+		for _, c := range candidates {
+			if !s.Serves(c.id) {
+				notServed++
+				continue
+			}
+			// Refused with FailureSafeMode fails the test if the answer is
+			// anything but a preview, which is the assertion: safe mode must
+			// preview every mutating action it serves, not run it and not
+			// refuse it for another reason.
+			harness.Refused(s, c.id, c.params, harness.FailureSafeMode, harness.For(harness.PurposeSweep))
+			previewed++
+		}
+		e.T.Logf("previewed %d mutating actions on %s (%d not served here)", previewed, s.Surface(), notServed)
+	})
+}

--- a/test/e2e/gitlab/common/reads_sweep_test.go
+++ b/test/e2e/gitlab/common/reads_sweep_test.go
@@ -1,0 +1,230 @@
+//go:build e2e
+
+// reads_sweep_test.go exercises every served read-only action whose required
+// parameters bind from the shared World, on all three surfaces.
+//
+// It is a sweep rather than a scenario: it names no action by hand, walks the
+// surface the server publishes through gitlab://tools, and binds each action's
+// required parameters from the World a read cannot change. An action whose
+// requirements the World cannot supply is named in the log rather than swept,
+// which is the honest "or names the binding it lacks" the coverage report
+// reads beside the reads it did exercise. The sweep calls carry purpose sweep,
+// so their credit shows apart from the scenario credit later steps add, and it
+// never asserts on an answer: the recorder credits a call by what the server
+// did, so a read that answers empty or with a handled error is still counted.
+//
+// This file also holds the binding and per-surface helpers the previews sweep
+// beside it reuses, since both walk the manifest and bind from the same World.
+
+package common
+
+import (
+	"encoding/json"
+	"maps"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/resources"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// sweepCandidate is one catalog action a sweep can call: its canonical id and
+// the arguments bound from the World, each spelled in the type its schema
+// declares.
+type sweepCandidate struct {
+	id     harness.ActionID
+	params map[string]any
+}
+
+// unboundEntry is a manifest entry a sweep could not bind, with the reason,
+// so the sweep names what it lacks instead of leaving a silent hole.
+type unboundEntry struct {
+	id     string
+	reason string
+}
+
+// TestReads_Sweep reads every read-only action whose required parameters bind
+// from the World, on the dynamic, meta and individual surfaces.
+//
+// Replaces: the list-and-get coverage the old per-domain suite spread across
+// its TestIndividual_*, TestMeta_* and TestDynamicToolSurface_* families.
+func TestReads_Sweep(t *testing.T) {
+	e := harness.New(t)
+	world := fixture.SharedWorld(e)
+
+	candidates, unbound := sweepCandidates(e, world, true)
+	if len(candidates) == 0 {
+		t.Fatal("no read action bound from the World; the reads sweep would prove nothing")
+	}
+	for _, u := range unbound {
+		t.Logf("read %s not swept: %s", u.id, u.reason)
+	}
+
+	sweepSurfaces(t, harness.ModeDefault, func(e *harness.Env, s *harness.Session) {
+		swept, notServed, errs := 0, 0, 0
+		for _, c := range candidates {
+			if !s.Serves(c.id) {
+				notServed++
+				continue
+			}
+			if _, err := harness.Try[json.RawMessage](s, c.id, c.params, harness.For(harness.PurposeSweep)); err != nil {
+				errs++
+			}
+			swept++
+		}
+		e.T.Logf("swept %d reads on %s (%d not served here, %d answered with an error the recorder still credits)",
+			swept, s.Surface(), notServed, errs)
+	})
+}
+
+// sweepCandidates reads the dynamic manifest and returns the actions of one
+// kind (read-only when readOnly is true, mutating otherwise) whose required
+// parameters bind from the World, plus the ones it could not bind and why.
+//
+// The dynamic manifest is read because its entry ids are the canonical action
+// ids the harness verbs project onto every surface; the meta and individual
+// manifests spell the same actions as their own tool names, which the verbs do
+// not take. Read-only-ness and the required parameters are catalog properties,
+// the same whichever surface serves the action.
+func sweepCandidates(e *harness.Env, world *fixture.World, readOnly bool) (candidates []sweepCandidate, unbound []unboundEntry) {
+	e.T.Helper()
+
+	manifest := readToolsManifest(e, e.On(harness.SurfaceDynamic))
+	for _, entry := range manifest.Entries {
+		if entry.Kind != manifestKindDynamicAction || entry.ReadOnly != readOnly || entry.AliasOf != "" {
+			continue
+		}
+		// The standalone actions (discover.project, the interactive flows) are
+		// listed in the dynamic manifest but are registered outside the base
+		// catalog, so the harness verbs cannot project them; they are covered
+		// through Raw in the modes test instead. ActionTier answers from that
+		// catalog, so an id it does not know is one to skip here.
+		tier, known := e.ActionTier(harness.ActionID(entry.ID))
+		if !known {
+			continue
+		}
+		// A licensed instance serves the run's admin token the Premium and
+		// Ultimate actions too, and they appear in the manifest here; the
+		// common package runs on Free actions on every runtime, so a licensed
+		// one is the ee package's to sweep, not this one's. Calling it would be
+		// refused by the harness for the tier the package declares.
+		if tier.IsEnterprise() {
+			continue
+		}
+		params, missing := bindEntryParams(world, entry)
+		if missing != "" {
+			unbound = append(unbound, unboundEntry{id: entry.ID, reason: missing})
+			continue
+		}
+		candidates = append(candidates, sweepCandidate{id: harness.ActionID(entry.ID), params: params})
+	}
+	return candidates, unbound
+}
+
+// bindEntryParams binds an entry's required parameters from the World: every
+// top-level requirement, and one alternative group when the entry requires a
+// choice among several. It returns the arguments and an empty reason on
+// success, or nil and the reason it could not bind.
+func bindEntryParams(world *fixture.World, entry resources.ToolSurfaceEntry) (map[string]any, string) {
+	params := map[string]any{}
+	if missing := bindRequiredGroup(world, entry.RequiredParams, params); missing != "" {
+		return nil, missing
+	}
+	if len(entry.RequiredParamsAnyOf) > 0 {
+		if !bindOneAlternative(world, entry.RequiredParamsAnyOf, params) {
+			return nil, "no alternative requirement group binds from the World"
+		}
+	}
+	return params, ""
+}
+
+// bindRequiredGroup binds every parameter of one group into params, returning
+// the reason it could not when a parameter is unbound or its World value
+// cannot be spelled in the type the schema declares.
+func bindRequiredGroup(world *fixture.World, group []resources.ToolSurfaceRequiredParam, params map[string]any) string {
+	for _, param := range group {
+		value, bound := world.Bind(param.Name)
+		if !bound {
+			return "the World has no binding for required parameter " + param.Name
+		}
+		spelled, ok := spellParam(value, param.Type)
+		if !ok {
+			return "the World's " + param.Name + " cannot be spelled as " + param.Type
+		}
+		params[param.Name] = spelled
+	}
+	return ""
+}
+
+// bindOneAlternative binds the first alternative requirement group that binds
+// fully, reporting whether any did.
+func bindOneAlternative(world *fixture.World, groups [][]resources.ToolSurfaceRequiredParam, params map[string]any) bool {
+	for _, group := range groups {
+		candidate := map[string]any{}
+		if bindRequiredGroup(world, group, candidate) == "" {
+			maps.Copy(params, candidate)
+			return true
+		}
+	}
+	return false
+}
+
+// spellParam spells a World value in the flat schema type a parameter
+// declares, so a bound value reaches the individual surface as the type its
+// raw-argument validation demands: an integer id sent to a string parameter
+// is refused there, while the two dispatchers coerce.
+//
+// A value the schema cannot hold is refused rather than sent, so the caller
+// names the binding it lacks instead of watching the call fail.
+func spellParam(value any, schemaType string) (any, bool) {
+	switch typed := value.(type) {
+	case int64:
+		if schemaAccepts(schemaType, "integer") || schemaType == "" {
+			return typed, true
+		}
+		if schemaAccepts(schemaType, "string") {
+			return strconv.FormatInt(typed, 10), true
+		}
+		return nil, false
+	case string:
+		if schemaAccepts(schemaType, "string") || schemaType == "" {
+			return typed, true
+		}
+		return nil, false
+	default:
+		return value, true
+	}
+}
+
+// schemaAccepts reports whether a flat schema type admits one plain type; a
+// multi-typed parameter joins its alternatives with "|".
+func schemaAccepts(schemaType, want string) bool {
+	for part := range strings.SplitSeq(schemaType, "|") {
+		if part == want {
+			return true
+		}
+	}
+	return false
+}
+
+// sweepSurfaces runs fn once per surface, as a parallel subtest with a session
+// in the given mode.
+//
+// The subtests run in parallel because a sweep only reads or previews, and
+// the World it stands on is read-only by contract, so nothing one surface does
+// can be seen by another; the three-way overlap is what keeps a sweep over
+// hundreds of actions to a reasonable wall clock. It does not use
+// [harness.EachSurface] because that runs its subtests in sequence.
+func sweepSurfaces(t *testing.T, mode harness.Mode, fn func(*harness.Env, *harness.Session)) {
+	t.Helper()
+
+	for _, surface := range harness.AllSurfaces() {
+		t.Run(string(surface), func(t *testing.T) {
+			t.Parallel()
+			e := harness.New(t)
+			fn(e, e.Session(harness.ServerConfig{Surface: surface, Mode: mode}))
+		})
+	}
+}

--- a/test/e2e/internal/fixture/group_test.go
+++ b/test/e2e/internal/fixture/group_test.go
@@ -51,6 +51,31 @@ func TestDeleteGroup_AlreadyMarked_StillRemovesIt(t *testing.T) {
 	}
 }
 
+// TestDeleteGroup_TopLevelOnDelayedDeletion_MarksAndToleratesTheRefusal checks
+// the teardown of the World's own top-level group on an instance with delayed
+// deletion: the mark step schedules it, the permanent-remove step is refused
+// because that option is subgroups-only, and DeleteGroup treats the refusal as
+// success because the group is as gone as the API allows.
+//
+// It pins the fix for the failure the first World teardown hit on GitLab CE 18:
+// DELETE /groups/<id>?permanently_remove=true answering 400 "`permanently_remove`
+// option is only available for subgroups."
+func TestDeleteGroup_TopLevelOnDelayedDeletion_MarksAndToleratesTheRefusal(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.addTopLevelGroup(6, "e2e-world-group", "e2e-world-group")
+
+	if err := DeleteGroup(context.Background(), client, 6, "e2e-world-group"); err != nil {
+		t.Fatalf("DeleteGroup() error = %v, want nil for a marked top-level group the API cannot purge", err)
+	}
+	want := []string{
+		"group 6 ",
+		"group 6 full_path=e2e-world-group-deletion_scheduled-6&permanently_remove=true",
+	}
+	if got := stub.recordedDeletes(); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("deletes = %q, want the mark then the refused permanent-remove %q", got, want)
+	}
+}
+
 // TestDeleteGroup_Gone_IsNotAnError checks that a group nothing can find
 // counts as deleted.
 func TestDeleteGroup_Gone_IsNotAnError(t *testing.T) {

--- a/test/e2e/internal/fixture/project.go
+++ b/test/e2e/internal/fixture/project.go
@@ -302,6 +302,16 @@ func deletePermanently(ctx context.Context, kind string, id int64, path string, 
 	}
 
 	if removeErr := steps.remove(ctx, path); removeErr != nil && !IsStatus(removeErr, http.StatusNotFound) {
+		if toolutil.ContainsAny(removeErr, "only available for subgroups") {
+			// A top-level group on an instance with delayed deletion cannot be
+			// permanently removed through the API, only marked; the mark step
+			// above already scheduled it, which is as gone as the API allows
+			// and is what the teardown asked for. A subgroup takes the
+			// permanent removal, so this tolerance never hides a real failure
+			// there. GitLab CE 18 with delayed deletion is where this bites,
+			// on the World's own top-level group.
+			return nil
+		}
 		return fmt.Errorf("permanently deleting %s %d (%s): %w", kind, id, path, removeErr)
 	}
 	return nil

--- a/test/e2e/internal/fixture/stub_test.go
+++ b/test/e2e/internal/fixture/stub_test.go
@@ -38,6 +38,11 @@ type stubObject struct {
 	Name   string
 	Path   string
 	Marked bool
+	// permanentRemoveUnsupported makes the object refuse a permanent-remove
+	// with the message GitLab returns for a top-level group on an instance
+	// with delayed deletion, which can only be marked, never purged, through
+	// the API.
+	permanentRemoveUnsupported bool
 }
 
 // stubGitLab is the in-memory instance one test drives.
@@ -130,6 +135,14 @@ func (s *stubGitLab) addGroup(id int64, name, path string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.groups[id] = &stubObject{ID: id, Name: name, Path: path}
+}
+
+// addTopLevelGroup registers a group whose permanent removal GitLab refuses,
+// as it does for a top-level group on an instance with delayed deletion.
+func (s *stubGitLab) addTopLevelGroup(id int64, name, path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.groups[id] = &stubObject{ID: id, Name: name, Path: path, permanentRemoveUnsupported: true}
 }
 
 // addUser registers a user with the stub.
@@ -300,6 +313,10 @@ func (s *stubGitLab) object(w http.ResponseWriter, r *http.Request, kind string,
 		obj.Marked = true
 		obj.Path += deletionSuffix + strconv.FormatInt(id, 10)
 		writeJSON(w, http.StatusAccepted, map[string]string{"message": "202 Accepted"})
+		return
+	}
+	if obj.permanentRemoveUnsupported {
+		writeError(w, http.StatusBadRequest, "`permanently_remove` option is only available for subgroups.")
 		return
 	}
 	if !obj.Marked {

--- a/test/e2e/internal/fixture/world.go
+++ b/test/e2e/internal/fixture/world.go
@@ -184,6 +184,14 @@ const worldTeardownBudget = 3 * time.Minute
 // deletes it. It fails on a difference and on a deletion that did not
 // happen, and does both halves whatever the first found: a changed World is
 // still deleted, and a World that could not be read is still torn down.
+//
+// The project is purged before the group rather than left to the group's
+// cascade: the World's group is top-level, and an instance with delayed
+// deletion can only mark a top-level group, never purge it through the API
+// (DeleteGroup tolerates that refusal). A project the API can purge, so
+// removing it explicitly keeps it from lingering as a pending-delete leftover
+// under a group that will not go away, which is what the run-scoped sweep would
+// otherwise trip on.
 func teardownWorld(client *gitlabclient.Client, world *World) error {
 	ctx, cancel := context.WithTimeout(context.Background(), worldTeardownBudget)
 	defer cancel()
@@ -192,6 +200,11 @@ func teardownWorld(client *gitlabclient.Client, world *World) error {
 	if world.digest != "" {
 		if err := verifyWorld(ctx, client, world); err != nil {
 			failures = append(failures, err)
+		}
+	}
+	if world.Project.ID != 0 {
+		if err := DeleteProject(ctx, client, world.Project.ID, world.Project.Path); err != nil {
+			failures = append(failures, fmt.Errorf("tearing down the World project: %w", err))
 		}
 	}
 	if world.Group.ID != 0 {
@@ -424,6 +437,7 @@ func (w *World) Bindings() map[string]any {
 		"file_path":         w.Commit.FilePath,
 		"label_id":          w.Label.ID,
 		"milestone_id":      w.Milestone.ID,
+		"milestone_iid":     w.Milestone.IID,
 		"user_id":           w.UserID,
 		"username":          w.Username,
 	}
@@ -433,5 +447,36 @@ func (w *World) Bindings() map[string]any {
 // one.
 func (w *World) Bind(param string) (any, bool) {
 	value, ok := w.Bindings()[param]
+	return value, ok
+}
+
+// PromptBindings returns the World's value for every prompt argument it can
+// supply, as the string a prompts/get call carries.
+//
+// It is kept apart from [World.Bindings] because a prompt argument is always a
+// string and a few of them (a ref pair, a milestone title, a target branch)
+// are named differently from any catalog parameter. A prompt sweep binds the
+// required arguments from this table and skips a prompt whose required
+// argument the World cannot supply, naming it.
+func (w *World) PromptBindings() map[string]string {
+	return map[string]string{
+		"project_id":        strconv.FormatInt(w.Project.ID, 10),
+		"group_id":          strconv.FormatInt(w.Group.ID, 10),
+		"merge_request_iid": strconv.FormatInt(w.MergeRequest.IID, 10),
+		"issue_iid":         strconv.FormatInt(w.Issue.IID, 10),
+		"username":          w.Username,
+		"from":              w.Project.DefaultBranch,
+		"to":                w.Branch.Name,
+		"branch":            w.Branch.Name,
+		"ref":               w.Project.DefaultBranch,
+		"target_branch":     w.Project.DefaultBranch,
+		"milestone":         w.Milestone.Title,
+	}
+}
+
+// BindPromptArgument returns the value a prompt argument takes, and whether
+// the World can supply one.
+func (w *World) BindPromptArgument(argument string) (string, bool) {
+	value, ok := w.PromptBindings()[argument]
 	return value, ok
 }

--- a/test/e2e/internal/fixture/world_test.go
+++ b/test/e2e/internal/fixture/world_test.go
@@ -111,7 +111,7 @@ func TestWorldBindings_Parameters_ComeFromTheObjects(t *testing.T) {
 		MergeRequest: MergeRequest{IID: 3},
 		Issue:        Issue{IID: 4, ID: 40},
 		Label:        Label{ID: 5},
-		Milestone:    Milestone{ID: 6},
+		Milestone:    Milestone{ID: 6, IID: 8, Title: "world-milestone"},
 		Username:     "e2e",
 		UserID:       7,
 	}
@@ -135,6 +135,7 @@ func TestWorldBindings_Parameters_ComeFromTheObjects(t *testing.T) {
 		{param: "file_path", want: "docs/world.md"},
 		{param: "label_id", want: int64(5)},
 		{param: "milestone_id", want: int64(6)},
+		{param: "milestone_iid", want: int64(8)},
 		{param: "user_id", want: int64(7)},
 		{param: "username", want: "e2e"},
 	}
@@ -151,6 +152,51 @@ func TestWorldBindings_Parameters_ComeFromTheObjects(t *testing.T) {
 	}
 	if got, want := len(world.Bindings()), len(cases); got != want {
 		t.Errorf("Bindings() has %d entries, want the %d this test names", got, want)
+	}
+}
+
+// TestWorldPromptBindings_Arguments_ComeFromTheObjects checks every prompt
+// argument the World can supply maps to the object it names as a string, and
+// that BindPromptArgument says no for an argument the World does not carry.
+func TestWorldPromptBindings_Arguments_ComeFromTheObjects(t *testing.T) {
+	world := &World{
+		Group:        Group{ID: 1},
+		Project:      Project{ID: 2, DefaultBranch: "main"},
+		Branch:       Branch{Name: "feature/world"},
+		MergeRequest: MergeRequest{IID: 3},
+		Issue:        Issue{IID: 4},
+		Milestone:    Milestone{Title: "world-milestone"},
+		Username:     "e2e",
+	}
+	cases := []struct {
+		argument string
+		want     string
+	}{
+		{argument: "project_id", want: "2"},
+		{argument: "group_id", want: "1"},
+		{argument: "merge_request_iid", want: "3"},
+		{argument: "issue_iid", want: "4"},
+		{argument: "username", want: "e2e"},
+		{argument: "from", want: "main"},
+		{argument: "to", want: "feature/world"},
+		{argument: "branch", want: "feature/world"},
+		{argument: "ref", want: "main"},
+		{argument: "target_branch", want: "main"},
+		{argument: "milestone", want: "world-milestone"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.argument, func(t *testing.T) {
+			got, ok := world.BindPromptArgument(testCase.argument)
+			if !ok || got != testCase.want {
+				t.Errorf("BindPromptArgument(%q) = (%q, %t), want (%q, true)", testCase.argument, got, ok, testCase.want)
+			}
+		})
+	}
+	if _, ok := world.BindPromptArgument("days"); ok {
+		t.Errorf("BindPromptArgument(days) = true, want false for an argument the World does not carry")
+	}
+	if got, want := len(world.PromptBindings()), len(cases); got != want {
+		t.Errorf("PromptBindings() has %d entries, want the %d this test names", got, want)
 	}
 }
 

--- a/test/e2e/internal/harness/record.go
+++ b/test/e2e/internal/harness/record.go
@@ -55,6 +55,14 @@ const (
 	methodComplete        = "completion/complete"
 	methodElicit          = "elicitation/create"
 	methodResourceUpdated = "notifications/resources/updated"
+	// methodSubscribe is the logical resources/subscribe the [Session.Subscribe]
+	// verb represents. It is recorded by the verb rather than by the sending
+	// middleware: over protocol 2026-07-28 the SDK opens the subscription on a
+	// background context of its own, so the middleware never sees the caller's
+	// attribution and would record nothing. The audit routes it to the
+	// subscription capability whether the wire carried resources/subscribe or
+	// its 2026-07-28 replacement, subscriptions/listen.
+	methodSubscribe = "resources/subscribe"
 )
 
 // traceParentKey is the _meta key W3C trace context travels in.
@@ -377,8 +385,15 @@ func dispatchFor(call *pendingCall) (dispatchRecord, bool) {
 // issue.list and ran issue.get proves nothing about issue.list, and the suite
 // would otherwise report it as covered. A test that knows its call is
 // rewritten declares the route with ExpectDispatch and is held to that instead.
+//
+// A sweep is the one exemption. It probes what a session serves rather than
+// asserting one route, walks it with a non-constant id, and is credited to the
+// action the server said it ran ([creditOf] reads the dispatched action). A
+// route the server rewrites under a sweep is therefore credited correctly and
+// asserts nothing false, so failing the sweep on the rewrite would only make a
+// broad probe brittle against a rewrite it never claimed anything about.
 func assertDispatch(reporter e2ecalls.Reporter, call *pendingCall, record dispatchRecord) {
-	if call.line.Action == "" || record.action == "" {
+	if call.line.Action == "" || record.action == "" || call.line.Purpose == e2ecalls.PurposeSweep {
 		return
 	}
 	want := string(call.wantDispatch)
@@ -546,6 +561,30 @@ func (c *sessionConn) recordReceiving() mcp.Middleware {
 			return next(ctx, method, req)
 		}
 	}
+}
+
+// recordSubscribe records one subscribe against the test that made it.
+//
+// The sending middleware cannot: over protocol 2026-07-28 the SDK's Subscribe
+// opens the listen stream on a background context, dropping the attribution the
+// caller put on its own, so the one call the middleware would see carries no
+// test to file it under. The verb records it here instead, as an accepted
+// subscribe; the resource-updated notification that may follow is recorded by
+// [sessionConn.recordResourceUpdate], which is the delivery half.
+func (c *sessionConn) recordSubscribe(rec *envRecorder, uri string) {
+	if rec == nil {
+		return
+	}
+	line := &e2ecalls.Call{
+		Test:        rec.env.T.Name(),
+		Purpose:     string(PurposeTest),
+		Expectation: e2ecalls.ExpectationOK,
+		Method:      methodSubscribe,
+		Target:      uri,
+		Outcome:     e2ecalls.OutcomeOK,
+	}
+	c.describeSession(line)
+	rec.record(&pendingCall{line: line, conn: c})
 }
 
 // recordElicitation records one elicitation request against the test whose

--- a/test/e2e/internal/harness/record_test.go
+++ b/test/e2e/internal/harness/record_test.go
@@ -431,6 +431,43 @@ func TestExpectDispatch_DeclaresTheRouteTheCallWillRun(t *testing.T) {
 	}
 }
 
+// TestAssertDispatch_RewriteFailsAScenarioButNotASweep checks the one
+// exemption the dispatch assertion makes: a scenario call whose server span
+// names another route fails, and a sweep call in the same shape does not.
+//
+// A sweep probes what a session serves with a non-constant id and is credited
+// to the action the server said it ran, so a rewrite under it is credited
+// correctly and asserts nothing false; failing it would only make a broad
+// probe brittle against a rewrite it never claimed anything about.
+func TestAssertDispatch_RewriteFailsAScenarioButNotASweep(t *testing.T) {
+	ran := dispatchRecord{action: "environment.protected_get"}
+
+	cases := []struct {
+		purpose  Purpose
+		wantFail bool
+	}{
+		{purpose: PurposeTest, wantFail: true},
+		{purpose: PurposeSweep, wantFail: false},
+	}
+	for _, testCase := range cases {
+		t.Run(string(testCase.purpose), func(t *testing.T) {
+			reporter := &capturedReporter{}
+			call := &pendingCall{line: &e2ecalls.Call{
+				Action:  "environment.get",
+				Surface: string(SurfaceMeta),
+				Purpose: string(testCase.purpose),
+			}}
+
+			assertDispatch(reporter, call, ran)
+
+			if failed := reporter.count() > 0; failed != testCase.wantFail {
+				t.Errorf("assertDispatch reported %d failures (%q), want a failure = %t",
+					reporter.count(), reporter.reported(), testCase.wantFail)
+			}
+		})
+	}
+}
+
 // TestNewTraceParent_IsAFreshSampledTraceEveryTime checks the value the server
 // reads the trace off.
 //
@@ -628,6 +665,39 @@ func TestSubscriberIndex_RecordsEveryWatcherAndForgetsTheReleasedOne(t *testing.
 	releaseFirst()
 	if watchers := index.recordersFor("gitlab://project/7"); len(watchers) != 0 {
 		t.Errorf("the last watcher was not dropped: %d left", len(watchers))
+	}
+}
+
+// TestRecordSubscribe_CreditsTheSubscribeToItsTest checks that the verb's own
+// record names the resource and the test, since the sending middleware cannot:
+// the SDK opens the subscription on a background context under the current
+// protocol, so the attribution never reaches it.
+func TestRecordSubscribe_CreditsTheSubscribeToItsTest(t *testing.T) {
+	env := newEnv(t, offlineInstance())
+	conn := &sessionConn{
+		label: "dynamic-default-full",
+		inst:  env.inst,
+		cfg:   ServerConfig{Surface: SurfaceDynamic, Mode: ModeDefault, Capabilities: CapabilitiesFull},
+	}
+
+	conn.recordSubscribe(env.recorder, "gitlab://project/7")
+
+	lines := env.recorder.finish(&capturedReporter{}, e2ecalls.StatusPassed)
+	var found *e2ecalls.Call
+	for _, line := range lines {
+		if record, isCall := line.(*e2ecalls.Call); isCall {
+			found = record
+		}
+	}
+	if found == nil {
+		t.Fatalf("recordSubscribe wrote no call line; %d lines written", len(lines))
+	}
+	if found.Method != methodSubscribe || found.Target != "gitlab://project/7" {
+		t.Errorf("subscribe line = method %q target %q, want %q and gitlab://project/7", found.Method, found.Target, methodSubscribe)
+	}
+	if found.Test != env.T.Name() || found.Outcome != e2ecalls.OutcomeOK || found.TestStatus != e2ecalls.StatusPassed {
+		t.Errorf("subscribe line credited test %q outcome %q status %q, want this test, ok, passed",
+			found.Test, found.Outcome, found.TestStatus)
 	}
 }
 

--- a/test/e2e/internal/harness/served.go
+++ b/test/e2e/internal/harness/served.go
@@ -47,9 +47,25 @@ type servedSets struct {
 	templates []string
 	// prompts are the prompt names.
 	prompts []string
+	// promptSpecs pairs each served prompt with the arguments it declares, so
+	// a sweep can bind the required ones from the World and skip a prompt it
+	// cannot satisfy rather than watch it error.
+	promptSpecs []PromptSpec
 	// actions are the catalog actions this session can reach, which is not a
 	// listing: it comes from the catalog the assemblers built.
 	actions map[ActionID]struct{}
+}
+
+// PromptSpec is one served prompt and the arguments it declares, split into
+// the ones a call must carry and the ones it may.
+type PromptSpec struct {
+	// Name is the prompt name a prompts/get call names.
+	Name string
+	// Required are the argument names the prompt refuses to render without.
+	Required []string
+	// Optional are the argument names it reads when given and does without
+	// otherwise.
+	Optional []string
 }
 
 // listServed reads the four listings a session publishes.
@@ -83,13 +99,33 @@ func listServed(ctx context.Context, session *mcp.ClientSession) (servedSets, er
 			return served, fmt.Errorf("prompts/list: %w", err)
 		}
 		served.prompts = append(served.prompts, prompt.Name)
+		served.promptSpecs = append(served.promptSpecs, promptSpecOf(prompt))
 	}
 
 	slices.Sort(served.tools)
 	slices.Sort(served.resources)
 	slices.Sort(served.templates)
 	slices.Sort(served.prompts)
+	slices.SortFunc(served.promptSpecs, func(a, b PromptSpec) int { return strings.Compare(a.Name, b.Name) })
 	return served, nil
+}
+
+// promptSpecOf splits a listed prompt's arguments into required and optional.
+func promptSpecOf(prompt *mcp.Prompt) PromptSpec {
+	spec := PromptSpec{Name: prompt.Name}
+	for _, arg := range prompt.Arguments {
+		if arg == nil {
+			continue
+		}
+		if arg.Required {
+			spec.Required = append(spec.Required, arg.Name)
+			continue
+		}
+		spec.Optional = append(spec.Optional, arg.Name)
+	}
+	slices.Sort(spec.Required)
+	slices.Sort(spec.Optional)
+	return spec
 }
 
 // surfaceExpectation is what one configuration should serve: the catalog-backed

--- a/test/e2e/internal/harness/session.go
+++ b/test/e2e/internal/harness/session.go
@@ -310,6 +310,21 @@ func (s *Session) ResourceTemplates() []string { return slices.Clone(s.conn.serv
 // Prompts returns the prompt names the session listed.
 func (s *Session) Prompts() []string { return slices.Clone(s.conn.served.prompts) }
 
+// PromptSpecs returns each served prompt with the arguments it declares, so a
+// sweep can bind the required ones and skip a prompt it cannot satisfy. The
+// slices are copied, so a caller cannot change what the session listed.
+func (s *Session) PromptSpecs() []PromptSpec {
+	specs := make([]PromptSpec, len(s.conn.served.promptSpecs))
+	for i, spec := range s.conn.served.promptSpecs {
+		specs[i] = PromptSpec{
+			Name:     spec.Name,
+			Required: slices.Clone(spec.Required),
+			Optional: slices.Clone(spec.Optional),
+		}
+	}
+	return specs
+}
+
 // Serves reports whether this session can reach the given action at all.
 //
 // It answers from the catalog the server built rather than from the base

--- a/test/e2e/internal/harness/verbs.go
+++ b/test/e2e/internal/harness/verbs.go
@@ -152,6 +152,11 @@ func (s *Session) Subscribe(uri string) *Subscription {
 		s.env.T.Fatalf("resources/subscribe %s: %v%s", uri, err, s.conn.failureContext())
 		return nil
 	}
+	// Recorded here rather than by the sending middleware: the SDK's Subscribe
+	// opens the subscription on a background context under protocol 2026-07-28,
+	// so the attribution on subscribeCtx never reaches the middleware and the
+	// subscribe would be credited to no test. See [sessionConn.recordSubscribe].
+	s.conn.recordSubscribe(s.env.recorder, uri)
 	s.env.T.Cleanup(func() {
 		// A background context, because the test's own is cancelled by the
 		// time cleanups run and an unsubscribe that never reached the server


### PR DESCRIPTION
Step S12 of the e2e rebuild (issue 704): the sweeps in `common`, driven by what each session serves rather than by a hand-written table.

Six files under `test/e2e/gitlab/common`. `mcp_resources_test.go` reads every static resource and every template the session lists, bound from the World; `mcp_prompts_test.go` fetches every prompt `ListPrompts` returns whose required arguments bind; `mcp_completions_test.go` asks a completion for every prompt argument and every template variable; `mcp_subscriptions_test.go` subscribes to every advertised subscribable template that binds, through the binary, since only `cmd/server` wires subscriptions; `reads_sweep_test.go` calls every served read-only action whose required parameters bind from `gitlab://tools`, on all three surfaces, spelling each value in the type the schema declares; `previews_sweep_test.go` asks one safe-mode preview per served mutating action. An unbound parameter names itself in the log. The reads and previews sweeps carry purpose `sweep`, so the report keeps their credit apart from scenario credit; the capability sweeps go through the harness verbs and are credited as asserted, which is what the plan asks for them. Capability sweeps run on one full-capability session rather than per surface, because resources, prompts, completions and subscriptions do not depend on the tool surface; reads and previews are per surface and run on all three.

The harness and the fixture library gained what the sweeps needed: `assertDispatch` no longer fails a sweep call on a rewrite, since a sweep is credited to the dispatched action; `Session.PromptSpecs` exposes prompt arguments; `Session.Subscribe` records the subscribe itself, because the SDK's 2026-07-28 subscribe runs on a background context the sending middleware never sees, so the call would have been credited to no test; the World binds `milestone_iid` and carries a `PromptBindings` table. The reads and previews sweeps cover Free-tier actions only, since `common`'s ceiling is Free on every runtime; the licensed sweeps belong to `ee` in S14.

One fixture defect surfaced, since this is the first step whose run builds and tears the World down: on delayed deletion a top-level group can only be marked through the API and never purged (`permanently_remove` is for subgroups), so the teardown tolerates that refusal and purges the World project before marking the group, which keeps the run-scoped sweep from tripping on a pending-delete leftover. Pinned against the stub.

Verified on truenas: `make test-e2e-ce` and `make test-e2e-ee` (licensed Ultimate) both end with 43 tests and no failure; `audit_e2e_coverage` on both runtimes reports 129 completion arguments, 36 prompts, 28 resource templates and 12 subscribable kinds asserted, with four scope-collision templates and one prompt on the error-path column because the small read-only World cannot resolve them (a group-scoped label or milestone addressed with the project's ids, the file template's path, a pipeline the runnerless World never ran); the sweep-only and preview-only cells show in their own columns. `-static` is clean.
