### PR TITLE
test(e2e): port the first half of the old EE suite to the runtime packages

### DIFF
--- a/cmd/audit_e2e_coverage/baseline.go
+++ b/cmd/audit_e2e_coverage/baseline.go
@@ -1,9 +1,64 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"sort"
 )
+
+// baselineResultsSuffix is appended to a baseline runtime's directory to
+// name the gotestsum stream recorded beside it: the old suite's shards carry
+// no verdicts of their own, and S09 wrote its results to
+// dist/e2e-calls/baseline-<runtime>.results.json next to
+// dist/e2e-calls/baseline-<runtime>/.
+const baselineResultsSuffix = ".results.json"
+
+// errBaselineUnjudged is a baseline whose calls carry no verdict and whose
+// directory has no results stream beside it.
+var errBaselineUnjudged = errors.New("the baseline carries no test verdicts and no results stream sits beside it")
+
+// joinBaselineResults gives every baseline runtime its verdicts, so that the
+// comparison has something to compare against.
+//
+// A credit counts only in a passing test, and the old suite's recorder wrote
+// no verdict onto its calls: its shards were joined with the gotestsum
+// stream when the baseline report was produced, and the same join has to
+// happen here. Without it every baseline call classifies as failed, the
+// baseline reaches nothing, and the superset check passes against nothing,
+// which is exactly the silence it exists to refuse. A baseline whose calls
+// already carry verdicts, the way the harness writes them, needs no stream
+// and is left alone; one that carries none and has no stream is refused
+// rather than compared vacuously.
+func joinBaselineResults(runtimes []*runtimeRecords) error {
+	for _, rt := range runtimes {
+		if baselineJudged(rt) {
+			continue
+		}
+		path := rt.dir + baselineResultsSuffix
+		results, err := readResults(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("%s: %w (looked for %s)", rt.dir, errBaselineUnjudged, path)
+			}
+			return fmt.Errorf("%s: %w", rt.dir, err)
+		}
+		joinResults(rt, results)
+	}
+	return nil
+}
+
+// baselineJudged reports whether any call of the runtime carries a verdict.
+// One is enough to say the shards were written with verdicts: a recorder
+// that writes them writes them on every call.
+func baselineJudged(rt *runtimeRecords) bool {
+	for _, call := range rt.calls {
+		if call.TestStatus != "" {
+			return true
+		}
+	}
+	return false
+}
 
 // reachedKey is one runtime x surface x mode x action x credit a passing test
 // reached, which is the unit the superset check compares.
@@ -60,7 +115,7 @@ func compareBaseline(current, baseline *classification, baselineDir string) *bas
 	now := reachedSet(current)
 	result := &baselineResult{BaselineDirectory: baselineDir, BaselineReached: len(before), Reached: len(now)}
 	for key := range before {
-		if !now[key] {
+		if !satisfied(now, key) {
 			result.Lost = append(result.Lost, key.String())
 		}
 	}
@@ -71,4 +126,37 @@ func compareBaseline(current, baseline *classification, baselineDir string) *bas
 	}
 	sort.Strings(result.Lost)
 	return result
+}
+
+// satisfied reports whether the run reached what one baseline key says the
+// old suite reached.
+//
+// A credit is its own key, and most are not interchangeable: a refusal, an
+// error path and a preview each show a behavior a successful call shows
+// nothing about. The two that say only "the action ran and answered" are
+// ordered, though. A cleanup credit is that answer made after the test
+// body, a sweep credit that answer made with no assertion on it, and an
+// asserted credit that answer with the test's assertion behind it, so each
+// is met by itself or by the stronger ones. Without this, the old suite's
+// habit of deleting in a cleanup what its body had already deleted, and
+// counting GitLab's answer as an ok, would be a credit the port could only
+// keep by repeating the habit.
+func satisfied(now map[reachedKey]bool, key reachedKey) bool {
+	if now[key] {
+		return true
+	}
+	switch key.credit {
+	case creditCleanup:
+		return now[key.with(creditSweep)] || now[key.with(creditAsserted)]
+	case creditSweep:
+		return now[key.with(creditAsserted)]
+	default:
+		return false
+	}
+}
+
+// with returns the key with another credit, for the lookup of a stronger one.
+func (k reachedKey) with(credit credit) reachedKey {
+	k.credit = credit
+	return k
 }

--- a/cmd/audit_e2e_coverage/baseline_test.go
+++ b/cmd/audit_e2e_coverage/baseline_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil/e2ecalls"
@@ -60,6 +64,138 @@ func TestCompareBaseline_DifferentRuns_LossesAndGains(t *testing.T) {
 	}
 	if result.Gained != result.Reached-1 {
 		t.Errorf("Gained = %d, want every reached key but the shared one (%d)", result.Gained, result.Reached-1)
+	}
+}
+
+// TestJoinBaselineResults_UnjudgedShards_TakeTheStreamBeside verifies the
+// join the old suite's baseline needs: its shards carry no verdict, so the
+// gotestsum stream recorded beside the directory, at <dir>.results.json, is
+// what gives its calls one. Without it every baseline call classified as
+// failed and the superset check compared against nothing, which is how the
+// S09 baseline passed every run vacuously.
+func TestJoinBaselineResults_UnjudgedShards_TakeTheStreamBeside(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "baseline-ce")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	rt := &runtimeRecords{dir: dir, key: "community/free", packages: map[*e2ecalls.Call]string{}}
+	passed := fixtureCall(callSpec{test: "TestOld_Passed", action: "issue.list", dispatched: "issue.list", shape: dynamicDefault})
+	failed := fixtureCall(callSpec{test: "TestOld_Failed", action: "issue.create", dispatched: "issue.create", shape: metaDefault})
+	// The old suite's recorder wrote no verdict, which the fixture builder
+	// cannot spell since it fills an empty one in.
+	passed.TestStatus, failed.TestStatus = "", ""
+	rt.calls = []*e2ecalls.Call{passed, failed}
+	rt.packages[passed], rt.packages[failed] = "suite", "suite"
+
+	writeFile(t, dir+baselineResultsSuffix, strings.Join([]string{
+		`{"Time":"2026-09-01T10:00:00Z","Action":"run","Package":"example.com/old/test/e2e/suite","Test":"TestOld_Passed"}`,
+		`{"Time":"2026-09-01T10:00:01Z","Action":"pass","Package":"example.com/old/test/e2e/suite","Test":"TestOld_Passed","Elapsed":1}`,
+		`{"Time":"2026-09-01T10:00:02Z","Action":"run","Package":"example.com/old/test/e2e/suite","Test":"TestOld_Failed"}`,
+		`{"Time":"2026-09-01T10:00:03Z","Action":"fail","Package":"example.com/old/test/e2e/suite","Test":"TestOld_Failed","Elapsed":1}`,
+		"",
+	}, "\n"))
+
+	if err := joinBaselineResults([]*runtimeRecords{rt}); err != nil {
+		t.Fatalf("joinBaselineResults() error = %v, want the stream beside the directory joined", err)
+	}
+	if passed.TestStatus != e2ecalls.StatusPassed || failed.TestStatus != e2ecalls.StatusFailed {
+		t.Errorf("verdicts after the join = (%q, %q), want (passed, failed)", passed.TestStatus, failed.TestStatus)
+	}
+	reached := reachedSet(classify(rt, fixtureCatalog()))
+	if !reached[reachedKey{surface: "dynamic", mode: modeDefault, action: "issue.list", credit: creditAsserted}] {
+		t.Errorf("the passed baseline call is not reached after the join: %v", reached)
+	}
+	if reached[reachedKey{surface: "meta", mode: modeDefault, action: "issue.create", credit: creditAsserted}] {
+		t.Errorf("the failed baseline call is reached after the join: %v", reached)
+	}
+}
+
+// TestJoinBaselineResults_UnjudgedShardsWithoutAStream_Refused verifies that
+// a baseline that could only reach nothing is refused, naming the file it
+// looked for, instead of being compared against.
+func TestJoinBaselineResults_UnjudgedShardsWithoutAStream_Refused(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "baseline-ee")
+	call := fixtureCall(callSpec{test: "TestOld", action: "issue.list", dispatched: "issue.list", shape: dynamicDefault})
+	call.TestStatus = ""
+	rt := &runtimeRecords{dir: dir, key: "enterprise/ultimate", calls: []*e2ecalls.Call{call}, packages: map[*e2ecalls.Call]string{call: "suite"}}
+
+	err := joinBaselineResults([]*runtimeRecords{rt})
+	if !errors.Is(err, errBaselineUnjudged) {
+		t.Fatalf("joinBaselineResults() error = %v, want %v", err, errBaselineUnjudged)
+	}
+	if !strings.Contains(err.Error(), dir+baselineResultsSuffix) {
+		t.Errorf("the refusal does not name the stream it looked for: %v", err)
+	}
+}
+
+// TestJoinBaselineResults_UnreadableStream_IsItsOwnError verifies that a
+// stream which is there and cannot be read is reported as that, and not as
+// a missing one: the two are different things to fix.
+func TestJoinBaselineResults_UnreadableStream_IsItsOwnError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "baseline-ee")
+	// A directory where the stream should be opens and cannot be parsed.
+	if err := os.MkdirAll(dir+baselineResultsSuffix, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	call := fixtureCall(callSpec{test: "TestOld", action: "issue.list", dispatched: "issue.list", shape: dynamicDefault})
+	call.TestStatus = ""
+	rt := &runtimeRecords{dir: dir, key: "enterprise/ultimate", calls: []*e2ecalls.Call{call}, packages: map[*e2ecalls.Call]string{call: "suite"}}
+
+	err := joinBaselineResults([]*runtimeRecords{rt})
+	if err == nil || errors.Is(err, errBaselineUnjudged) {
+		t.Fatalf("joinBaselineResults() error = %v, want a read error that is not the missing-stream refusal", err)
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Errorf("the error does not name the baseline: %v", err)
+	}
+}
+
+// TestJoinBaselineResults_JudgedShards_LeftAlone verifies that a baseline
+// the harness wrote, whose calls carry their verdicts, is not made to look
+// for a stream it does not need.
+func TestJoinBaselineResults_JudgedShards_LeftAlone(t *testing.T) {
+	rt := fixtureRuntime()
+	rt.dir = filepath.Join(t.TempDir(), "nowhere")
+	if err := joinBaselineResults([]*runtimeRecords{rt}); err != nil {
+		t.Errorf("joinBaselineResults() error = %v on shards that carry verdicts, want nil", err)
+	}
+}
+
+// TestCompareBaseline_WeakerCredits_MetByStrongerOnes verifies the one
+// ordering the comparison admits: a cleanup or sweep credit of the old
+// suite is met by the same cell asserted in the new one, since all three say
+// the action ran and answered, while a refusal, an error path or a preview
+// is met by nothing but itself.
+func TestCompareBaseline_WeakerCredits_MetByStrongerOnes(t *testing.T) {
+	current := classify(fixtureRuntime(), fixtureCatalog())
+	// The fixture asserts issue.list on dynamic and previews issue.create on
+	// individual in safe mode; it refuses, and never asserts, issue.delete on
+	// dynamic.
+	cases := []struct {
+		name string
+		spec callSpec
+		lost bool
+	}{
+		{name: "cleanup met by asserted", spec: callSpec{test: "TestOld", purpose: e2ecalls.PurposeCleanup, expectation: e2ecalls.ExpectationAny, action: "issue.list", dispatched: "issue.list", shape: dynamicDefault}},
+		{name: "sweep met by asserted", spec: callSpec{test: "TestOld", purpose: e2ecalls.PurposeSweep, action: "issue.list", dispatched: "issue.list", shape: dynamicDefault}},
+		{name: "cleanup met by sweep", spec: callSpec{test: "TestOld", purpose: e2ecalls.PurposeCleanup, expectation: e2ecalls.ExpectationAny, action: "issue.list", dispatched: "issue.list", shape: individualDefault}},
+		{name: "asserted not met by cleanup", spec: callSpec{test: "TestOld", action: "issue.delete", dispatched: "issue.delete", shape: metaDefault}, lost: true},
+		{name: "asserted not met by a refusal", spec: callSpec{test: "TestOld", action: "issue.delete", dispatched: "issue.delete", shape: dynamicDefault}, lost: true},
+		{name: "refusal not met by asserted", spec: callSpec{test: "TestOld", expectation: "needs_confirmation", action: "issue.list", dispatched: "issue.list", outcome: e2ecalls.RefusedOutcome("needs_confirmation"), shape: dynamicDefault}, lost: true},
+		{name: "error path not met by a preview", spec: callSpec{test: "TestOld", expectation: "tool_error", action: "issue.create", dispatched: "issue.create", outcome: e2ecalls.OutcomeToolError, shape: individualSafe}, lost: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baselineRT := fixtureRuntime()
+			baselineRT.calls = []*e2ecalls.Call{fixtureCall(tc.spec)}
+			result := compareBaseline(current, classify(baselineRT, fixtureCatalog()), "old")
+			if result.BaselineReached != 1 {
+				t.Fatalf("the baseline reached %d keys, want the one the case names", result.BaselineReached)
+			}
+			if got := len(result.Lost) == 1; got != tc.lost {
+				t.Errorf("lost = %q, want lost=%t", result.Lost, tc.lost)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_e2e_coverage/doc.go
+++ b/cmd/audit_e2e_coverage/doc.go
@@ -42,7 +42,12 @@
 // -run filter (a partial run is not a coverage claim about the rest), and
 // when the asserted count falls below the floor exemptions.go records. -baseline compares two shard
 // directories and fails on any runtime x surface x mode x action x credit the
-// old suite reached in a passing test and the new one does not. -port-map
+// old suite reached in a passing test and the new one does not; a cleanup or
+// sweep credit is also met by the same cell asserted, since all three say the
+// action ran and answered. A baseline whose shards carry no verdicts, which is
+// how the old suite's recorder wrote them, is joined with the gotestsum stream
+// at <directory>.results.json beside it, and refused when there is none rather
+// than compared against nothing. -port-map
 // reads the "// Replaces:" lines of the new suite against every Test function
 // of the old one, with declared drops for the tests nothing replaces.
 //

--- a/cmd/audit_e2e_coverage/main.go
+++ b/cmd/audit_e2e_coverage/main.go
@@ -245,6 +245,10 @@ func classifyRuntimes(opts options, runtimes []*runtimeRecords, selectors []stri
 			fmt.Fprintln(stderr, "audit_e2e_coverage: baseline:", err)
 			return nil, exitUsage
 		}
+		if err = joinBaselineResults(baseline); err != nil {
+			fmt.Fprintln(stderr, "audit_e2e_coverage: baseline:", err)
+			return nil, exitUsage
+		}
 	}
 	status = exitOK
 	// An empty list rather than null when no runtime was selected, so a

--- a/internal/tools/mrapprovals/action_specs_test.go
+++ b/internal/tools/mrapprovals/action_specs_test.go
@@ -4,6 +4,7 @@ package mrapprovals
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -177,6 +178,83 @@ func TestActionSpecs_DiscoveryMetadata(t *testing.T) {
 			assertRichDiscoveryMeta(t, tool, spec)
 		})
 	}
+}
+
+// TestActionSpecs_RuleSchemas_RequireOnlyWhatTheAPIDemands pins the
+// required list of the rule create and update schemas to the fields GitLab
+// itself demands, and holds every optional field out of it.
+//
+// It exists because the individual surface validates arguments against
+// the published schema before any handler runs, and a field the generator
+// marked required by default refused every create that named no source rule
+// and no approvers: the licensed end-to-end run found
+// gitlab_mr_approval_rule_create answering "missing properties:
+// approval_project_rule_id, user_ids, group_ids" on the individual surface
+// while the two dispatcher surfaces, which decode the arguments directly,
+// ran the same call.
+func TestActionSpecs_RuleSchemas_RequireOnlyWhatTheAPIDemands(t *testing.T) {
+	byTool := approvalSpecsByTool(t, ActionSpecs(testutil.NewTestClient(t, approvalActionHandler())))
+
+	cases := []struct {
+		tool     string
+		required []string
+		optional []string
+	}{
+		{
+			tool:     "gitlab_mr_approval_rule_create",
+			required: []string{"project_id", "merge_request_iid", "name", "approvals_required"},
+			optional: []string{"approval_project_rule_id", "user_ids", "group_ids"},
+		},
+		{
+			tool:     "gitlab_mr_approval_rule_update",
+			required: []string{"project_id", "merge_request_iid", "approval_rule_id"},
+			optional: []string{"name", "approvals_required", "user_ids", "group_ids"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			// The individual projection, not the route's own schema: the
+			// projection reflects its required list from the input type, and
+			// that is the list the surface validates arguments against.
+			tool, err := toolutil.IndividualToolFromActionSpec(byTool[tc.tool], toolutil.IndividualToolProjectionOptions{})
+			if err != nil {
+				t.Fatalf("IndividualToolFromActionSpec(%s) error: %v", tc.tool, err)
+			}
+			schema, ok := tool.InputSchema.(map[string]any)
+			if !ok {
+				t.Fatalf("%s input schema is %T, want map[string]any", tc.tool, tool.InputSchema)
+			}
+			required := schemaRequiredFields(schema)
+			for _, field := range tc.required {
+				if !slices.Contains(required, field) {
+					t.Errorf("%s does not require %q; required = %v", tc.tool, field, required)
+				}
+			}
+			for _, field := range tc.optional {
+				if slices.Contains(required, field) {
+					t.Errorf("%s requires %q, which GitLab treats as optional; required = %v", tc.tool, field, required)
+				}
+			}
+		})
+	}
+}
+
+// schemaRequiredFields reads the required list of an input schema, which
+// the generator writes as []string and a round trip through JSON as []any.
+func schemaRequiredFields(schema map[string]any) []string {
+	switch required := schema["required"].(type) {
+	case []string:
+		return required
+	case []any:
+		fields := make([]string, 0, len(required))
+		for _, raw := range required {
+			if field, ok := raw.(string); ok {
+				fields = append(fields, field)
+			}
+		}
+		return fields
+	}
+	return nil
 }
 
 // assertRichDiscoveryMeta asserts that an action spec carries non-generic

--- a/internal/tools/mrapprovals/mr_approvals.go
+++ b/internal/tools/mrapprovals/mr_approvals.go
@@ -43,25 +43,34 @@ type ResetInput struct {
 }
 
 // CreateRuleInput defines parameters for creating an MR approval rule.
+//
+// The three optional fields carry omitempty because the schema generator
+// marks a field required unless the tag says it may be absent: without it
+// the individual surface, which validates arguments against the schema
+// before any handler runs, refused every create that named no source rule
+// and no approvers, which is the ordinary one. The dispatcher surfaces
+// decode the arguments directly and never saw the refusal.
 type CreateRuleInput struct {
-	ProjectID             toolutil.StringOrInt `json:"project_id"               jsonschema:"Project ID or URL-encoded path,required"`
-	MRIID                 int64                `json:"merge_request_iid"                   jsonschema:"Merge request internal ID,required"`
-	Name                  string               `json:"name"                     jsonschema:"Rule name,required"`
-	ApprovalsRequired     int64                `json:"approvals_required"       jsonschema:"Number of approvals required,required"`
-	ApprovalProjectRuleID int64                `json:"approval_project_rule_id" jsonschema:"Project-level approval rule ID to inherit from"`
-	UserIDs               []int64              `json:"user_ids"                 jsonschema:"User IDs eligible to approve"`
-	GroupIDs              []int64              `json:"group_ids"                jsonschema:"Group IDs eligible to approve"`
+	ProjectID             toolutil.StringOrInt `json:"project_id"                         jsonschema:"Project ID or URL-encoded path,required"`
+	MRIID                 int64                `json:"merge_request_iid"                  jsonschema:"Merge request internal ID,required"`
+	Name                  string               `json:"name"                               jsonschema:"Rule name,required"`
+	ApprovalsRequired     int64                `json:"approvals_required"                 jsonschema:"Number of approvals required,required"`
+	ApprovalProjectRuleID int64                `json:"approval_project_rule_id,omitempty" jsonschema:"Project-level approval rule ID to inherit from"`
+	UserIDs               []int64              `json:"user_ids,omitempty"                 jsonschema:"User IDs eligible to approve"`
+	GroupIDs              []int64              `json:"group_ids,omitempty"                jsonschema:"Group IDs eligible to approve"`
 }
 
-// UpdateRuleInput defines parameters for updating an MR approval rule.
+// UpdateRuleInput defines parameters for updating an MR approval rule. Every
+// field but the three that name the rule is optional, and says so for the
+// reason [CreateRuleInput] gives.
 type UpdateRuleInput struct {
-	ProjectID         toolutil.StringOrInt `json:"project_id"         jsonschema:"Project ID or URL-encoded path,required"`
-	MRIID             int64                `json:"merge_request_iid"             jsonschema:"Merge request internal ID,required"`
-	ApprovalRuleID    int64                `json:"approval_rule_id"   jsonschema:"Approval rule ID,required"`
-	Name              string               `json:"name"               jsonschema:"Rule name"`
-	ApprovalsRequired *int64               `json:"approvals_required" jsonschema:"Number of approvals required"`
-	UserIDs           []int64              `json:"user_ids"           jsonschema:"User IDs eligible to approve"`
-	GroupIDs          []int64              `json:"group_ids"          jsonschema:"Group IDs eligible to approve"`
+	ProjectID         toolutil.StringOrInt `json:"project_id"                   jsonschema:"Project ID or URL-encoded path,required"`
+	MRIID             int64                `json:"merge_request_iid"            jsonschema:"Merge request internal ID,required"`
+	ApprovalRuleID    int64                `json:"approval_rule_id"             jsonschema:"Approval rule ID,required"`
+	Name              string               `json:"name,omitempty"               jsonschema:"Rule name"`
+	ApprovalsRequired *int64               `json:"approvals_required,omitempty" jsonschema:"Number of approvals required"`
+	UserIDs           []int64              `json:"user_ids,omitempty"           jsonschema:"User IDs eligible to approve"`
+	GroupIDs          []int64              `json:"group_ids,omitempty"          jsonschema:"Group IDs eligible to approve"`
 }
 
 // DeleteRuleInput defines parameters for deleting an MR approval rule.

--- a/test/e2e/gitlab/common/actions_test.go
+++ b/test/e2e/gitlab/common/actions_test.go
@@ -34,3 +34,60 @@ const (
 	// without admin_mode is not served.
 	actionAdminMetadataGet harness.ActionID = "admin.metadata_get"
 )
+
+// A project's service accounts and their tokens.
+const (
+	actionProjectServiceAccountList      harness.ActionID = "project.service_account_list"
+	actionProjectServiceAccountCreate    harness.ActionID = "project.service_account_create"
+	actionProjectServiceAccountUpdate    harness.ActionID = "project.service_account_update"
+	actionProjectServiceAccountDelete    harness.ActionID = "project.service_account_delete"
+	actionProjectServiceAccountPATCreate harness.ActionID = "project.service_account_pat_create"
+	actionProjectServiceAccountPATList   harness.ActionID = "project.service_account_pat_list"
+	actionProjectServiceAccountPATRotate harness.ActionID = "project.service_account_pat_rotate"
+	actionProjectServiceAccountPATRevoke harness.ActionID = "project.service_account_pat_revoke"
+)
+
+// The instance's service accounts, and the user delete that removes one.
+const (
+	actionUserListServiceAccounts  harness.ActionID = "user.list_service_accounts"
+	actionUserCreateServiceAccount harness.ActionID = "user.create_service_account"
+	actionUserUpdateServiceAccount harness.ActionID = "user.update_service_account"
+	actionUserDelete               harness.ActionID = "user.delete"
+)
+
+// The project and snippet halves of the storage move family, which are
+// Free; the group half is licensed and lives in the ee package.
+const (
+	actionStorageMoveRetrieveAllProject   harness.ActionID = "storage_move.retrieve_all_project"
+	actionStorageMoveRetrieveProject      harness.ActionID = "storage_move.retrieve_project"
+	actionStorageMoveGetProject           harness.ActionID = "storage_move.get_project"
+	actionStorageMoveGetProjectForProject harness.ActionID = "storage_move.get_project_for_project"
+	actionStorageMoveScheduleProject      harness.ActionID = "storage_move.schedule_project"
+	actionStorageMoveScheduleAllProject   harness.ActionID = "storage_move.schedule_all_project"
+	actionStorageMoveRetrieveAllSnippet   harness.ActionID = "storage_move.retrieve_all_snippet"
+	actionStorageMoveRetrieveSnippet      harness.ActionID = "storage_move.retrieve_snippet"
+	actionStorageMoveGetSnippet           harness.ActionID = "storage_move.get_snippet"
+	actionStorageMoveGetSnippetForSnippet harness.ActionID = "storage_move.get_snippet_for_snippet"
+	actionStorageMoveScheduleSnippet      harness.ActionID = "storage_move.schedule_snippet"
+	actionStorageMoveScheduleAllSnippet   harness.ActionID = "storage_move.schedule_all_snippet"
+)
+
+// Group labels, driven for their archived flag.
+const (
+	actionGroupLabelCreate harness.ActionID = "group.group_label_create"
+	actionGroupLabelList   harness.ActionID = "group.group_label_list"
+	actionGroupLabelUpdate harness.ActionID = "group.group_label_update"
+	actionGroupLabelDelete harness.ActionID = "group.group_label_delete"
+)
+
+// The runner reads and the two project-scoped writes an instance runner
+// refuses.
+const (
+	actionRunnerListAll        harness.ActionID = "runner.list_all"
+	actionRunnerListProject    harness.ActionID = "runner.list_project"
+	actionRunnerListGroup      harness.ActionID = "runner.list_group"
+	actionRunnerGet            harness.ActionID = "runner.get"
+	actionRunnerListManagers   harness.ActionID = "runner.list_managers"
+	actionRunnerEnableProject  harness.ActionID = "runner.enable_project"
+	actionRunnerDisableProject harness.ActionID = "runner.disable_project"
+)

--- a/test/e2e/gitlab/common/grouplabels_test.go
+++ b/test/e2e/gitlab/common/grouplabels_test.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+// grouplabels_test.go covers the archived flag of a group label: created
+// archived, filtered by it in the listing, unarchived by an update, and
+// deleted. The flag is a Free feature the old suite believed licensed and
+// so never drove on the Community runtime.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/grouplabels"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// labelColor is the color every fixture label carries.
+const labelColor = "#428BCA"
+
+// labelNames lists the names of a label listing.
+func labelNames(labels []grouplabels.Output) []string {
+	names := make([]string, 0, len(labels))
+	for _, label := range labels {
+		names = append(names, label.Name)
+	}
+	return names
+}
+
+// TestGroupLabels_Archived_RoundTripsThroughCreateListAndUpdate creates an
+// archived label and a plain one in a group of the surface's own, shows
+// the archived filter tells them apart, unarchives the first by an update,
+// deletes it, and leaves the plain one for the test's own cleanup to
+// delete through the server, as an agent undoing its work would.
+//
+// Replaces: TestMeta_GroupLabelArchive
+func TestGroupLabels_Archived_RoundTripsThroughCreateListAndUpdate(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("labels"))
+		scope := map[string]any{"group_id": group.IDParam()}
+		archivedName, plainName := e.Name("archived"), e.Name("plain")
+
+		archived := harness.Do[grouplabels.Output](s, actionGroupLabelCreate, withParams(scope, map[string]any{
+			"name": archivedName, "color": labelColor, "archived": true,
+		}))
+		if archived.Name != archivedName || !archived.Archived {
+			e.T.Errorf("create answered %+v, want the label %q archived", archived, archivedName)
+		}
+		plain := harness.Do[grouplabels.Output](s, actionGroupLabelCreate, withParams(scope, map[string]any{"name": plainName, "color": labelColor}))
+		if plain.Name != plainName || plain.Archived {
+			e.T.Errorf("create answered %+v, want the label %q active", plain, plainName)
+		}
+		e.T.Cleanup(func() {
+			// The group goes with its labels, so a delete that failed here
+			// leaves nothing behind and is worth a line rather than a failure.
+			if _, err := harness.Try[grouplabels.Output](s, actionGroupLabelDelete, withParams(scope, map[string]any{"label_id": plainName}), harness.For(harness.PurposeCleanup)); err != nil {
+				e.T.Logf("the cleanup delete of label %q answered: %v", plainName, err)
+			}
+		})
+
+		onlyArchived := harness.Do[grouplabels.ListOutput](s, actionGroupLabelList, withParams(scope, map[string]any{"archived": true}))
+		if names := labelNames(onlyArchived.Labels); len(names) != 1 || names[0] != archivedName {
+			e.T.Errorf("the listing filtered to archived labels holds %v, want only %q", names, archivedName)
+		}
+		everything := harness.Do[grouplabels.ListOutput](s, actionGroupLabelList, scope)
+		if names := labelNames(everything.Labels); len(names) != 2 {
+			e.T.Errorf("the unfiltered listing holds %v, want both labels", names)
+		}
+
+		unarchived := harness.Do[grouplabels.Output](s, actionGroupLabelUpdate, withParams(scope, map[string]any{"label_id": archivedName, "archived": false}))
+		if unarchived.Archived {
+			e.T.Errorf("update answered %+v after unarchiving, want archived=false", unarchived)
+		}
+
+		harness.DoVoid(s, actionGroupLabelDelete, withParams(scope, map[string]any{"label_id": archivedName}))
+		remaining := harness.Do[grouplabels.ListOutput](s, actionGroupLabelList, scope)
+		if names := labelNames(remaining.Labels); len(names) != 1 || names[0] != plainName {
+			e.T.Errorf("the listing after the delete holds %v, want only %q", names, plainName)
+		}
+	})
+}

--- a/test/e2e/gitlab/common/helpers_test.go
+++ b/test/e2e/gitlab/common/helpers_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+// helpers_test.go holds the two things every file here says about a
+// refusal: that it names what a caller needs to act on it, and how it is
+// quoted in a log line.
+
+package common
+
+import (
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// assertMentions checks that a refusal carries every substring, without
+// regard to case. The substrings are what the tool promises a caller: the
+// parameter to fix, the sibling tool to call first, the state the object
+// must be in. A refusal that lost one of them is a refusal a model cannot
+// act on.
+func assertMentions(e *harness.Env, what, text string, substrings ...string) {
+	e.T.Helper()
+	lowered := strings.ToLower(text)
+	for _, want := range substrings {
+		if !strings.Contains(lowered, strings.ToLower(want)) {
+			e.T.Errorf("%s does not mention %q: %s", what, want, firstLine(text))
+		}
+	}
+}
+
+// firstLine returns the first line of a refusal for a log line, since the
+// card a refusal comes as runs to a dozen lines and the first names the
+// reason.
+func firstLine(text string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	return line
+}

--- a/test/e2e/gitlab/common/mcp_completions_test.go
+++ b/test/e2e/gitlab/common/mcp_completions_test.go
@@ -23,8 +23,8 @@ import (
 // TestCompletions_Sweep drives a completion for every prompt argument and
 // every resource template variable the full-capability server serves.
 //
-// Replaces: the completion coverage the old suite had none of, since no
-// TestMain session drove completions.
+// It replaces no old test: the old suite had no completion coverage, since
+// no TestMain session drove completions.
 func TestCompletions_Sweep(t *testing.T) {
 	e := harness.New(t)
 	s := e.On(harness.SurfaceDynamic)

--- a/test/e2e/gitlab/common/mcp_prompts_test.go
+++ b/test/e2e/gitlab/common/mcp_prompts_test.go
@@ -23,8 +23,8 @@ import (
 // TestPrompts_Sweep renders every served prompt whose required arguments bind
 // from the World.
 //
-// Replaces: the prompt coverage the old suite had none of, since no TestMain
-// session registered prompts.
+// It replaces no old test: the old suite had no prompt coverage, since no
+// TestMain session registered prompts.
 func TestPrompts_Sweep(t *testing.T) {
 	e := harness.New(t)
 	world := fixture.SharedWorld(e)

--- a/test/e2e/gitlab/common/mcp_resources_test.go
+++ b/test/e2e/gitlab/common/mcp_resources_test.go
@@ -26,8 +26,9 @@ import (
 // TestResources_Sweep reads every static resource and every bindable template
 // the full-capability server serves.
 //
-// Replaces: the resource coverage the old suite held to a handful of URIs in
-// its capability tests.
+// It replaces no old test by name: the old suite held its resource coverage
+// to a handful of URIs in its capability tests, which the port of those
+// tests names.
 func TestResources_Sweep(t *testing.T) {
 	e := harness.New(t)
 	world := fixture.SharedWorld(e)

--- a/test/e2e/gitlab/common/mcp_subscriptions_test.go
+++ b/test/e2e/gitlab/common/mcp_subscriptions_test.go
@@ -24,7 +24,7 @@ import (
 // TestSubscriptions_Sweep subscribes to every advertised subscribable template
 // whose URI binds from the World.
 //
-// Replaces: the subscription coverage the old suite had none of, since
+// It replaces no old test: the old suite had no subscription coverage, since
 // subscriptions are wired only in cmd/server, which the in-process suite never
 // started.
 func TestSubscriptions_Sweep(t *testing.T) {

--- a/test/e2e/gitlab/common/previews_sweep_test.go
+++ b/test/e2e/gitlab/common/previews_sweep_test.go
@@ -24,8 +24,9 @@ import (
 // TestPreviews_Sweep previews every mutating action whose required parameters
 // bind from the World, on the dynamic, meta and individual surfaces.
 //
-// Replaces: the safe-mode coverage the old suite held to two hand-picked
-// actions in TestSafeMode and TestSafeModeDynamicSurface.
+// It widens what TestModes_Safe replaced: the old suite held its safe-mode
+// coverage to two hand-picked actions in TestSafeMode and
+// TestSafeModeDynamicSurface, and this drives every mutating one.
 func TestPreviews_Sweep(t *testing.T) {
 	e := harness.New(t)
 	world := fixture.SharedWorld(e)

--- a/test/e2e/gitlab/common/projectserviceaccounts_test.go
+++ b/test/e2e/gitlab/common/projectserviceaccounts_test.go
@@ -1,0 +1,98 @@
+//go:build e2e
+
+// projectserviceaccounts_test.go covers a project's service accounts and
+// their tokens: create, update, list, mint a token, list the tokens, rotate
+// it, revoke it, delete the account. The actions are Free in the catalog
+// and the endpoints answer on every edition, so the scenario runs on both
+// runtimes; the old suite kept it in its Enterprise half.
+
+package common
+
+import (
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projectserviceaccounts"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The lifetimes the fixture tokens are minted and rotated with.
+const (
+	serviceAccountTokenLifetime = 7 * 24 * time.Hour
+	serviceAccountRotatedLife   = 14 * 24 * time.Hour
+)
+
+// TestProjectServiceAccounts_Lifecycle_AccountAndTokens walks one service
+// account per surface, on a project of the surface's own, through its
+// whole life and its token's.
+//
+// Replaces: TestMeta_ProjectServiceAccounts
+func TestProjectServiceAccounts_Lifecycle_AccountAndTokens(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		project := fixture.NewProject(e, fixture.WithNamePrefix("projsa"))
+		id := project.IDParam()
+
+		empty := harness.Do[projectserviceaccounts.ListOutput](s, actionProjectServiceAccountList, map[string]any{"project_id": id})
+		if len(empty.Accounts) != 0 {
+			e.T.Errorf("a fresh project lists %d service accounts: %+v", len(empty.Accounts), empty.Accounts)
+		}
+
+		name := e.Name("sa")
+		created := harness.Do[projectserviceaccounts.Output](s, actionProjectServiceAccountCreate, map[string]any{
+			"project_id": id, "name": name, "username": name,
+		})
+		if created.ID == 0 {
+			e.T.Fatalf("service_account_create answered %+v, want an account with an ID", created)
+		}
+		account := map[string]any{"project_id": id, "service_account_id": created.ID}
+
+		updated := harness.Do[projectserviceaccounts.Output](s, actionProjectServiceAccountUpdate, withParams(account, map[string]any{"name": "Updated " + name}))
+		if updated.ID != created.ID {
+			e.T.Errorf("service_account_update answered account %d, want %d", updated.ID, created.ID)
+		}
+		listed := harness.Do[projectserviceaccounts.ListOutput](s, actionProjectServiceAccountList, map[string]any{"project_id": id})
+		found := false
+		for _, item := range listed.Accounts {
+			if item.ID == created.ID {
+				found = true
+			}
+		}
+		if !found {
+			e.T.Errorf("the listing does not hold the created account %d: %+v", created.ID, listed.Accounts)
+		}
+
+		token := harness.Do[projectserviceaccounts.PATOutput](s, actionProjectServiceAccountPATCreate, withParams(account, map[string]any{
+			"name": e.Name("pat"), "scopes": []string{"api"}, "expires_at": time.Now().Add(serviceAccountTokenLifetime).Format(time.DateOnly),
+		}))
+		if token.ID == 0 {
+			e.T.Fatalf("service_account_pat_create answered %+v, want a token with an ID", token)
+		}
+		tokens := harness.Do[projectserviceaccounts.ListPATOutput](s, actionProjectServiceAccountPATList, account)
+		if len(tokens.Tokens) == 0 {
+			e.T.Errorf("the token listing of account %d is empty right after minting one", created.ID)
+		}
+		rotated := harness.Do[projectserviceaccounts.PATOutput](s, actionProjectServiceAccountPATRotate, withParams(account, map[string]any{
+			"token_id": token.ID, "expires_at": time.Now().Add(serviceAccountRotatedLife).Format(time.DateOnly),
+		}))
+		if rotated.ID == 0 {
+			e.T.Fatalf("service_account_pat_rotate answered %+v, want a token with an ID", rotated)
+		}
+		harness.DoVoid(s, actionProjectServiceAccountPATRevoke, withParams(account, map[string]any{"token_id": rotated.ID}))
+
+		harness.DoVoid(s, actionProjectServiceAccountDelete, withParams(account, map[string]any{"hard_delete": true}))
+	})
+}
+
+// withParams returns one parameter map holding both, for a call that shares
+// a scope with its siblings and adds its own.
+func withParams(shared, own map[string]any) map[string]any {
+	merged := make(map[string]any, len(shared)+len(own))
+	maps.Copy(merged, shared)
+	maps.Copy(merged, own)
+	return merged
+}

--- a/test/e2e/gitlab/common/projectstoragemoves_test.go
+++ b/test/e2e/gitlab/common/projectstoragemoves_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+// projectstoragemoves_test.go covers a project's repository storage moves,
+// which are a Free feature of a Gitaly deployment on every edition. A
+// single-storage instance can still schedule a move: GitLab picks the
+// destination by weight and lands the repository where it already is, which
+// is the one move a throwaway project can be given. A move to a storage
+// the instance lacks is refused, and a move nobody scheduled is a not-found.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projectstoragemoves"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The two things nothing on an instance has: a move by this ID, and a
+// Gitaly storage by this name.
+const (
+	missingMoveID  = int64(999999)
+	missingStorage = "e2e-missing-storage"
+)
+
+// TestProjectStorageMoves_SingleStorage_SchedulesListsAndRefuses schedules
+// a move of a project of the surface's own, finds it in both listings,
+// reads a move that does not exist both ways, and asks for a move to a
+// storage the instance lacks, for the project and for every project.
+//
+// Replaces: TestMeta_StorageMoves, TestMeta_ProjectStorageMoves_Graceful404
+func TestProjectStorageMoves_SingleStorage_SchedulesListsAndRefuses(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		project := fixture.NewProject(e, fixture.WithNamePrefix("psm"))
+
+		none := harness.Do[projectstoragemoves.ListOutput](s, actionStorageMoveRetrieveProject, map[string]any{"project_id": project.ID})
+		if len(none.Moves) != 0 {
+			e.T.Errorf("a fresh project lists %d storage moves: %+v", len(none.Moves), none.Moves)
+		}
+
+		scheduled := harness.Do[projectstoragemoves.Output](s, actionStorageMoveScheduleProject, map[string]any{"project_id": project.ID})
+		if scheduled.ID == 0 {
+			e.T.Fatalf("schedule_project answered %+v, want a move with an ID", scheduled)
+		}
+		mine := harness.Do[projectstoragemoves.ListOutput](s, actionStorageMoveRetrieveProject, map[string]any{"project_id": project.ID})
+		if !moveListed(mine.Moves, scheduled.ID) {
+			e.T.Errorf("the project's moves do not hold the scheduled move %d: %+v", scheduled.ID, mine.Moves)
+		}
+		all := harness.Do[projectstoragemoves.ListOutput](s, actionStorageMoveRetrieveAllProject, map[string]any{"per_page": 100})
+		if !moveListed(all.Moves, scheduled.ID) {
+			e.T.Errorf("the instance's project moves do not hold the scheduled move %d among %d", scheduled.ID, len(all.Moves))
+		}
+
+		refused := harness.Refused(s, actionStorageMoveGetProject, map[string]any{"id": missingMoveID}, harness.FailureNotFound)
+		e.T.Logf("the read of a missing move is refused: %s", firstLine(refused))
+		refused = harness.Refused(s, actionStorageMoveGetProjectForProject, map[string]any{"project_id": project.ID, "id": missingMoveID}, harness.FailureNotFound)
+		e.T.Logf("the read of a missing move of the project is refused: %s", firstLine(refused))
+
+		refused = harness.ExpectToolError(s, actionStorageMoveScheduleProject, map[string]any{
+			"project_id": project.ID, "destination_storage_name": missingStorage,
+		}, "storage")
+		assertMentions(e, "a move to a storage the instance lacks", refused, "destination_storage_name", "Gitaly")
+		refused = harness.ExpectToolError(s, actionStorageMoveScheduleAllProject, map[string]any{
+			"source_storage_name": missingStorage + "-source", "destination_storage_name": missingStorage,
+		}, "storage")
+		e.T.Logf("a move of every project between storages the instance lacks is refused: %s", firstLine(refused))
+	})
+}
+
+// moveListed reports whether a move listing holds one by ID.
+func moveListed(moves []projectstoragemoves.Output, id int64) bool {
+	for _, move := range moves {
+		if move.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/gitlab/common/reads_sweep_test.go
+++ b/test/e2e/gitlab/common/reads_sweep_test.go
@@ -48,8 +48,9 @@ type unboundEntry struct {
 // TestReads_Sweep reads every read-only action whose required parameters bind
 // from the World, on the dynamic, meta and individual surfaces.
 //
-// Replaces: the list-and-get coverage the old per-domain suite spread across
-// its TestIndividual_*, TestMeta_* and TestDynamicToolSurface_* families.
+// It replaces no old test by name: the old per-domain suite spread its
+// list-and-get coverage across its TestIndividual_*, TestMeta_* and
+// TestDynamicToolSurface_* families, whose ports name them.
 func TestReads_Sweep(t *testing.T) {
 	e := harness.New(t)
 	world := fixture.SharedWorld(e)

--- a/test/e2e/gitlab/common/runners_test.go
+++ b/test/e2e/gitlab/common/runners_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+// runners_test.go covers what a session can say about the instance runner
+// the Docker stack registers: list it at every scope, read it and its
+// managers, and show what happens when a project tries to claim it, which
+// an instance runner refuses, and to release it, which a runner never held
+// answers as a not-found.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/runners"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// missingGroupID is a group nothing on an instance has, spelled as the
+// group_id parameter takes it.
+const missingGroupID = "0"
+
+// TestRunners_DockerRunner_ListedReadAndNotClaimable finds the Docker
+// runner in the instance listing on every surface, reads it and its
+// managers, lists a project's and a group's runners, and shows a project
+// can neither claim nor release an instance runner.
+//
+// Replaces: TestEE_MetaRunnerManagement
+func TestRunners_DockerRunner_ListedReadAndNotClaimable(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin, harness.NeedRunner))
+	runnerID := fixture.DockerRunnerID(e)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("runners"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("runners"))
+
+		all := harness.Do[runners.ListOutput](s, actionRunnerListAll, nil)
+		found := false
+		for _, runner := range all.Runners {
+			if runner.ID == runnerID {
+				found = true
+			}
+		}
+		if !found {
+			e.T.Errorf("the instance listing of %d runner(s) does not hold the Docker runner %d", len(all.Runners), runnerID)
+		}
+
+		ofProject := harness.Do[runners.ListOutput](s, actionRunnerListProject, map[string]any{"project_id": project.IDParam()})
+		e.T.Logf("project %s sees %d runner(s)", project.Path, len(ofProject.Runners))
+		ofGroup := harness.Do[runners.ListOutput](s, actionRunnerListGroup, map[string]any{"group_id": group.IDParam()})
+		e.T.Logf("group %s sees %d runner(s)", group.Path, len(ofGroup.Runners))
+		refused := harness.Refused(s, actionRunnerListGroup, map[string]any{"group_id": missingGroupID}, harness.FailureNotFound)
+		e.T.Logf("the runners of a missing group are refused: %s", firstLine(refused))
+
+		got := harness.Do[runners.DetailsOutput](s, actionRunnerGet, map[string]any{"runner_id": runnerID})
+		if got.ID != runnerID {
+			e.T.Errorf("get answered runner %d, want %d", got.ID, runnerID)
+		}
+		managers := harness.Do[runners.ManagerListOutput](s, actionRunnerListManagers, map[string]any{"runner_id": runnerID})
+		e.T.Logf("runner %d has %d manager(s)", runnerID, len(managers.Managers))
+
+		claim := map[string]any{"project_id": project.IDParam(), "runner_id": runnerID}
+		refused = harness.ExpectToolError(s, actionRunnerEnableProject, claim, "runner")
+		e.T.Logf("claiming the instance runner for a project is refused: %s", firstLine(refused))
+		refused = harness.Refused(s, actionRunnerDisableProject, claim, harness.FailureNotFound)
+		e.T.Logf("releasing a runner the project never held is refused: %s", firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/common/snippetstoragemoves_test.go
+++ b/test/e2e/gitlab/common/snippetstoragemoves_test.go
@@ -1,0 +1,54 @@
+//go:build e2e
+
+// snippetstoragemoves_test.go covers a snippet's repository storage moves,
+// the snippet half of the Free storage move family: the listings of a real
+// snippet answer, and everything asked about a snippet or a move that does
+// not exist is a not-found.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/snippetstoragemoves"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// missingSnippetID is a snippet nothing on a fresh instance has.
+const missingSnippetID = int64(999999)
+
+// TestSnippetStorageMoves_SingleStorage_ListsAndRefusesTheMissing lists
+// the moves of a snippet of the surface's own and of every snippet, then
+// reads and schedules against a snippet and a move that do not exist.
+//
+// Replaces: TestMeta_StorageMoves, TestMeta_SnippetStorageMoves_Graceful404
+func TestSnippetStorageMoves_SingleStorage_ListsAndRefusesTheMissing(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		snippet := fixture.NewSnippet(e)
+
+		mine := harness.Do[snippetstoragemoves.ListOutput](s, actionStorageMoveRetrieveSnippet, map[string]any{"snippet_id": snippet.ID})
+		if len(mine.Moves) != 0 {
+			e.T.Errorf("a fresh snippet lists %d storage moves: %+v", len(mine.Moves), mine.Moves)
+		}
+		all := harness.Do[snippetstoragemoves.ListOutput](s, actionStorageMoveRetrieveAllSnippet, nil)
+		e.T.Logf("%d snippet storage move(s) on the instance", len(all.Moves))
+
+		refused := harness.Refused(s, actionStorageMoveRetrieveSnippet, map[string]any{"snippet_id": missingSnippetID}, harness.FailureNotFound)
+		e.T.Logf("the moves of a missing snippet are refused: %s", firstLine(refused))
+		refused = harness.Refused(s, actionStorageMoveGetSnippet, map[string]any{"id": missingMoveID}, harness.FailureNotFound)
+		e.T.Logf("the read of a missing move is refused: %s", firstLine(refused))
+		refused = harness.Refused(s, actionStorageMoveGetSnippetForSnippet, map[string]any{"snippet_id": snippet.ID, "id": missingMoveID}, harness.FailureNotFound)
+		e.T.Logf("the read of a missing move of the snippet is refused: %s", firstLine(refused))
+		refused = harness.Refused(s, actionStorageMoveScheduleSnippet, map[string]any{"snippet_id": missingSnippetID}, harness.FailureNotFound)
+		e.T.Logf("a move of a missing snippet is refused: %s", firstLine(refused))
+
+		refused = harness.ExpectToolError(s, actionStorageMoveScheduleAllSnippet, map[string]any{
+			"source_storage_name": missingStorage + "-source", "destination_storage_name": missingStorage,
+		}, "storage")
+		e.T.Logf("a move of every snippet between storages the instance lacks is refused: %s", firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/common/users_test.go
+++ b/test/e2e/gitlab/common/users_test.go
@@ -1,0 +1,71 @@
+//go:build e2e
+
+// users_test.go covers the instance-level service accounts of the user
+// group: list them, create one, update it. The account is a user, so it is
+// removed through the fixture library's user deletion rather than through
+// a delete of its own, which the group has none for.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/users"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestUserServiceAccounts_Instance_ListsCreatesAndUpdates creates one
+// instance service account per surface, finds it in the listing and
+// renames it. Service accounts are an administrator's to create.
+//
+// Replaces: TestEE_MetaUserServiceAccounts
+func TestUserServiceAccounts_Instance_ListsCreatesAndUpdates(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+
+		before := harness.Do[users.ServiceAccountListOutput](s, actionUserListServiceAccounts, nil)
+		e.T.Logf("%d instance service account(s) before the create", len(before.Accounts))
+
+		name := e.Name("sa")
+		created := harness.Do[users.Output](s, actionUserCreateServiceAccount, map[string]any{"name": name, "username": name})
+		if created.ID == 0 {
+			e.T.Fatalf("create_service_account answered %+v, want an account with an ID", created)
+		}
+		// The account is a user, and the user group has no delete of its own
+		// for a service account: the test's cleanup removes it the way an
+		// agent's session would, through the user delete, and the fixture's
+		// deletion behind it is the safety net for a delete that failed.
+		e.Defer("service account "+name, func(ctx context.Context) error {
+			return fixture.DeleteUser(ctx, e.Client(), created.ID)
+		})
+		e.T.Cleanup(func() {
+			if _, err := harness.Try[users.DeleteOutput](s, actionUserDelete, map[string]any{"user_id": created.ID}, harness.For(harness.PurposeCleanup)); err != nil {
+				e.T.Logf("the cleanup delete of service account %d answered: %v", created.ID, err)
+			}
+		})
+
+		// Newest first, so the account just created is on the first page
+		// whatever earlier runs left on the instance.
+		after := harness.Do[users.ServiceAccountListOutput](s, actionUserListServiceAccounts, map[string]any{"order_by": "id", "sort": "desc"})
+		found := false
+		for _, account := range after.Accounts {
+			if account.ID == created.ID {
+				found = true
+			}
+		}
+		if !found {
+			e.T.Errorf("the listing does not hold the created account %d: %+v", created.ID, after.Accounts)
+		}
+
+		updated := harness.Do[users.Output](s, actionUserUpdateServiceAccount, map[string]any{
+			"service_account_id": created.ID, "name": "Updated " + name,
+		})
+		if updated.ID != created.ID {
+			e.T.Errorf("update_service_account answered account %d, want %d", updated.ID, created.ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/actions_test.go
+++ b/test/e2e/gitlab/ee/actions_test.go
@@ -1,0 +1,260 @@
+//go:build e2e
+
+// actions_test.go names every catalog action this package calls, once.
+//
+// They are typed constants rather than string literals at the call sites
+// because the push-time static gate reads constants of the harness's
+// ActionID type out of the type checker's record, follows them through
+// helper parameters, and checks each against the catalog and against the
+// package's tier. A literal would be invisible to it. Keeping them together
+// also means a renamed action fails to compile in one place.
+//
+// A Free action is here too where the scenario that drives it needs a
+// license: the license endpoints, a merge request's approval reset, a
+// deployment's approval and the group Datadog integration are Free in the
+// catalog and answer only on a licensed instance.
+
+package ee
+
+import "github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+
+// The license, the one thing this package changes about the instance.
+const (
+	actionLicenseGet    harness.ActionID = "admin.license_get"
+	actionLicenseAdd    harness.ActionID = "admin.license_add"
+	actionLicenseDelete harness.ActionID = "admin.license_delete"
+)
+
+// Audit events at their three scopes.
+const (
+	actionAuditEventListProject  harness.ActionID = "audit_event.list_project"
+	actionAuditEventGetProject   harness.ActionID = "audit_event.get_project"
+	actionAuditEventListGroup    harness.ActionID = "audit_event.list_group"
+	actionAuditEventGetGroup     harness.ActionID = "audit_event.get_group"
+	actionAuditEventListInstance harness.ActionID = "audit_event.list_instance"
+	actionAuditEventGetInstance  harness.ActionID = "audit_event.get_instance"
+)
+
+// Merge trains.
+const (
+	actionMergeTrainListProject harness.ActionID = "merge_train.list_project"
+	actionMergeTrainListBranch  harness.ActionID = "merge_train.list_branch"
+	actionMergeTrainAdd         harness.ActionID = "merge_train.add"
+	actionMergeTrainGet         harness.ActionID = "merge_train.get"
+)
+
+// DORA metrics.
+const (
+	actionDORAMetricsProject harness.ActionID = "dora_metrics.project"
+	actionDORAMetricsGroup   harness.ActionID = "dora_metrics.group"
+)
+
+// Dependencies and their exports.
+const (
+	actionDependencyList           harness.ActionID = "dependency.list"
+	actionDependencyExportCreate   harness.ActionID = "dependency.export_create"
+	actionDependencyExportGet      harness.ActionID = "dependency.export_get"
+	actionDependencyExportDownload harness.ActionID = "dependency.export_download"
+)
+
+// External status checks.
+const (
+	actionStatusCheckListProjectChecks   harness.ActionID = "external_status_check.list_project_checks"
+	actionStatusCheckListProject         harness.ActionID = "external_status_check.list_project"
+	actionStatusCheckCreateProject       harness.ActionID = "external_status_check.create_project"
+	actionStatusCheckUpdateProject       harness.ActionID = "external_status_check.update_project"
+	actionStatusCheckDeleteProject       harness.ActionID = "external_status_check.delete_project"
+	actionStatusCheckListProjectMRChecks harness.ActionID = "external_status_check.list_project_mr_checks"
+	actionStatusCheckSetProjectMRStatus  harness.ActionID = "external_status_check.set_project_mr_status"
+	actionStatusCheckRetryProject        harness.ActionID = "external_status_check.retry_project"
+)
+
+// Custom member roles at both levels.
+const (
+	actionMemberRoleListInstance   harness.ActionID = "member_role.list_instance"
+	actionMemberRoleCreateInstance harness.ActionID = "member_role.create_instance"
+	actionMemberRoleDeleteInstance harness.ActionID = "member_role.delete_instance"
+	actionMemberRoleListGroup      harness.ActionID = "member_role.list_group"
+	actionMemberRoleCreateGroup    harness.ActionID = "member_role.create_group"
+	actionMemberRoleDeleteGroup    harness.ActionID = "member_role.delete_group"
+)
+
+// Attestations.
+const (
+	actionAttestationList     harness.ActionID = "attestation.list"
+	actionAttestationDownload harness.ActionID = "attestation.download"
+)
+
+// The compliance policy settings.
+const (
+	actionCompliancePolicyGet    harness.ActionID = "compliance_policy.get"
+	actionCompliancePolicyUpdate harness.ActionID = "compliance_policy.update"
+)
+
+// Project aliases.
+const (
+	actionProjectAliasList   harness.ActionID = "project_alias.list"
+	actionProjectAliasCreate harness.ActionID = "project_alias.create"
+	actionProjectAliasGet    harness.ActionID = "project_alias.get"
+	actionProjectAliasDelete harness.ActionID = "project_alias.delete"
+)
+
+// Geo sites.
+const (
+	actionGeoList       harness.ActionID = "geo.list"
+	actionGeoCreate     harness.ActionID = "geo.create"
+	actionGeoGet        harness.ActionID = "geo.get"
+	actionGeoEdit       harness.ActionID = "geo.edit"
+	actionGeoListStatus harness.ActionID = "geo.list_status"
+	actionGeoGetStatus  harness.ActionID = "geo.get_status"
+	actionGeoRepair     harness.ActionID = "geo.repair"
+	actionGeoDelete     harness.ActionID = "geo.delete"
+)
+
+// Group storage moves, the licensed half of the storage move family.
+const (
+	actionStorageMoveRetrieveAllGroup harness.ActionID = "storage_move.retrieve_all_group"
+	actionStorageMoveRetrieveGroup    harness.ActionID = "storage_move.retrieve_group"
+	actionStorageMoveGetGroup         harness.ActionID = "storage_move.get_group"
+	actionStorageMoveGetGroupForGroup harness.ActionID = "storage_move.get_group_for_group"
+	actionStorageMoveScheduleGroup    harness.ActionID = "storage_move.schedule_group"
+	actionStorageMoveScheduleAllGroup harness.ActionID = "storage_move.schedule_all_group"
+)
+
+// Security findings, categories, attributes and scan profiles.
+const (
+	actionSecurityFindingList            harness.ActionID = "security_finding.list"
+	actionSecurityCategoryCreate         harness.ActionID = "security_category.create"
+	actionSecurityCategoryUpdate         harness.ActionID = "security_category.update"
+	actionSecurityCategoryDelete         harness.ActionID = "security_category.delete"
+	actionSecurityAttributeCreate        harness.ActionID = "security_attribute.create"
+	actionSecurityAttributeUpdate        harness.ActionID = "security_attribute.update"
+	actionSecurityAttributeDelete        harness.ActionID = "security_attribute.delete"
+	actionSecurityAttributeProjectUpdate harness.ActionID = "security_attribute.project_update"
+	actionSecurityAttributeBulkUpdate    harness.ActionID = "security_attribute.bulk_update"
+	actionScanProfileAttach              harness.ActionID = "security_scan_profile.attach"
+	actionScanProfileDetach              harness.ActionID = "security_scan_profile.detach"
+	actionScanProfileListProjectStatuses harness.ActionID = "security_scan_profile.list_project_statuses"
+)
+
+// Group SCIM identities.
+const (
+	actionGroupSCIMList   harness.ActionID = "group_scim.list"
+	actionGroupSCIMGet    harness.ActionID = "group_scim.get"
+	actionGroupSCIMUpdate harness.ActionID = "group_scim.update"
+	actionGroupSCIMDelete harness.ActionID = "group_scim.delete"
+)
+
+// Enterprise users.
+const (
+	actionEnterpriseUserList       harness.ActionID = "enterprise_user.list"
+	actionEnterpriseUserGet        harness.ActionID = "enterprise_user.get"
+	actionEnterpriseUserDisable2FA harness.ActionID = "enterprise_user.disable_2fa"
+	actionEnterpriseUserDelete     harness.ActionID = "enterprise_user.delete"
+)
+
+// The licensed reads and writes of the group tool that stand on a group
+// alone, and the group Datadog integration the project tool routes.
+const (
+	actionGroupAnalyticsIssuesCount   harness.ActionID = "group.analytics_issues_count"
+	actionGroupAnalyticsMRCount       harness.ActionID = "group.analytics_mr_count"
+	actionGroupAnalyticsMembersCount  harness.ActionID = "group.analytics_members_count"
+	actionGroupSecuritySettingsUpdate harness.ActionID = "group.security_settings_update"
+	actionGroupDatadogSet             harness.ActionID = "project.integration_set_group_datadog"
+	actionGroupDatadogGet             harness.ActionID = "project.integration_get_group_datadog"
+	actionGroupDatadogDelete          harness.ActionID = "project.integration_delete_group_datadog"
+)
+
+// Protected environments and the deployment approval they gate.
+const (
+	actionProtectedEnvProtect       harness.ActionID = "environment.protected_protect"
+	actionProtectedEnvList          harness.ActionID = "environment.protected_list"
+	actionProtectedEnvGet           harness.ActionID = "environment.protected_get"
+	actionProtectedEnvUpdate        harness.ActionID = "environment.protected_update"
+	actionProtectedEnvUnprotect     harness.ActionID = "environment.protected_unprotect"
+	actionDeploymentCreate          harness.ActionID = "environment.deployment_create"
+	actionDeploymentApproveOrReject harness.ActionID = "environment.deployment_approve_or_reject"
+)
+
+// The licensed actions of the project tool.
+const (
+	actionPushRuleAdd                   harness.ActionID = "project.push_rule_add"
+	actionPushRuleGet                   harness.ActionID = "project.push_rule_get"
+	actionPushRuleEdit                  harness.ActionID = "project.push_rule_edit"
+	actionPushRuleDelete                harness.ActionID = "project.push_rule_delete"
+	actionTargetBranchRuleCreate        harness.ActionID = "project.target_branch_rule_create"
+	actionTargetBranchRuleList          harness.ActionID = "project.target_branch_rule_list"
+	actionTargetBranchRuleDelete        harness.ActionID = "project.target_branch_rule_delete"
+	actionPullMirrorGet                 harness.ActionID = "project.pull_mirror_get"
+	actionPullMirrorConfigure           harness.ActionID = "project.pull_mirror_configure"
+	actionStartMirroring                harness.ActionID = "project.start_mirroring"
+	actionProjectApprovalConfigGet      harness.ActionID = "project.approval_config_get"
+	actionProjectApprovalConfigChange   harness.ActionID = "project.approval_config_change"
+	actionProjectApprovalRuleCreate     harness.ActionID = "project.approval_rule_create"
+	actionProjectApprovalRuleList       harness.ActionID = "project.approval_rule_list"
+	actionProjectApprovalRuleGet        harness.ActionID = "project.approval_rule_get"
+	actionProjectApprovalRuleUpdate     harness.ActionID = "project.approval_rule_update"
+	actionProjectApprovalRuleDelete     harness.ActionID = "project.approval_rule_delete"
+	actionProjectSecuritySettingsGet    harness.ActionID = "project.security_settings_get"
+	actionProjectSecuritySettingsUpdate harness.ActionID = "project.security_settings_update"
+)
+
+// The licensed actions of the merge request tool, and the three Free ones
+// its approval scenarios stand on.
+const (
+	actionApprovalSettingsProjectGet    harness.ActionID = "merge_request.approval_settings_project_get"
+	actionApprovalSettingsProjectUpdate harness.ActionID = "merge_request.approval_settings_project_update"
+	actionApprovalSettingsGroupGet      harness.ActionID = "merge_request.approval_settings_group_get"
+	actionApprovalSettingsGroupUpdate   harness.ActionID = "merge_request.approval_settings_group_update"
+	actionMRApprovalState               harness.ActionID = "merge_request.approval_state"
+	actionMRApprovalRules               harness.ActionID = "merge_request.approval_rules"
+	actionMRApprovalConfig              harness.ActionID = "merge_request.approval_config"
+	actionMRApprovalRuleCreate          harness.ActionID = "merge_request.approval_rule_create"
+	actionMRApprovalRuleUpdate          harness.ActionID = "merge_request.approval_rule_update"
+	actionMRApprovalRuleDelete          harness.ActionID = "merge_request.approval_rule_delete"
+	actionMRApprove                     harness.ActionID = "merge_request.approve"
+	actionMRApprovalReset               harness.ActionID = "merge_request.approval_reset"
+	actionMRDependenciesList            harness.ActionID = "merge_request.dependencies_list"
+	actionMRDependencyCreate            harness.ActionID = "merge_request.dependency_create"
+	actionMRDependencyDelete            harness.ActionID = "merge_request.dependency_delete"
+)
+
+// The licensed reads of the issue tool.
+const (
+	actionIssueWeightEventList    harness.ActionID = "issue.event_issue_weight_list"
+	actionIterationListProject    harness.ActionID = "issue.iteration_list_project"
+	actionIterationListGroup      harness.ActionID = "issue.iteration_list_group"
+	actionIssueIterationEventList harness.ActionID = "issue.event_issue_iteration_list"
+	actionIssueIterationEventGet  harness.ActionID = "issue.event_issue_iteration_get"
+)
+
+// Runner controllers, their tokens and their scopes.
+const (
+	actionRunnerControllerList                harness.ActionID = "runner.controller_list"
+	actionRunnerControllerGet                 harness.ActionID = "runner.controller_get"
+	actionRunnerControllerCreate              harness.ActionID = "runner.controller_create"
+	actionRunnerControllerUpdate              harness.ActionID = "runner.controller_update"
+	actionRunnerControllerDelete              harness.ActionID = "runner.controller_delete"
+	actionRunnerControllerTokenCreate         harness.ActionID = "runner.controller_token_create"
+	actionRunnerControllerTokenList           harness.ActionID = "runner.controller_token_list"
+	actionRunnerControllerTokenGet            harness.ActionID = "runner.controller_token_get"
+	actionRunnerControllerTokenRotate         harness.ActionID = "runner.controller_token_rotate"
+	actionRunnerControllerTokenRevoke         harness.ActionID = "runner.controller_token_revoke"
+	actionRunnerControllerScopeList           harness.ActionID = "runner.controller_scope_list"
+	actionRunnerControllerScopeAddInstance    harness.ActionID = "runner.controller_scope_add_instance"
+	actionRunnerControllerScopeRemoveInstance harness.ActionID = "runner.controller_scope_remove_instance"
+	actionRunnerControllerScopeAddRunner      harness.ActionID = "runner.controller_scope_add_runner"
+	actionRunnerControllerScopeRemoveRunner   harness.ActionID = "runner.controller_scope_remove_runner"
+)
+
+// Vulnerabilities.
+const (
+	actionVulnerabilitySeverityCount           harness.ActionID = "vulnerability.severity_count"
+	actionVulnerabilityList                    harness.ActionID = "vulnerability.list"
+	actionVulnerabilityPipelineSecuritySummary harness.ActionID = "vulnerability.pipeline_security_summary"
+	actionVulnerabilityGet                     harness.ActionID = "vulnerability.get"
+	actionVulnerabilityConfirm                 harness.ActionID = "vulnerability.confirm"
+	actionVulnerabilityResolve                 harness.ActionID = "vulnerability.resolve"
+	actionVulnerabilityRevert                  harness.ActionID = "vulnerability.revert"
+	actionVulnerabilityDismiss                 harness.ActionID = "vulnerability.dismiss"
+)

--- a/test/e2e/gitlab/ee/attestations_test.go
+++ b/test/e2e/gitlab/ee/attestations_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+
+// attestations_test.go covers the two attestation actions on a project that
+// has published none: the listing by subject digest answers empty, and the
+// download of an attestation that does not exist is refused with the hint
+// naming the listing to find one in.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/attestations"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// emptySubjectDigest is a well-formed digest nothing was ever attested
+// under.
+const emptySubjectDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+// TestAttestations_UnattestedProject_ListsNothingAndRefusesADownload lists
+// the attestations of a fresh project under a digest and asks for one by a
+// number nothing has, on every surface.
+//
+// Replaces: TestMeta_Attestations
+func TestAttestations_UnattestedProject_ListsNothingAndRefusesADownload(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("attest"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+
+		listed := harness.Do[attestations.ListOutput](s, actionAttestationList,
+			map[string]any{"project_id": project.IDParam(), "subject_digest": emptySubjectDigest})
+		if len(listed.Attestations) != 0 {
+			e.T.Errorf("a project that attested nothing lists %d attestations: %+v", len(listed.Attestations), listed.Attestations)
+		}
+
+		refused := harness.Refused(s, actionAttestationDownload,
+			map[string]any{"project_id": project.IDParam(), "attestation_iid": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the download of a missing attestation", refused, "attestation_iid", "gitlab_attestation", "gitlab_list_attestations")
+	})
+}

--- a/test/e2e/gitlab/ee/auditevents_test.go
+++ b/test/e2e/gitlab/ee/auditevents_test.go
@@ -1,0 +1,99 @@
+//go:build e2e
+
+// auditevents_test.go covers the audit event reads at their three scopes:
+// a project's, a group's and the instance's, each listed and then read back
+// one event at a time.
+//
+// The fixture causes the events it then asks for, by editing a group and a
+// project it owns through client-go, so a listing that comes back empty is
+// a listing that missed something rather than a scope nothing happened in.
+// GitLab writes audit events asynchronously, which is why the first read of
+// each scope waits for them.
+
+package ee
+
+import (
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/auditevents"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The audit event waits: GitLab indexes an event a moment after the change
+// that caused it, and a loaded Docker instance takes longer.
+const (
+	auditEventInterval = 2 * time.Second
+	auditEventWait     = 90 * time.Second
+)
+
+// auditFixture is a group and a project whose descriptions were changed,
+// so each carries at least one audit event of its own.
+type auditFixture struct {
+	group   fixture.Group
+	project fixture.Project
+}
+
+// buildAuditFixture creates the two objects and edits each once through
+// client-go, which is the mutation GitLab records.
+func buildAuditFixture(e *harness.Env) auditFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("audit"))
+	project := fixture.NewProject(e, fixture.WithNamePrefix("audit"))
+
+	if _, _, err := e.Client().GL().Groups.UpdateGroup(group.ID, &gl.UpdateGroupOptions{
+		Description: new("e2e audit event fixture"),
+	}, gl.WithContext(e.Ctx)); err != nil {
+		e.T.Fatalf("editing group %d to cause an audit event: %v", group.ID, err)
+	}
+	if _, _, err := e.Client().GL().Projects.EditProject(project.ID, &gl.EditProjectOptions{
+		Description: new("e2e audit event fixture"),
+	}, gl.WithContext(e.Ctx)); err != nil {
+		e.T.Fatalf("editing project %d to cause an audit event: %v", project.ID, err)
+	}
+	return auditFixture{group: group, project: project}
+}
+
+// hasAuditEvents is the condition each listing waits for.
+func hasAuditEvents(out auditevents.ListOutput) bool { return len(out.AuditEvents) > 0 }
+
+// TestAuditEvents_EachScope_ListsAndGetsWhatTheFixtureCaused lists the
+// audit events of the fixture's project, its group and the instance on
+// every surface, waiting for GitLab to index them, and reads the first of
+// each back by ID. The instance scope is the administrator's, which the
+// run's token is.
+//
+// Replaces: TestMeta_AuditEvents, TestMeta_AuditEventListActions
+func TestAuditEvents_EachScope_ListsAndGetsWhatTheFixtureCaused(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.SurfacesWith(e, buildAuditFixture, func(e *harness.Env, surface harness.Surface, f auditFixture) {
+		s := e.On(surface)
+
+		projectEvents := harness.Eventually(s, actionAuditEventListProject,
+			map[string]any{"project_id": f.project.IDParam(), "per_page": 20}, auditEventInterval, auditEventWait, hasAuditEvents)
+		projectEvent := harness.Do[auditevents.Output](s, actionAuditEventGetProject,
+			map[string]any{"project_id": f.project.IDParam(), "event_id": projectEvents.AuditEvents[0].ID})
+		if projectEvent.ID != projectEvents.AuditEvents[0].ID {
+			e.T.Errorf("get_project answered event %d, want the listed %d", projectEvent.ID, projectEvents.AuditEvents[0].ID)
+		}
+
+		groupEvents := harness.Eventually(s, actionAuditEventListGroup,
+			map[string]any{"group_id": f.group.IDParam(), "per_page": 20}, auditEventInterval, auditEventWait, hasAuditEvents)
+		groupEvent := harness.Do[auditevents.Output](s, actionAuditEventGetGroup,
+			map[string]any{"group_id": f.group.IDParam(), "event_id": groupEvents.AuditEvents[0].ID})
+		if groupEvent.ID != groupEvents.AuditEvents[0].ID {
+			e.T.Errorf("get_group answered event %d, want the listed %d", groupEvent.ID, groupEvents.AuditEvents[0].ID)
+		}
+
+		instanceEvents := harness.Eventually(s, actionAuditEventListInstance,
+			map[string]any{"per_page": 20}, auditEventInterval, auditEventWait, hasAuditEvents)
+		instanceEvent := harness.Do[auditevents.Output](s, actionAuditEventGetInstance,
+			map[string]any{"event_id": instanceEvents.AuditEvents[0].ID})
+		if instanceEvent.ID != instanceEvents.AuditEvents[0].ID {
+			e.T.Errorf("get_instance answered event %d, want the listed %d", instanceEvent.ID, instanceEvents.AuditEvents[0].ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/compliancepolicy_test.go
+++ b/test/e2e/gitlab/ee/compliancepolicy_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+// compliancepolicy_test.go covers the instance's compliance policy
+// settings: the read, and the two refusals the update makes, one before
+// GitLab is asked and one from GitLab. Nothing here changes the setting,
+// which is instance-wide and would be visible to every other test.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/compliancepolicy"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestCompliancePolicy_Settings_ReadAndTheUpdateRefusals reads the
+// settings on every surface, then asks for an update with no namespace,
+// which the handler refuses before any request, and one naming a namespace
+// that does not exist, which GitLab refuses.
+//
+// Replaces: TestMeta_CompliancePolicy
+func TestCompliancePolicy_Settings_ReadAndTheUpdateRefusals(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin, harness.Tier(edition.Ultimate)))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+
+		settings := harness.Do[compliancepolicy.Output](s, actionCompliancePolicyGet, nil)
+		if settings.CSPNamespaceID == nil {
+			e.T.Log("no compliance policy namespace is set")
+		} else {
+			e.T.Logf("the compliance policy namespace is %d", *settings.CSPNamespaceID)
+		}
+
+		refused := harness.ExpectToolError(s, actionCompliancePolicyUpdate, nil, "csp_namespace_id")
+		assertMentions(e, "the update with no namespace", refused, "required")
+
+		refused = harness.ExpectToolError(s, actionCompliancePolicyUpdate, map[string]any{"csp_namespace_id": missingID}, "csp_namespace_id")
+		assertMentions(e, "the update naming a missing namespace", refused, "top-level group", "lock")
+	})
+}

--- a/test/e2e/gitlab/ee/dependencies_test.go
+++ b/test/e2e/gitlab/ee/dependencies_test.go
@@ -1,0 +1,56 @@
+//go:build e2e
+
+// dependencies_test.go covers the dependency list of a project and the three
+// export actions, which on a project that never ran a dependency scan can
+// only be shown to route and to refuse an export that does not exist with
+// the hint that says where one comes from.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/dependencies"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// missingID is an identifier nothing on a fresh instance has, for the reads
+// whose subject is the not-found they answer.
+const missingID = int64(999999999)
+
+// TestDependencies_UnscannedProject_ListsNothingAndRefusesMissingExports
+// lists the dependencies of a project with no scan, plain and filtered by
+// package manager, and asks for an export of a pipeline and an export ID
+// that do not exist, on every surface.
+//
+// Replaces: TestMeta_Dependencies
+func TestDependencies_UnscannedProject_ListsNothingAndRefusesMissingExports(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("deps"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+
+		listed := harness.Do[dependencies.ListOutput](s, actionDependencyList, map[string]any{"project_id": project.IDParam()})
+		if len(listed.Dependencies) != 0 {
+			e.T.Errorf("a project with no scan lists %d dependencies: %+v", len(listed.Dependencies), listed.Dependencies)
+		}
+		filtered := harness.Do[dependencies.ListOutput](s, actionDependencyList,
+			map[string]any{"project_id": project.IDParam(), "package_manager": "npm", "per_page": 10})
+		if len(filtered.Dependencies) != 0 {
+			e.T.Errorf("a project with no scan lists %d npm dependencies: %+v", len(filtered.Dependencies), filtered.Dependencies)
+		}
+
+		refused := harness.Refused(s, actionDependencyExportCreate, map[string]any{"pipeline_id": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the export of a missing pipeline", refused, "pipeline_id", "gitlab_pipeline", "dependency scanning", "SBOM")
+
+		refused = harness.Refused(s, actionDependencyExportGet, map[string]any{"export_id": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the read of a missing export", refused, "export_id", "gitlab_create_dependency_list_export", "finished")
+
+		refused = harness.Refused(s, actionDependencyExportDownload, map[string]any{"export_id": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the download of a missing export", refused, "export_id", "gitlab_get_dependency_list_export", "CycloneDX")
+	})
+}

--- a/test/e2e/gitlab/ee/dorametrics_test.go
+++ b/test/e2e/gitlab/ee/dorametrics_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+// dorametrics_test.go covers the two DORA metric reads, a project's and a
+// group's, and the one refusal the project read makes on its own: an
+// environment tier filter the endpoint does not take.
+
+package ee
+
+import (
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/dorametrics"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// doraFixture is a group and a project to ask metrics of.
+type doraFixture struct {
+	group   fixture.Group
+	project fixture.Project
+}
+
+// buildDORAFixture creates both. Neither has deployed anything, so every
+// metric is empty, and what the test asserts is that each scope answers.
+func buildDORAFixture(e *harness.Env) doraFixture {
+	return doraFixture{
+		group:   fixture.NewGroup(e, fixture.WithGroupNamePrefix("dora")),
+		project: fixture.NewProject(e, fixture.WithNamePrefix("dora")),
+	}
+}
+
+// TestDORAMetrics_ProjectAndGroup_AnswerOverTheLastMonth reads the
+// deployment frequency of a project and the lead time of a group over the
+// last month on every surface, and shows that an environment_tiers filter is
+// refused with the hint to omit it.
+//
+// Replaces: TestMeta_DORAMetrics
+func TestDORAMetrics_ProjectAndGroup_AnswerOverTheLastMonth(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+	end := time.Now().UTC()
+	start := end.AddDate(0, -1, 0)
+	window := map[string]any{"start_date": start.Format(time.DateOnly), "end_date": end.Format(time.DateOnly)}
+
+	harness.SurfacesWith(e, buildDORAFixture, func(e *harness.Env, surface harness.Surface, f doraFixture) {
+		s := e.On(surface)
+
+		project := harness.Do[dorametrics.Output](s, actionDORAMetricsProject, withParams(window, map[string]any{
+			"project_id": f.project.IDParam(), "metric": "deployment_frequency", "interval": "daily",
+		}))
+		e.T.Logf("project %s deployment frequency: %d metric rows", f.project.Path, len(project.Metrics))
+
+		refused := harness.ExpectToolError(s, actionDORAMetricsProject, withParams(window, map[string]any{
+			"project_id": f.project.IDParam(), "metric": "deployment_frequency", "interval": "daily",
+			"environment_tiers": []string{"production"},
+		}), "environment_tiers")
+		assertMentions(e, "the environment_tiers refusal", refused, "omit environment_tiers", "deployment environment tiers")
+
+		group := harness.Do[dorametrics.Output](s, actionDORAMetricsGroup, withParams(window, map[string]any{
+			"group_id": f.group.IDParam(), "metric": "lead_time_for_changes", "interval": "all",
+		}))
+		e.T.Logf("group %s lead time: %d metric rows", f.group.Path, len(group.Metrics))
+	})
+}
+
+// withParams returns one parameter map holding both, for a call that shares
+// a window or a scope with its siblings and adds its own.
+func withParams(shared, own map[string]any) map[string]any {
+	merged := make(map[string]any, len(shared)+len(own))
+	maps.Copy(merged, shared)
+	maps.Copy(merged, own)
+	return merged
+}

--- a/test/e2e/gitlab/ee/enterpriseusers_test.go
+++ b/test/e2e/gitlab/ee/enterpriseusers_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+// enterpriseusers_test.go covers the enterprise user actions on a group
+// that manages no user: the listing answers empty, plain and filtered, and
+// the read, the 2FA reset and the delete of a user the group does not
+// manage are refused with the hint naming the listing.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/enterpriseusers"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestEnterpriseUsers_UnmanagedGroup_ListsNothingAndRefusesAMissingUser
+// lists a fresh group's enterprise users on every surface, with and without
+// filters, and asks about a user nothing manages through get, disable_2fa
+// and delete.
+//
+// Replaces: TestMeta_EnterpriseUsers
+func TestEnterpriseUsers_UnmanagedGroup_ListsNothingAndRefusesAMissingUser(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("entusers"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		hint := []string{"user_id", "gitlab_enterprise_user", "enterprise namespace"}
+
+		listed := harness.Do[enterpriseusers.ListOutput](s, actionEnterpriseUserList, map[string]any{"group_id": group.IDParam()})
+		if len(listed.Users) != 0 {
+			e.T.Errorf("a group that manages nobody lists %d enterprise users: %+v", len(listed.Users), listed.Users)
+		}
+		filtered := harness.Do[enterpriseusers.ListOutput](s, actionEnterpriseUserList, map[string]any{
+			"group_id": group.IDParam(), "search": "e2e-nonexistent-enterprise-user", "active": true, "two_factor": "disabled", "per_page": 10,
+		})
+		if len(filtered.Users) != 0 {
+			e.T.Errorf("the filtered listing holds %d enterprise users: %+v", len(filtered.Users), filtered.Users)
+		}
+
+		refused := harness.Refused(s, actionEnterpriseUserGet, map[string]any{"group_id": group.IDParam(), "user_id": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the read of an unmanaged user", refused, hint...)
+
+		refused = harness.Refused(s, actionEnterpriseUserDisable2FA, map[string]any{"group_id": group.IDParam(), "user_id": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the 2FA reset of an unmanaged user", refused, hint...)
+
+		refused = harness.Refused(s, actionEnterpriseUserDelete, map[string]any{"group_id": group.IDParam(), "user_id": missingID, "hard_delete": false}, harness.FailureNotFound)
+		assertMentions(e, "the delete of an unmanaged user", refused, "user_id", "gitlab_enterprise_user", "irreversible")
+	})
+}

--- a/test/e2e/gitlab/ee/externalstatuschecks_test.go
+++ b/test/e2e/gitlab/ee/externalstatuschecks_test.go
@@ -1,0 +1,122 @@
+//go:build e2e
+
+// externalstatuschecks_test.go covers the external status check lifecycle
+// on a project and on one of its merge requests: create, list twice (the
+// current listing and the deprecated one), update, set the check's status
+// on the request, retry, and delete.
+//
+// The retry is the one step that refuses: a check can only be retried from
+// the failed state, and the fixture sets it to passed a moment before, so
+// the refusal is the assertion and names the listing to read the state from.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/externalstatuschecks"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// statusCheckFixture is a project with a mergeable merge request whose head
+// commit the status is set on.
+type statusCheckFixture struct {
+	project fixture.Project
+	mr      fixture.MergeRequest
+	commit  fixture.Commit
+}
+
+// buildStatusCheckFixture creates the project, a branch with one commit and
+// the merge request from it.
+func buildStatusCheckFixture(e *harness.Env) statusCheckFixture {
+	project := fixture.NewProject(e, fixture.WithNamePrefix("esc"))
+	branch := fixture.NewBranch(e, project, e.Name("esc"))
+	commit := fixture.CommitFile(e, project, branch.Name, "external-status.txt", "external status check\n", "add the external status check fixture")
+	mr := fixture.NewMergeRequest(e, project, branch.Name, project.DefaultBranch, "external status check fixture")
+	return statusCheckFixture{project: project, mr: mr, commit: commit}
+}
+
+// mergeStatusCheckStatus returns the status a merge request listing reports
+// for one check, and whether the check is listed at all.
+func mergeStatusCheckStatus(items []externalstatuschecks.MergeStatusCheckOutput, checkID int64) (string, bool) {
+	for _, item := range items {
+		if item.ID == checkID {
+			return item.Status, true
+		}
+	}
+	return "", false
+}
+
+// TestExternalStatusChecks_Lifecycle_CreatesSetsRetriesAndDeletes walks one
+// check per surface through its whole life on the shared merge request.
+//
+// Replaces: TestMeta_ExternalStatusChecks
+func TestExternalStatusChecks_Lifecycle_CreatesSetsRetriesAndDeletes(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, buildStatusCheckFixture, func(e *harness.Env, surface harness.Surface, f statusCheckFixture) {
+		s := e.On(surface)
+		project := f.project.IDParam()
+
+		deprecated := harness.Do[externalstatuschecks.ListProjectStatusCheckOutput](s, actionStatusCheckListProjectChecks, map[string]any{"project_id": project})
+		e.T.Logf("the deprecated project listing holds %d check(s) before the create", len(deprecated.Items))
+
+		name := e.Name("check")
+		created := harness.Do[externalstatuschecks.ProjectStatusCheckOutput](s, actionStatusCheckCreateProject, map[string]any{
+			"project_id": project, "name": name, "external_url": "https://example.com/e2e/" + name,
+		})
+		if created.ID == 0 || created.Name != name {
+			e.T.Fatalf("create answered %+v, want a check named %q with an ID", created, name)
+		}
+
+		listed := harness.Do[externalstatuschecks.ListProjectStatusCheckOutput](s, actionStatusCheckListProject, map[string]any{"project_id": project})
+		ids := make([]int64, 0, len(listed.Items))
+		for _, item := range listed.Items {
+			ids = append(ids, item.ID)
+		}
+		if !containsID(ids, created.ID) {
+			e.T.Errorf("the project listing does not hold the created check %d: %v", created.ID, ids)
+		}
+
+		updated := harness.Do[externalstatuschecks.ProjectStatusCheckOutput](s, actionStatusCheckUpdateProject, map[string]any{
+			"project_id": project, "check_id": created.ID, "name": name + "-updated", "external_url": "https://example.com/e2e/" + name + "-updated",
+		})
+		if updated.ID != created.ID || updated.Name != name+"-updated" {
+			e.T.Errorf("update answered %+v, want check %d renamed to %q", updated, created.ID, name+"-updated")
+		}
+
+		onRequest := harness.Do[externalstatuschecks.ListMergeStatusCheckOutput](s, actionStatusCheckListProjectMRChecks, map[string]any{
+			"project_id": project, "merge_request_iid": f.mr.IID, "page": 1, "per_page": 10,
+		})
+		if _, listedOnRequest := mergeStatusCheckStatus(onRequest.Items, created.ID); !listedOnRequest {
+			e.T.Errorf("merge request !%d does not list check %d: %+v", f.mr.IID, created.ID, onRequest.Items)
+		}
+
+		harness.DoVoid(s, actionStatusCheckSetProjectMRStatus, map[string]any{
+			"project_id": project, "merge_request_iid": f.mr.IID, "sha": f.commit.SHA,
+			"external_status_check_id": created.ID, "status": "passed",
+		})
+		afterSet := harness.Do[externalstatuschecks.ListMergeStatusCheckOutput](s, actionStatusCheckListProjectMRChecks, map[string]any{
+			"project_id": project, "merge_request_iid": f.mr.IID,
+		})
+		if status, listedOnRequest := mergeStatusCheckStatus(afterSet.Items, created.ID); !listedOnRequest || status != "passed" {
+			e.T.Errorf("check %d on merge request !%d reads %q (listed=%t) after being set to passed", created.ID, f.mr.IID, status, listedOnRequest)
+		}
+
+		// A check that passed cannot be retried: only a failed one can.
+		refused := harness.ExpectToolError(s, actionStatusCheckRetryProject, map[string]any{
+			"project_id": project, "merge_request_iid": f.mr.IID, "check_id": created.ID,
+		}, "failed")
+		assertMentions(e, "the retry of a passed check", refused, "gitlab_list_project_mr_external_status_checks")
+
+		harness.DoVoid(s, actionStatusCheckDeleteProject, map[string]any{"project_id": project, "check_id": created.ID})
+		remaining := harness.Do[externalstatuschecks.ListProjectStatusCheckOutput](s, actionStatusCheckListProject, map[string]any{"project_id": project})
+		for _, item := range remaining.Items {
+			if item.ID == created.ID {
+				e.T.Errorf("check %d is still listed after its delete", created.ID)
+			}
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/geo_test.go
+++ b/test/e2e/gitlab/ee/geo_test.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+// geo_test.go covers the Geo site actions on an instance with no Geo
+// deployment: a disabled secondary site can still be created, read, listed,
+// edited, repaired and deleted, and the status actions answer what a site
+// that never reported gives, an empty status list and a not-found for the
+// site's own status.
+
+package ee
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/geo"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// geoSiteURL is the address the fixture site claims to be at. Nothing ever
+// connects to it: the site is created disabled.
+const geoSiteURL = "https://geo-secondary.example.com/"
+
+// geoRepositoryCapacity is the value the edit changes the site's backfill
+// capacity to, which is read back as the proof the edit happened.
+const geoRepositoryCapacity = int64(11)
+
+// geoSiteIDs lists the IDs of a site listing.
+func geoSiteIDs(sites []geo.Output) []int64 {
+	ids := make([]int64, 0, len(sites))
+	for _, site := range sites {
+		ids = append(ids, site.ID)
+	}
+	return ids
+}
+
+// TestGeo_DisabledSecondarySite_Lifecycle walks one disabled site per
+// surface through create, get, list, edit, the two status reads, repair and
+// delete. Geo is an administrator's, so the run's token must be one.
+//
+// Replaces: TestMeta_Geo
+func TestGeo_DisabledSecondarySite_Lifecycle(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		name := e.Name("geo")
+
+		before := harness.Do[geo.ListOutput](s, actionGeoList, nil)
+		e.T.Logf("%d Geo site(s) before the create", len(before.Sites))
+
+		created := harness.Do[geo.Output](s, actionGeoCreate, map[string]any{
+			"name": name, "url": geoSiteURL, "internal_url": geoSiteURL, "enabled": false,
+		})
+		if created.ID == 0 || created.Name != name || created.Enabled {
+			e.T.Fatalf("create answered %+v, want a disabled site named %q with an ID", created, name)
+		}
+		e.Defer("geo site "+name, func(ctx context.Context) error {
+			_, err := e.Client().GL().GeoSites.DeleteGeoSite(created.ID, gl.WithContext(ctx))
+			if err != nil && !fixture.IsStatus(err, http.StatusNotFound) {
+				return err
+			}
+			return nil
+		})
+
+		got := harness.Do[geo.Output](s, actionGeoGet, map[string]any{"id": created.ID})
+		if got.ID != created.ID || got.Name != name {
+			e.T.Errorf("get answered %+v, want site %d named %q", got, created.ID, name)
+		}
+
+		listed := harness.Do[geo.ListOutput](s, actionGeoList, nil)
+		if !containsID(geoSiteIDs(listed.Sites), created.ID) {
+			e.T.Errorf("the listing does not hold the created site %d: %v", created.ID, geoSiteIDs(listed.Sites))
+		}
+
+		edited := harness.Do[geo.Output](s, actionGeoEdit, map[string]any{
+			"id": created.ID, "name": name + "-updated", "repos_max_capacity": geoRepositoryCapacity,
+		})
+		if edited.ID != created.ID || edited.Name != name+"-updated" || edited.ReposMaxCapacity != geoRepositoryCapacity {
+			e.T.Errorf("edit answered %+v, want site %d renamed to %q with repos_max_capacity %d", edited, created.ID, name+"-updated", geoRepositoryCapacity)
+		}
+
+		statuses := harness.Do[geo.ListStatusOutput](s, actionGeoListStatus, nil)
+		e.T.Logf("%d Geo status(es) reported", len(statuses.Statuses))
+
+		// A site that never ran has reported nothing, and the read of its
+		// status says so rather than answering an empty one.
+		refused := harness.Refused(s, actionGeoGetStatus, map[string]any{"id": created.ID}, harness.FailureNotFound)
+		assertMentions(e, "the status of a site that never reported", refused, "reported status", "gitlab_list_geo_sites")
+
+		repaired := harness.Do[geo.Output](s, actionGeoRepair, map[string]any{"id": created.ID})
+		if repaired.ID != created.ID {
+			e.T.Errorf("repair answered site %d, want %d", repaired.ID, created.ID)
+		}
+
+		harness.DoVoid(s, actionGeoDelete, map[string]any{"id": created.ID})
+		gone := harness.Do[geo.ListOutput](s, actionGeoList, nil)
+		if containsID(geoSiteIDs(gone.Sites), created.ID) {
+			e.T.Errorf("the listing still holds site %d after its delete", created.ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groups_test.go
+++ b/test/e2e/gitlab/ee/groups_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+// groups_test.go covers two licensed reads and one licensed write of the
+// group tool that stand on nothing but a fresh group: the three analytics
+// counts, and the group's secret push protection switch. The group's other
+// licensed families, its boards, wikis, links, certificates, credentials
+// and protected refs, each have a file of their own.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupanalytics"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securitysettings"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestGroupAnalytics_FreshGroup_CountsAnswerForThePath asks a fresh group
+// for its recently created issues, merge requests and members on every
+// surface, and checks each answer names the group it was asked about.
+//
+// Replaces: TestEE_MetaGroupEnterpriseOperations
+func TestGroupAnalytics_FreshGroup_CountsAnswerForThePath(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("analytics"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		params := map[string]any{"group_path": group.Path}
+
+		issues := harness.Do[groupanalytics.IssuesCountOutput](s, actionGroupAnalyticsIssuesCount, params)
+		if issues.GroupPath != group.Path {
+			e.T.Errorf("analytics_issues_count answered for %q, want %q", issues.GroupPath, group.Path)
+		}
+		mrs := harness.Do[groupanalytics.MRCountOutput](s, actionGroupAnalyticsMRCount, params)
+		if mrs.GroupPath != group.Path {
+			e.T.Errorf("analytics_mr_count answered for %q, want %q", mrs.GroupPath, group.Path)
+		}
+		members := harness.Do[groupanalytics.MembersCountOutput](s, actionGroupAnalyticsMembersCount, params)
+		if members.GroupPath != group.Path {
+			e.T.Errorf("analytics_members_count answered for %q, want %q", members.GroupPath, group.Path)
+		}
+	})
+}
+
+// TestGroupSecuritySettings_Update_TurnsSecretPushProtectionOn turns secret
+// push protection on for a fresh group on every surface and reads the
+// switch off the answer.
+//
+// Replaces: TestEE_MetaGroupEnterpriseOperations
+func TestGroupSecuritySettings_Update_TurnsSecretPushProtectionOn(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("secset"))
+
+		updated := harness.Do[securitysettings.GroupOutput](s, actionGroupSecuritySettingsUpdate, map[string]any{
+			"group_id": group.IDParam(), "secret_push_protection_enabled": true,
+		})
+		if !updated.SecretPushProtectionEnabled {
+			e.T.Errorf("security_settings_update answered %+v, want secret push protection on", updated)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupscim_test.go
+++ b/test/e2e/gitlab/ee/groupscim_test.go
@@ -1,0 +1,47 @@
+//go:build e2e
+
+// groupscim_test.go covers the group SCIM identity actions on a group with
+// no SAML provider: the listing answers empty, and the read, update and
+// delete of an identity nothing provisioned are refused with the hint that
+// says where identities come from.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupscim"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestGroupSCIM_UnprovisionedGroup_ListsNothingAndRefusesAMissingIdentity
+// lists a fresh group's SCIM identities on every surface and asks for one
+// by a uid nothing provisioned, through get, update and delete.
+//
+// Replaces: TestMeta_GroupSCIM
+func TestGroupSCIM_UnprovisionedGroup_ListsNothingAndRefusesAMissingIdentity(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("scim"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		hint := []string{"uid", "gitlab_group_scim", "SCIM provisioning"}
+		uid := e.Name("scim")
+
+		listed := harness.Do[groupscim.ListOutput](s, actionGroupSCIMList, map[string]any{"group_id": group.IDParam()})
+		if len(listed.Identities) != 0 {
+			e.T.Errorf("a group with no SAML provider lists %d SCIM identities: %+v", len(listed.Identities), listed.Identities)
+		}
+
+		refused := harness.Refused(s, actionGroupSCIMGet, map[string]any{"group_id": group.IDParam(), "uid": uid}, harness.FailureNotFound)
+		assertMentions(e, "the read of a missing identity", refused, hint...)
+
+		refused = harness.Refused(s, actionGroupSCIMUpdate, map[string]any{"group_id": group.IDParam(), "uid": uid, "extern_uid": e.Name("extern")}, harness.FailureNotFound)
+		assertMentions(e, "the update of a missing identity", refused, hint...)
+
+		refused = harness.Refused(s, actionGroupSCIMDelete, map[string]any{"group_id": group.IDParam(), "uid": uid}, harness.FailureNotFound)
+		assertMentions(e, "the delete of a missing identity", refused, hint...)
+	})
+}

--- a/test/e2e/gitlab/ee/groupstoragemoves_test.go
+++ b/test/e2e/gitlab/ee/groupstoragemoves_test.go
@@ -1,0 +1,58 @@
+//go:build e2e
+
+// groupstoragemoves_test.go covers the group half of the storage move
+// actions, the half a license gates. A single-storage instance has nothing
+// to move a group to, so the listings answer empty, a move nobody scheduled
+// is a not-found, and a schedule naming a storage the instance does not
+// have is refused. The project and snippet halves are Free and live in the
+// common package.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupstoragemoves"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// missingStorage is a Gitaly storage name no instance has.
+const missingStorage = "e2e-missing-storage"
+
+// TestGroupStorageMoves_SingleStorage_ListsRefusesAndCannotSchedule lists
+// the group storage moves at both scopes on every surface, reads a move
+// that does not exist both ways, and asks for a move to a storage the
+// instance lacks, alone and for every group.
+//
+// Replaces: TestMeta_StorageMoves, TestMeta_GroupStorageMoves_Graceful404
+func TestGroupStorageMoves_SingleStorage_ListsRefusesAndCannotSchedule(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("gsm"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+
+		all := harness.Do[groupstoragemoves.ListOutput](s, actionStorageMoveRetrieveAllGroup, nil)
+		e.T.Logf("%d group storage move(s) on the instance", len(all.Moves))
+		mine := harness.Do[groupstoragemoves.ListOutput](s, actionStorageMoveRetrieveGroup, map[string]any{"group_id": group.ID})
+		if len(mine.Moves) != 0 {
+			e.T.Errorf("a fresh group lists %d storage moves: %+v", len(mine.Moves), mine.Moves)
+		}
+
+		refused := harness.Refused(s, actionStorageMoveGetGroup, map[string]any{"id": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the read of a missing group move", refused, "storage move")
+		refused = harness.Refused(s, actionStorageMoveGetGroupForGroup, map[string]any{"group_id": group.ID, "id": missingID}, harness.FailureNotFound)
+		assertMentions(e, "the read of a missing move of the group", refused, "storage move")
+
+		refused = harness.ExpectToolError(s, actionStorageMoveScheduleGroup, map[string]any{
+			"group_id": group.ID, "destination_storage_name": missingStorage,
+		}, "storage")
+		e.T.Logf("a move to a storage the instance lacks is refused: %s", firstLine(refused))
+		refused = harness.ExpectToolError(s, actionStorageMoveScheduleAllGroup, map[string]any{
+			"source_storage_name": missingStorage + "-source", "destination_storage_name": missingStorage,
+		}, "storage")
+		e.T.Logf("a move of every group between storages the instance lacks is refused: %s", firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/ee/helpers_test.go
+++ b/test/e2e/gitlab/ee/helpers_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+// helpers_test.go holds the two assertions every file here makes about a
+// refusal: that it names the things a caller needs to act on it, and how it
+// is quoted in a log line.
+
+package ee
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// assertMentions checks that a refusal carries every substring, without
+// regard to case. The substrings are what the tool promises a caller: the
+// parameter to fix, the sibling tool to call first, the state the object
+// must be in. A refusal that lost one of them is a refusal a model cannot
+// act on.
+func assertMentions(e *harness.Env, what, text string, substrings ...string) {
+	e.T.Helper()
+	lowered := strings.ToLower(text)
+	for _, want := range substrings {
+		if !strings.Contains(lowered, strings.ToLower(want)) {
+			e.T.Errorf("%s does not mention %q: %s", what, want, firstLine(text))
+		}
+	}
+}
+
+// firstLine returns the first line of a refusal for a log line, since the
+// card a refusal comes as runs to a dozen lines and the first names the
+// reason.
+func firstLine(text string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	return line
+}
+
+// containsID reports whether an ID is among those listed. It is a name for
+// the question every listing here is asked, so an assertion reads as one.
+func containsID(ids []int64, want int64) bool {
+	return slices.Contains(ids, want)
+}

--- a/test/e2e/gitlab/ee/integrations_test.go
+++ b/test/e2e/gitlab/ee/integrations_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+
+// integrations_test.go covers the group-level Datadog integration, the one
+// group integration with actions of its own: set it with a placeholder key,
+// read it back, delete it, and show that a set naming no field is refused
+// before GitLab is asked.
+//
+// The key is a placeholder of the shape GitLab validates and nothing ever
+// sends to Datadog: the integration is created inactive, since GitLab
+// cannot verify the key, and it is deleted in the same test. The endpoint is
+// licensed although the catalog lists the actions as Free, which is why the
+// scenario lives here rather than in the common package.
+
+package ee
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/integrations"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// placeholderDatadogKey has the 32-hex shape GitLab accepts for an API key.
+// It is not a credential and reaches no Datadog.
+const placeholderDatadogKey = "0123456789abcdef0123456789abcdef"
+
+// TestGroupDatadogIntegration_Lifecycle_SetsReadsAndDeletes walks the
+// integration of a fresh group through set, get and delete on every
+// surface, and asks for a set with nothing to set.
+//
+// Replaces: TestGroupDatadogIntegration
+func TestGroupDatadogIntegration_Lifecycle_SetsReadsAndDeletes(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("datadog"))
+		params := map[string]any{"group_id": group.IDParam()}
+
+		refused := harness.ExpectToolError(s, actionGroupDatadogSet, params, "at least one of")
+		e.T.Logf("a set naming no field is refused before any request: %s", firstLine(refused))
+
+		set := harness.Do[integrations.SetGroupDatadogOutput](s, actionGroupDatadogSet, withParams(params, map[string]any{"api_key": placeholderDatadogKey}))
+		e.T.Logf("set answered %+v", set)
+
+		got := harness.Do[integrations.GetGroupDatadogOutput](s, actionGroupDatadogGet, params)
+		if got.Integration.ID == 0 || !got.Integration.Active {
+			e.T.Errorf("get answered %+v after the set, want the active integration record", got.Integration)
+		}
+
+		harness.DoVoid(s, actionGroupDatadogDelete, params)
+		// A deleted group integration is disabled rather than removed: the
+		// licensed run found the read answering the record with active off,
+		// so that is what is asserted, and a not-found is accepted as the
+		// other way GitLab can say the integration is gone.
+		after, err := harness.Try[integrations.GetGroupDatadogOutput](s, actionGroupDatadogGet, params)
+		switch {
+		case err != nil && strings.Contains(strings.ToLower(err.Error()), "not found"):
+			e.T.Logf("the read after the delete is refused: %s", firstLine(err.Error()))
+		case err != nil:
+			e.T.Errorf("the read after the delete failed for another reason than not found: %v", err)
+		case after.Integration.Active:
+			e.T.Errorf("the integration is still active after its delete: %+v", after.Integration)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/issues_test.go
+++ b/test/e2e/gitlab/ee/issues_test.go
@@ -1,0 +1,151 @@
+//go:build e2e
+
+// issues_test.go covers the licensed reads of the issue group: an issue's
+// weight events, the iterations of a project and of its group, and an
+// issue's iteration events.
+//
+// Every one of them stands on state GitLab records asynchronously, so the
+// first read of each waits; and the iteration reads stand on a fixture
+// GitLab offers no REST API to build, which the fixture library makes over
+// GraphQL. These are the reads the old suite kept behind an enterprise
+// guard in its Community issue file, where they never ran.
+
+package ee
+
+import (
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupiterations"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/iterationdata"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projectiterations"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/resourceevents"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The resource event waits: GitLab records an event a moment after the
+// change, and a loaded Docker instance takes longer.
+const (
+	resourceEventInterval = 2 * time.Second
+	resourceEventWait     = 60 * time.Second
+)
+
+// The two weights the fixture issue is given, so at least two events are
+// recorded whether or not GitLab records one for the first assignment.
+const (
+	firstWeight = int64(3)
+	finalWeight = int64(5)
+)
+
+// weightFixture is a project with an issue whose weight was changed twice.
+type weightFixture struct {
+	project fixture.Project
+	issue   fixture.Issue
+}
+
+// buildWeightFixture creates the project and the issue and changes the
+// weight twice through client-go.
+func buildWeightFixture(e *harness.Env) weightFixture {
+	project := fixture.NewProject(e, fixture.WithNamePrefix("weight"))
+	issue := fixture.NewIssue(e, project, "weight events fixture")
+	for _, weight := range []int64{firstWeight, finalWeight} {
+		if _, _, err := e.Client().GL().Issues.UpdateIssue(project.ID, issue.IID, &gl.UpdateIssueOptions{Weight: new(weight)}, gl.WithContext(e.Ctx)); err != nil {
+			e.T.Fatalf("setting the weight of issue #%d to %d: %v", issue.IID, weight, err)
+		}
+	}
+	return weightFixture{project: project, issue: issue}
+}
+
+// TestIssueWeightEvents_TwoChanges_ListTheFinalWeight lists the weight
+// events of the fixture issue on every surface, waiting for GitLab to
+// record them, and checks that the final weight is among them.
+//
+// Replaces: TestMeta_IssueWeightEvents
+func TestIssueWeightEvents_TwoChanges_ListTheFinalWeight(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildWeightFixture, func(e *harness.Env, surface harness.Surface, f weightFixture) {
+		s := e.On(surface)
+
+		events := harness.Eventually(s, actionIssueWeightEventList,
+			map[string]any{"project_id": f.project.IDParam(), "issue_iid": f.issue.IID}, resourceEventInterval, resourceEventWait,
+			func(out resourceevents.ListWeightEventsOutput) bool { return len(out.Events) > 0 })
+		sawFinal := false
+		for _, event := range events.Events {
+			if event.ID == 0 {
+				e.T.Errorf("a weight event has no ID: %+v", event)
+			}
+			if event.Weight == finalWeight {
+				sawFinal = true
+			}
+		}
+		if !sawFinal {
+			e.T.Errorf("no weight event records the final weight %d among %d event(s): %+v", finalWeight, len(events.Events), events.Events)
+		}
+	})
+}
+
+// iterationFixture is a group with one iteration, a project in the group,
+// and an issue of that project put into the iteration.
+type iterationFixture struct {
+	group     fixture.Group
+	iteration fixture.Iteration
+	project   fixture.Project
+	issue     fixture.Issue
+}
+
+// buildIterationFixture creates all four.
+func buildIterationFixture(e *harness.Env) iterationFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("iter"))
+	iteration := fixture.NewIteration(e, group)
+	project := fixture.NewProject(e, fixture.WithNamePrefix("iter"), fixture.InGroup(group))
+	issue := fixture.NewIssue(e, project, "iteration fixture")
+	fixture.AssignIssueIteration(e, project, issue, iteration)
+	return iterationFixture{group: group, iteration: iteration, project: project, issue: issue}
+}
+
+// TestIterations_GroupAndProject_ListAndRecordTheIssueEvent lists the
+// iterations of the fixture's project and of its group on every surface,
+// finding the one the fixture created, then lists the issue's iteration
+// events and reads the first back.
+//
+// Replaces: TestMeta_IssuesDeep, TestMeta_ProjectIterations
+func TestIterations_GroupAndProject_ListAndRecordTheIssueEvent(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildIterationFixture, func(e *harness.Env, surface harness.Surface, f iterationFixture) {
+		s := e.On(surface)
+
+		ofProject := harness.Do[projectiterations.ListOutput](s, actionIterationListProject, map[string]any{"project_id": f.project.IDParam(), "state": "all"})
+		if !iterationListed(ofProject.Iterations, f.iteration.IID) {
+			e.T.Errorf("the project's iterations do not hold %s: %+v", f.iteration, ofProject.Iterations)
+		}
+		ofGroup := harness.Do[groupiterations.ListOutput](s, actionIterationListGroup, map[string]any{"group_id": f.group.IDParam(), "state": "all"})
+		if !iterationListed(ofGroup.Iterations, f.iteration.IID) {
+			e.T.Errorf("the group's iterations do not hold %s: %+v", f.iteration, ofGroup.Iterations)
+		}
+
+		params := map[string]any{"project_id": f.project.IDParam(), "issue_iid": f.issue.IID}
+		events := harness.Eventually(s, actionIssueIterationEventList, params, resourceEventInterval, resourceEventWait,
+			func(out resourceevents.ListIterationEventsOutput) bool { return len(out.Events) > 0 })
+		got := harness.Do[resourceevents.IterationEventOutput](s, actionIssueIterationEventGet,
+			withParams(params, map[string]any{"iteration_event_id": events.Events[0].ID}))
+		if got.ID != events.Events[0].ID {
+			e.T.Errorf("event_issue_iteration_get answered event %d, want the listed %d", got.ID, events.Events[0].ID)
+		}
+	})
+}
+
+// iterationListed reports whether an iteration listing holds one by iid.
+// Both listings alias the one iteration shape, so both are read through it.
+func iterationListed(iterations []iterationdata.Output, iid int64) bool {
+	for _, iteration := range iterations {
+		if iteration.IID == iid {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/gitlab/ee/license_test.go
+++ b/test/e2e/gitlab/ee/license_test.go
@@ -3,20 +3,81 @@
 // license_test.go covers the license API on an instance that has one, which
 // is the twin of the ce package's test and the first scenario of this
 // package: it needs nothing but the license the package requires, and it is
-// what a run pointed at the wrong runtime is refused on.
+// what a run pointed at the wrong runtime is refused on. Beside it is the
+// one test that changes the license, by adding and removing a copy of it.
 
 package ee
 
 import (
+	"context"
+	"net/http"
 	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/license"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
 	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
 )
 
-// actionLicenseGet reads the installed license through the admin group.
-const actionLicenseGet harness.ActionID = "admin.license_get"
+// TestLicense_AddAndDeleteADuplicate_LeavesTheInstanceAsFound installs a
+// second copy of the license the instance already runs on and removes that
+// copy again, on every surface, which is the only state-preserving way to
+// drive license_add and license_delete: the active license never changes,
+// since GitLab keeps the newest one active and the copy is deleted before
+// anything else runs.
+//
+// It holds the license lock and runs alone in its package, because a
+// license that comes and goes underneath every other session would change
+// what those sessions are served; and it re-probes the tier afterwards, so
+// a copy that failed to delete is reported here rather than as a scattering
+// of catalog mismatches in later tests. It runs only against the disposable
+// Docker instance, whose provisioning script is what cached the key it
+// reads.
+//
+// Replaces: TestMeta_AdminLicenseLifecycle
+func TestLicense_AddAndDeleteADuplicate_LeavesTheInstanceAsFound(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin), harness.Locks(harness.LockInstanceLicense), harness.Serial())
+	if !e.DockerMode() {
+		e.Skipf("license mutations are only exercised against the ephemeral Docker instance")
+	}
+	key := fixture.CachedEnterpriseLicense(e)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+
+		before := harness.Do[license.GetOutput](s, actionLicenseGet, nil)
+		if before.License.ID == 0 {
+			e.T.Fatalf("license_get answered %+v before the add, want the installed license", before.License)
+		}
+
+		added := harness.Do[license.AddOutput](s, actionLicenseAdd, map[string]any{"license": key})
+		if added.License.ID == 0 || added.License.ID == before.License.ID {
+			e.T.Fatalf("license_add answered %+v, want a new record beside %d", added.License, before.License.ID)
+		}
+		// The copy is removed whatever happens below, so a failed assertion
+		// cannot leave the instance with two licenses; a copy already gone is
+		// not an error.
+		e.Defer("duplicate license", func(ctx context.Context) error {
+			_, err := e.Client().GL().License.DeleteLicense(added.License.ID, gl.WithContext(ctx))
+			if err != nil && !fixture.IsStatus(err, http.StatusNotFound) {
+				return err
+			}
+			return nil
+		})
+
+		harness.DoVoid(s, actionLicenseDelete, map[string]any{"id": added.License.ID})
+
+		after := harness.Do[license.GetOutput](s, actionLicenseGet, nil)
+		if after.License.ID != before.License.ID {
+			e.T.Errorf("the active license is %d after the cycle, want %d as found", after.License.ID, before.License.ID)
+		}
+		if now, was := e.ReprobeTier(); now != was {
+			e.T.Errorf("the instance probes as %s after the cycle, and was %s before it", now, was)
+		}
+	})
+}
 
 // TestLicense_InstalledLicenseMatchesTier runs admin.license_get on every
 // surface and holds the answer to what the harness's probe resolved from the

--- a/test/e2e/gitlab/ee/memberroles_test.go
+++ b/test/e2e/gitlab/ee/memberroles_test.go
@@ -1,0 +1,108 @@
+//go:build e2e
+
+// memberroles_test.go covers custom member roles at the two levels GitLab
+// offers them: the instance level, which a self-managed Ultimate instance
+// serves, and the group level, which it refuses as deprecated and points at
+// the instance level instead. The group half is therefore a refusal on the
+// runtime this package targets, and it is asserted as one.
+
+package ee
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/memberroles"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The access level a custom role is based on: Guest, the lowest GitLab
+// accepts for one.
+const memberRoleBaseAccessLevel = int64(10)
+
+// memberRoleIDs lists the IDs of a role listing.
+func memberRoleIDs(roles []memberroles.Output) []int64 {
+	ids := make([]int64, 0, len(roles))
+	for _, role := range roles {
+		ids = append(ids, role.ID)
+	}
+	return ids
+}
+
+// TestMemberRoles_InstanceLevel_CreatesListsAndDeletes creates an instance
+// custom role on every surface, finds it in the listing, and deletes it.
+//
+// Replaces: TestMeta_MemberRoles
+func TestMemberRoles_InstanceLevel_CreatesListsAndDeletes(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin, harness.Tier(edition.Ultimate)))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+
+		before := harness.Do[memberroles.ListOutput](s, actionMemberRoleListInstance, nil)
+		e.T.Logf("%d instance member role(s) before the create", len(before.Roles))
+
+		created := harness.Do[memberroles.Output](s, actionMemberRoleCreateInstance, map[string]any{
+			"name": e.Name("role"), "base_access_level": memberRoleBaseAccessLevel,
+			"description": "e2e instance custom role", "read_code": true,
+		})
+		if created.ID == 0 {
+			e.T.Fatalf("create_instance answered %+v, want a role with an ID", created)
+		}
+		e.Defer("instance member role", func(ctx context.Context) error {
+			_, err := e.Client().GL().MemberRolesService.DeleteInstanceMemberRole(created.ID, gl.WithContext(ctx))
+			if err != nil && !fixture.IsStatus(err, http.StatusNotFound) {
+				return err
+			}
+			return nil
+		})
+
+		after := harness.Do[memberroles.ListOutput](s, actionMemberRoleListInstance, nil)
+		if !containsID(memberRoleIDs(after.Roles), created.ID) {
+			e.T.Errorf("the instance listing does not hold the created role %d: %v", created.ID, memberRoleIDs(after.Roles))
+		}
+
+		harness.DoVoid(s, actionMemberRoleDeleteInstance, map[string]any{"member_role_id": created.ID})
+		gone := harness.Do[memberroles.ListOutput](s, actionMemberRoleListInstance, nil)
+		if containsID(memberRoleIDs(gone.Roles), created.ID) {
+			e.T.Errorf("the instance listing still holds role %d after its delete", created.ID)
+		}
+	})
+}
+
+// TestMemberRoles_GroupLevel_IsRefusedAsDeprecatedOnSelfManaged asks for
+// the group-level roles of a fresh group on every surface and checks that
+// all three group actions are refused with the hint naming the instance
+// level, which is where a self-managed instance keeps custom roles.
+//
+// Replaces: TestMeta_MemberRoles
+func TestMemberRoles_GroupLevel_IsRefusedAsDeprecatedOnSelfManaged(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin, harness.Tier(edition.Ultimate)))
+	if e.Client().IsGitLabDotCom() {
+		e.Skipf("group-level custom roles are served on GitLab.com, and this scenario asserts the self-managed refusal")
+	}
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("roles"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		hint := []string{"deprecated", "self-managed", "instance-level"}
+
+		refused := harness.ExpectToolError(s, actionMemberRoleListGroup, map[string]any{"group_id": group.IDParam()}, "deprecated")
+		assertMentions(e, "the group role listing", refused, hint...)
+
+		refused = harness.ExpectToolError(s, actionMemberRoleCreateGroup, map[string]any{
+			"group_id": group.IDParam(), "name": e.Name("role"), "base_access_level": memberRoleBaseAccessLevel,
+			"description": "e2e group custom role", "read_code": true,
+		}, "deprecated")
+		assertMentions(e, "the group role create", refused, hint...)
+
+		refused = harness.ExpectToolError(s, actionMemberRoleDeleteGroup, map[string]any{"group_id": group.IDParam(), "member_role_id": int64(1)}, "deprecated")
+		assertMentions(e, "the group role delete", refused, hint...)
+	})
+}

--- a/test/e2e/gitlab/ee/mergerequests_test.go
+++ b/test/e2e/gitlab/ee/mergerequests_test.go
@@ -1,0 +1,230 @@
+//go:build e2e
+
+// mergerequests_test.go covers the licensed half of the merge request
+// group: the approval settings of a project and of a group, a request's
+// approval state and rules, the reset of its approvals, and the blocking
+// dependencies between two requests.
+//
+// The approval reset is the one scenario that needs a second credential.
+// GitLab allows that call to a bot user alone, one holding a project or a
+// group token, and answers a person with 401; so the request is approved
+// and reset from a private session started on a group token, and the run's
+// own session then reads that no approval is left.
+
+package ee
+
+import (
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/mergerequests"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/mrapprovals"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/mrapprovalsettings"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The propagation waits: a bot minted a moment ago is not yet a member
+// every endpoint recognizes, and the old suite retried on that for the
+// same reason.
+const (
+	membershipInterval = 2 * time.Second
+	membershipWait     = 60 * time.Second
+)
+
+// approvalFixture is a project with an open, mergeable merge request.
+type approvalFixture struct {
+	project fixture.Project
+	mr      fixture.MergeRequest
+}
+
+// newApprovalFixture creates the project, a branch with one commit, and the
+// merge request from it. The prefix keeps the projects of the tests here
+// apart in a listing.
+func newApprovalFixture(e *harness.Env, prefix string, opts ...fixture.ProjectOption) approvalFixture {
+	project := fixture.NewProject(e, append([]fixture.ProjectOption{fixture.WithNamePrefix(prefix)}, opts...)...)
+	branch := fixture.NewBranch(e, project, e.Name(prefix))
+	fixture.CommitFile(e, project, branch.Name, prefix+".txt", prefix+" fixture\n", "add the "+prefix+" fixture")
+	mr := fixture.NewMergeRequest(e, project, branch.Name, project.DefaultBranch, prefix+" fixture")
+	return approvalFixture{project: project, mr: mr}
+}
+
+// TestMRApprovalSettings_ProjectAndGroup_ReadAndUpdate reads the approval
+// settings of a project and of a group on every surface, then turns author
+// approval and approval retention on for both and reads the change off the
+// answer.
+//
+// Replaces: TestMeta_MRApprovalSettings, TestMeta_GroupMRApprovalSettings
+func TestMRApprovalSettings_ProjectAndGroup_ReadAndUpdate(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		project := fixture.NewProject(e, fixture.WithNamePrefix("apprset"))
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("apprset"))
+
+		before := harness.Do[mrapprovalsettings.Output](s, actionApprovalSettingsProjectGet, map[string]any{"project_id": project.IDParam()})
+		e.T.Logf("project approval settings before: author=%t committer=%t", before.AllowAuthorApproval.Value, before.AllowCommitterApproval.Value)
+		updated := harness.Do[mrapprovalsettings.Output](s, actionApprovalSettingsProjectUpdate, map[string]any{
+			"project_id": project.IDParam(), "allow_author_approval": true, "retain_approvals_on_push": true,
+		})
+		if !updated.AllowAuthorApproval.Value || !updated.RetainApprovalsOnPush.Value {
+			e.T.Errorf("the project update answered author=%t retain=%t, want both true", updated.AllowAuthorApproval.Value, updated.RetainApprovalsOnPush.Value)
+		}
+
+		groupBefore := harness.Do[mrapprovalsettings.Output](s, actionApprovalSettingsGroupGet, map[string]any{"group_id": group.IDParam()})
+		e.T.Logf("group approval settings before: author=%t retain=%t", groupBefore.AllowAuthorApproval.Value, groupBefore.RetainApprovalsOnPush.Value)
+		groupUpdated := harness.Do[mrapprovalsettings.Output](s, actionApprovalSettingsGroupUpdate, map[string]any{
+			"group_id": group.IDParam(), "allow_author_approval": true, "retain_approvals_on_push": true,
+		})
+		if !groupUpdated.AllowAuthorApproval.Value || !groupUpdated.RetainApprovalsOnPush.Value {
+			e.T.Errorf("the group update answered author=%t retain=%t, want both true", groupUpdated.AllowAuthorApproval.Value, groupUpdated.RetainApprovalsOnPush.Value)
+		}
+	})
+}
+
+// mrApprovalRuleIDs lists the IDs of a request's rules.
+func mrApprovalRuleIDs(rules []mrapprovals.RuleOutput) []int64 {
+	ids := make([]int64, 0, len(rules))
+	for _, rule := range rules {
+		ids = append(ids, rule.ID)
+	}
+	return ids
+}
+
+// TestMRApprovalRules_Lifecycle_ReadsStateAndManagesARule reads a fresh
+// request's approval state, rules and configuration, then creates, updates
+// and deletes a rule of its own, once per surface on a shared request. This
+// is the block the old suite kept behind an enterprise guard in its
+// Community merge request file, where it never ran.
+//
+// Replaces: TestMeta_MRDeep
+func TestMRApprovalRules_Lifecycle_ReadsStateAndManagesARule(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) approvalFixture {
+		return newApprovalFixture(e, "apprrules")
+	}, func(e *harness.Env, surface harness.Surface, f approvalFixture) {
+		s := e.On(surface)
+		params := map[string]any{"project_id": f.project.IDParam(), "merge_request_iid": f.mr.IID}
+
+		state := harness.Do[mrapprovals.StateOutput](s, actionMRApprovalState, params)
+		e.T.Logf("approval state: overwritten=%t rules=%d", state.ApprovalRulesOverwritten, len(state.Rules))
+		rules := harness.Do[mrapprovals.RulesOutput](s, actionMRApprovalRules, params)
+		e.T.Logf("%d approval rule(s) before the create", len(rules.Rules))
+		// What the fixture guarantees is that nobody approved. Whether the
+		// request counts as approved is GitLab's own reading of a request
+		// that requires no approvals, which it settles as it computes the
+		// request's mergeability, and a licensed run saw both answers.
+		config := harness.Do[mrapprovals.ConfigOutput](s, actionMRApprovalConfig, params)
+		if len(config.ApprovedBy) != 0 || config.UserHasApproved {
+			e.T.Errorf("a fresh request reports %d approver(s) and user_has_approved=%t, want none", len(config.ApprovedBy), config.UserHasApproved)
+		}
+
+		name := e.Name("rule")
+		created := harness.Do[mrapprovals.RuleOutput](s, actionMRApprovalRuleCreate, withParams(params, map[string]any{"name": name, "approvals_required": 1}))
+		if created.ID == 0 {
+			e.T.Fatalf("approval_rule_create answered %+v, want a rule with an ID", created)
+		}
+
+		updated := harness.Do[mrapprovals.RuleOutput](s, actionMRApprovalRuleUpdate, withParams(params, map[string]any{
+			"approval_rule_id": created.ID, "name": name + "-updated", "approvals_required": 2,
+		}))
+		if updated.ID != created.ID || updated.Name != name+"-updated" || updated.ApprovalsRequired != 2 {
+			e.T.Errorf("approval_rule_update answered %+v, want rule %d renamed to %q requiring 2", updated, created.ID, name+"-updated")
+		}
+
+		harness.DoVoid(s, actionMRApprovalRuleDelete, withParams(params, map[string]any{"approval_rule_id": created.ID}))
+		remaining := harness.Do[mrapprovals.RulesOutput](s, actionMRApprovalRules, params)
+		if containsID(mrApprovalRuleIDs(remaining.Rules), created.ID) {
+			e.T.Errorf("rule %d is still listed after its delete", created.ID)
+		}
+	})
+}
+
+// TestMRApprovalReset_GroupBot_ClearsTheApproval approves a request from a
+// session started on a group bot's token, resets the approvals from that
+// same session, and reads from the run's own session that none is left.
+// The bot is the request's only approver, through a rule that names it.
+//
+// The bot's session is served the Free catalog on a licensed instance, since
+// the license endpoint answers administrators only, and the two actions it
+// makes are Free: what the license gates is the rule that makes the bot an
+// approver, which the run's own session creates.
+//
+// Replaces: TestMeta_MRDeep
+func TestMRApprovalReset_GroupBot_ClearsTheApproval(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("apprreset"))
+		f := newApprovalFixture(e, "apprreset", fixture.InGroup(group))
+		bot := fixture.NewGroupToken(e, group, gl.OwnerPermissions)
+		params := map[string]any{"project_id": f.project.IDParam(), "merge_request_iid": f.mr.IID}
+
+		// The rule is retried while the bot's membership propagates, the
+		// window the old suite met as 400s and 404s on this same call.
+		rule := harness.Eventually(s, actionMRApprovalRuleCreate, withParams(params, map[string]any{
+			"name": e.Name("bot-rule"), "approvals_required": 1, "user_ids": []int64{bot.UserID},
+		}), membershipInterval, membershipWait, func(out mrapprovals.RuleOutput) bool { return out.ID != 0 })
+		e.T.Logf("rule %d names the bot user %d as the approver", rule.ID, bot.UserID)
+
+		botSession := e.Session(harness.ServerConfig{Surface: surface, Token: bot.Value, Private: true})
+		approved := harness.Eventually(botSession, actionMRApprove, params, membershipInterval, membershipWait,
+			func(out mergerequests.ApproveOutput) bool { return out.ApprovedBy > 0 })
+		e.T.Logf("the bot approved: approved=%t by %d", approved.Approved, approved.ApprovedBy)
+
+		harness.DoVoid(botSession, actionMRApprovalReset, params)
+
+		config := harness.Do[mrapprovals.ConfigOutput](s, actionMRApprovalConfig, params)
+		if len(config.ApprovedBy) != 0 {
+			e.T.Errorf("the request still lists %d approver(s) after the reset: %+v", len(config.ApprovedBy), config.ApprovedBy)
+		}
+	})
+}
+
+// TestMRDependencies_Lifecycle_BlocksThenUnblocksARequest opens two
+// requests in one project, makes the first block the second, finds the
+// block in the second's listing and removes it, once per surface. The
+// create names the blocking request by its instance-wide ID and the delete
+// names the block record, which is the shape GitLab gives both.
+//
+// Replaces: TestMeta_MRBlockingDependencies, TestIndividual_MRDependenciesList
+func TestMRDependencies_Lifecycle_BlocksThenUnblocksARequest(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		blocking := newApprovalFixture(e, "mrdeps")
+		dependentBranch := fixture.NewBranch(e, blocking.project, e.Name("dependent"))
+		fixture.CommitFile(e, blocking.project, dependentBranch.Name, "dependent.txt", "dependent fixture\n", "add the dependent fixture")
+		dependent := fixture.NewMergeRequest(e, blocking.project, dependentBranch.Name, blocking.project.DefaultBranch, "dependent fixture")
+		params := map[string]any{"project_id": blocking.project.IDParam(), "merge_request_iid": dependent.IID}
+
+		fresh := harness.Do[mergerequests.DependenciesOutput](s, actionMRDependenciesList, params)
+		if len(fresh.Dependencies) != 0 {
+			e.T.Errorf("a fresh request lists %d dependencies: %+v", len(fresh.Dependencies), fresh.Dependencies)
+		}
+
+		created := harness.Do[mergerequests.DependencyOutput](s, actionMRDependencyCreate, withParams(params, map[string]any{
+			"blocking_merge_request_id": blocking.mr.ID,
+		}))
+		if created.ID == 0 || created.BlockingMergeRequest == nil || created.BlockingMergeRequest.IID != blocking.mr.IID {
+			e.T.Fatalf("dependency_create answered %+v, want a block record naming request !%d", created, blocking.mr.IID)
+		}
+
+		blocked := harness.Do[mergerequests.DependenciesOutput](s, actionMRDependenciesList, params)
+		if len(blocked.Dependencies) != 1 {
+			e.T.Errorf("the blocked request lists %d dependencies, want the one: %+v", len(blocked.Dependencies), blocked.Dependencies)
+		}
+
+		harness.DoVoid(s, actionMRDependencyDelete, withParams(params, map[string]any{"blocking_merge_request_id": created.ID}))
+		unblocked := harness.Do[mergerequests.DependenciesOutput](s, actionMRDependenciesList, params)
+		if len(unblocked.Dependencies) != 0 {
+			e.T.Errorf("the request lists %d dependencies after the delete: %+v", len(unblocked.Dependencies), unblocked.Dependencies)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/mergetrains_test.go
+++ b/test/e2e/gitlab/ee/mergetrains_test.go
@@ -1,0 +1,86 @@
+//go:build e2e
+
+// mergetrains_test.go covers the merge train actions on a project that has
+// trains switched on: the project listing, the branch listing, adding a
+// merge request and reading its entry.
+//
+// The project lives in a group, because GitLab keeps merge_trains_enabled
+// only on a project whose namespace carries the licensed feature; on a
+// personal namespace the edit answers 200 and the flag is dropped, which is
+// how the suite this replaces spent its first runs asserting on a project
+// with no train. Even with trains on, a merge request with no pipeline of
+// its own cannot board: GitLab refuses the add, and the entry read for it
+// is a not-found. Both are the deterministic answers a project without CI
+// gives, and both are asserted as such rather than tolerated.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/mergetrains"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// mergeTrainFixture is a group-scoped project with merge trains enabled.
+type mergeTrainFixture struct {
+	project fixture.Project
+	// enabled is whether GitLab kept both switches, which decides whether
+	// the add is refused for want of a pipeline or for want of a train.
+	enabled bool
+}
+
+// buildMergeTrainFixture creates the group, the project in it, and turns
+// the trains on.
+func buildMergeTrainFixture(e *harness.Env) mergeTrainFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("mt"))
+	project := fixture.NewProject(e, fixture.WithNamePrefix("mt"), fixture.InGroup(group))
+	enabled := fixture.EnableMergeTrains(e, project)
+	if !enabled {
+		e.T.Logf("GitLab did not keep merge trains enabled on %s; the add and the entry read assert the refusals a project without a train gives", project.Path)
+	}
+	return mergeTrainFixture{project: project, enabled: enabled}
+}
+
+// TestMergeTrains_ProjectInGroup_ListsAndRefusesAnUnpipelinedRequest lists
+// the project's and the target branch's trains on every surface, opens a
+// merge request of the surface's own, and shows that a request with no
+// pipeline is refused boarding and reported as not on a train.
+//
+// Replaces: TestMeta_MergeTrains, TestMeta_MergeTrainGet
+func TestMergeTrains_ProjectInGroup_ListsAndRefusesAnUnpipelinedRequest(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildMergeTrainFixture, func(e *harness.Env, surface harness.Surface, f mergeTrainFixture) {
+		s := e.On(surface)
+		project := f.project.IDParam()
+
+		listed := harness.Do[mergetrains.ListOutput](s, actionMergeTrainListProject, map[string]any{"project_id": project})
+		if len(listed.Trains) != 0 {
+			e.T.Errorf("a project nothing has boarded lists %d train entries: %+v", len(listed.Trains), listed.Trains)
+		}
+
+		branch := fixture.NewBranch(e, f.project, e.Name("mt"))
+		fixture.CommitFile(e, f.project, branch.Name, "merge-train.txt", "merge train fixture\n", "add the merge train fixture")
+		mr := fixture.NewMergeRequest(e, f.project, branch.Name, f.project.DefaultBranch, "merge train fixture")
+
+		// No pipeline ever ran for this request, so GitLab cannot board it.
+		// The refusal is asserted by the operation it names rather than by
+		// GitLab's wording, which differs between a train that is off and a
+		// request that cannot board one.
+		refused := harness.ExpectToolError(s, actionMergeTrainAdd,
+			map[string]any{"project_id": project, "merge_request_iid": mr.IID}, "merge_train")
+		e.T.Logf("add refused for merge request !%d as expected: %s", mr.IID, firstLine(refused))
+
+		onBranch := harness.Do[mergetrains.ListOutput](s, actionMergeTrainListBranch,
+			map[string]any{"project_id": project, "target_branch": f.project.DefaultBranch})
+		if len(onBranch.Trains) != 0 {
+			e.T.Errorf("the target branch lists %d train entries after a refused add: %+v", len(onBranch.Trains), onBranch.Trains)
+		}
+
+		notFound := harness.Refused(s, actionMergeTrainGet,
+			map[string]any{"project_id": project, "merge_request_iid": mr.IID}, harness.FailureNotFound)
+		assertMentions(e, "the entry read for a request that never boarded", notFound, "merge train")
+	})
+}

--- a/test/e2e/gitlab/ee/orbit_test.go
+++ b/test/e2e/gitlab/ee/orbit_test.go
@@ -1,0 +1,51 @@
+//go:build e2e
+
+// orbit_test.go pins the one licensed thing a self-managed instance must not
+// serve: the Orbit knowledge graph group, which exists on GitLab.com alone.
+// It is named by prefix rather than by a typed action ID on purpose, since
+// the actions are absent from the catalog a self-managed instance builds,
+// and a constant naming one would be refused by the static gate as not a
+// catalog action, which is the very fact under test.
+
+package ee
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The two spellings the Orbit group has: the tool names on the meta and
+// individual surfaces, and the action IDs on the dynamic one.
+const (
+	orbitToolPrefix   = "gitlab_orbit"
+	orbitActionPrefix = "orbit."
+)
+
+// TestOrbit_SelfManaged_ServesNoOrbitToolOrAction lists what every surface
+// serves and checks that nothing of Orbit is among the tools or the
+// actions on a self-managed instance, whatever its tier.
+//
+// Replaces: TestEnterpriseOrbit_NotRegisteredOnSelfManaged
+func TestOrbit_SelfManaged_ServesNoOrbitToolOrAction(t *testing.T) {
+	e := harness.New(t)
+	if e.Client().IsGitLabDotCom() {
+		e.Skipf("Orbit is served on GitLab.com, and this scenario asserts its absence elsewhere")
+	}
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+
+		for _, tool := range s.Tools() {
+			if strings.HasPrefix(tool, orbitToolPrefix) {
+				e.T.Errorf("the %s session serves the tool %s on a self-managed instance", surface, tool)
+			}
+		}
+		for _, action := range s.Actions() {
+			if strings.HasPrefix(string(action), orbitActionPrefix) {
+				e.T.Errorf("the %s session serves the action %s on a self-managed instance", surface, action)
+			}
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/projectaliases_test.go
+++ b/test/e2e/gitlab/ee/projectaliases_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+// projectaliases_test.go covers the project alias lifecycle: create one for
+// a project, read it, find it in the listing, delete it, and show the read
+// of a deleted alias is refused with the hint naming the listing.
+
+package ee
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projectaliases"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// aliasListed reports whether a listing holds an alias by name and project.
+func aliasListed(aliases []projectaliases.Output, name string, projectID int64) bool {
+	for _, alias := range aliases {
+		if alias.Name == name && alias.ProjectID == projectID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProjectAliases_Lifecycle_CreatesReadsListsAndDeletes walks one alias
+// per surface through its life on a shared project. Aliases are an
+// administrator's, so the run's token must be one.
+//
+// Replaces: TestMeta_ProjectAliases
+func TestProjectAliases_Lifecycle_CreatesReadsListsAndDeletes(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("alias"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		name := e.Name("alias")
+
+		before := harness.Do[projectaliases.ListOutput](s, actionProjectAliasList, nil)
+		if aliasListed(before.Aliases, name, project.ID) {
+			e.T.Fatalf("alias %q exists before the create", name)
+		}
+
+		created := harness.Do[projectaliases.Output](s, actionProjectAliasCreate, map[string]any{"name": name, "project_id": project.ID})
+		if created.Name != name || created.ProjectID != project.ID {
+			e.T.Fatalf("create answered %+v, want alias %q for project %d", created, name, project.ID)
+		}
+		e.Defer("project alias "+name, func(ctx context.Context) error {
+			_, err := e.Client().GL().ProjectAliases.DeleteProjectAlias(name, gl.WithContext(ctx))
+			if err != nil && !fixture.IsStatus(err, http.StatusNotFound) {
+				return err
+			}
+			return nil
+		})
+
+		got := harness.Do[projectaliases.Output](s, actionProjectAliasGet, map[string]any{"name": name})
+		if got.Name != name || got.ProjectID != project.ID {
+			e.T.Errorf("get answered %+v, want alias %q for project %d", got, name, project.ID)
+		}
+
+		after := harness.Do[projectaliases.ListOutput](s, actionProjectAliasList, nil)
+		if !aliasListed(after.Aliases, name, project.ID) {
+			e.T.Errorf("the listing does not hold the created alias %q: %+v", name, after.Aliases)
+		}
+
+		harness.DoVoid(s, actionProjectAliasDelete, map[string]any{"name": name})
+		refused := harness.Refused(s, actionProjectAliasGet, map[string]any{"name": name}, harness.FailureNotFound)
+		assertMentions(e, "the read of a deleted alias", refused, "alias", "gitlab_list_project_aliases")
+	})
+}

--- a/test/e2e/gitlab/ee/projects_test.go
+++ b/test/e2e/gitlab/ee/projects_test.go
@@ -1,0 +1,206 @@
+//go:build e2e
+
+// projects_test.go covers the licensed actions of the project group that
+// stand on nothing but a project: target branch rules, pull mirroring, the
+// project's approval configuration and rules, and its security settings.
+
+package ee
+
+import (
+	"strings"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projects"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securitysettings"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestTargetBranchRules_Lifecycle_CreatesListsAndDeletes adds a rule
+// mapping release branches to the default branch, finds it in the listing
+// and deletes it, once per surface on a shared project.
+//
+// The create takes the numeric project ID and the list takes the full
+// path: the two GraphQL operations behind them disagree about how a
+// project is named, and the test states both spellings on purpose.
+//
+// Replaces: TestMeta_TargetBranchRules
+func TestTargetBranchRules_Lifecycle_CreatesListsAndDeletes(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("tbr"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		pattern := "release/" + string(surface) + "/*"
+
+		created := harness.Do[projects.TargetBranchRuleOutput](s, actionTargetBranchRuleCreate, map[string]any{
+			"project_id": project.IDParam(), "name": pattern, "target_branch": project.DefaultBranch,
+		})
+		if created.ID == 0 || created.TargetBranch != project.DefaultBranch {
+			e.T.Fatalf("create answered %+v, want a rule targeting %q with an ID", created, project.DefaultBranch)
+		}
+
+		listed := harness.Do[projects.ListTargetBranchRulesOutput](s, actionTargetBranchRuleList, map[string]any{"project_id": project.Path})
+		found := false
+		for _, rule := range listed.TargetBranchRules {
+			if rule.ID == created.ID {
+				found = true
+			}
+		}
+		if !found {
+			e.T.Errorf("the listing does not hold the created rule %d: %+v", created.ID, listed.TargetBranchRules)
+		}
+
+		harness.DoVoid(s, actionTargetBranchRuleDelete, map[string]any{"rule_id": created.ID})
+		remaining := harness.Do[projects.ListTargetBranchRulesOutput](s, actionTargetBranchRuleList, map[string]any{"project_id": project.Path})
+		for _, rule := range remaining.TargetBranchRules {
+			if rule.ID == created.ID {
+				e.T.Errorf("rule %d is still listed after its delete", created.ID)
+			}
+		}
+	})
+}
+
+// TestPullMirror_Lifecycle_ConfiguresStartsAndDisables reads the mirror of
+// a project that has none, configures one from a public sibling project,
+// reads it back, starts an update and disables it, once per surface. The
+// source is reached at the address GitLab has for itself inside the Docker
+// network, since the published one is not routable from the container.
+//
+// Replaces: TestMeta_ProjectMirroring
+func TestPullMirror_Lifecycle_ConfiguresStartsAndDisables(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("mirror-src"), fixture.WithVisibility(gl.PublicVisibility))
+	}, func(e *harness.Env, surface harness.Surface, upstream fixture.Project) {
+		s := e.On(surface)
+		project := fixture.NewProject(e, fixture.WithNamePrefix("mirror"))
+		source := fixture.RepositoryURL(e, upstream)
+
+		refused := harness.ExpectToolError(s, actionPullMirrorGet, map[string]any{"project_id": project.IDParam()}, "not mirrored")
+		assertMentions(e, "the read of a project that is not mirrored", refused, "pull_mirror_configure", "pull_mirror_get")
+
+		configured := harness.Do[projects.PullMirrorOutput](s, actionPullMirrorConfigure, map[string]any{
+			"project_id": project.IDParam(), "enabled": true, "url": source, "mirror_trigger_builds": false,
+			"only_mirror_protected_branches": false, "mirror_overwrites_diverged_branches": true,
+		})
+		if !configured.Enabled || !strings.Contains(configured.URL, upstream.Path) {
+			e.T.Errorf("configure answered %+v, want an enabled mirror of %s", configured, upstream.Path)
+		}
+
+		got := harness.Do[projects.PullMirrorOutput](s, actionPullMirrorGet, map[string]any{"project_id": project.IDParam()})
+		if !got.Enabled || !strings.Contains(got.URL, upstream.Path) {
+			e.T.Errorf("get answered %+v, want the enabled mirror of %s", got, upstream.Path)
+		}
+
+		harness.DoVoid(s, actionStartMirroring, map[string]any{"project_id": project.IDParam()})
+
+		disabled := harness.Do[projects.PullMirrorOutput](s, actionPullMirrorConfigure, map[string]any{"project_id": project.IDParam(), "enabled": false})
+		if disabled.Enabled {
+			e.T.Errorf("configure answered %+v after disabling, want enabled=false", disabled)
+		}
+	})
+}
+
+// TestProjectApprovals_Lifecycle_ConfiguresAndManagesRules reads and
+// changes the project's approval configuration, then walks one approval
+// rule through create, list, get, update and delete, once per surface on a
+// shared project. These are the calls the old suite kept behind an
+// enterprise guard in a Community file, where they never ran; the
+// configuration change is also the one the two merge request approval
+// tests of that file made before approving, which their port makes here.
+//
+// Replaces: TestMeta_ProjectApprovals
+func TestProjectApprovals_Lifecycle_ConfiguresAndManagesRules(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("approvals"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		id := project.IDParam()
+
+		config := harness.Do[projects.ApprovalConfigOutput](s, actionProjectApprovalConfigGet, map[string]any{"project_id": id})
+		e.T.Logf("approval configuration before the change: reset_on_push=%t author_approval=%t", config.ResetApprovalsOnPush, config.MergeRequestsAuthorApproval)
+
+		changed := harness.Do[projects.ApprovalConfigOutput](s, actionProjectApprovalConfigChange, map[string]any{
+			"project_id": id, "reset_approvals_on_push": true, "disable_overriding_approvers_per_merge_request": false,
+			"merge_requests_author_approval": true, "merge_requests_disable_committers_approval": false,
+		})
+		if !changed.ResetApprovalsOnPush || changed.DisableOverridingApproversPerMergeRequest || !changed.MergeRequestsAuthorApproval {
+			e.T.Errorf("approval_config_change answered %+v, want reset_on_push=true, overriding allowed and author approval allowed", changed)
+		}
+
+		name := e.Name("rule")
+		created := harness.Do[projects.ApprovalRuleOutput](s, actionProjectApprovalRuleCreate, map[string]any{
+			"project_id": id, "name": name, "approvals_required": 1,
+		})
+		if created.ID == 0 {
+			e.T.Fatalf("approval_rule_create answered %+v, want a rule with an ID", created)
+		}
+
+		listed := harness.Do[projects.ListApprovalRulesOutput](s, actionProjectApprovalRuleList, map[string]any{"project_id": id})
+		if !containsID(projectApprovalRuleIDs(listed.Rules), created.ID) {
+			e.T.Errorf("the listing does not hold the created rule %d: %v", created.ID, projectApprovalRuleIDs(listed.Rules))
+		}
+
+		got := harness.Do[projects.ApprovalRuleOutput](s, actionProjectApprovalRuleGet, map[string]any{"project_id": id, "rule_id": created.ID})
+		if got.ID != created.ID || got.Name != name {
+			e.T.Errorf("approval_rule_get answered %+v, want rule %d named %q", got, created.ID, name)
+		}
+
+		updated := harness.Do[projects.ApprovalRuleOutput](s, actionProjectApprovalRuleUpdate, map[string]any{
+			"project_id": id, "rule_id": created.ID, "name": name + "-updated", "approvals_required": 2,
+		})
+		if updated.ID != created.ID || updated.Name != name+"-updated" || updated.ApprovalsRequired != 2 {
+			e.T.Errorf("approval_rule_update answered %+v, want rule %d renamed to %q requiring 2", updated, created.ID, name+"-updated")
+		}
+
+		harness.DoVoid(s, actionProjectApprovalRuleDelete, map[string]any{"project_id": id, "rule_id": created.ID})
+		remaining := harness.Do[projects.ListApprovalRulesOutput](s, actionProjectApprovalRuleList, map[string]any{"project_id": id})
+		if containsID(projectApprovalRuleIDs(remaining.Rules), created.ID) {
+			e.T.Errorf("rule %d is still listed after its delete", created.ID)
+		}
+	})
+}
+
+// projectApprovalRuleIDs lists the IDs of a rule listing.
+func projectApprovalRuleIDs(rules []projects.ApprovalRuleOutput) []int64 {
+	ids := make([]int64, 0, len(rules))
+	for _, rule := range rules {
+		ids = append(ids, rule.ID)
+	}
+	return ids
+}
+
+// TestProjectSecuritySettings_Read_ThenSecretPushProtectionOn reads a
+// project's security settings and turns secret push protection on, once
+// per surface on a project of the surface's own so that each starts from
+// the default.
+//
+// Replaces: TestMeta_ProjectSecuritySettings
+func TestProjectSecuritySettings_Read_ThenSecretPushProtectionOn(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		project := fixture.NewProject(e, fixture.WithNamePrefix("secset"))
+
+		settings := harness.Do[securitysettings.ProjectOutput](s, actionProjectSecuritySettingsGet, map[string]any{"project_id": project.IDParam()})
+		if settings.ProjectID != project.ID {
+			e.T.Errorf("security_settings_get answered project %d, want %d", settings.ProjectID, project.ID)
+		}
+
+		updated := harness.Do[securitysettings.ProjectOutput](s, actionProjectSecuritySettingsUpdate, map[string]any{
+			"project_id": project.IDParam(), "secret_push_protection_enabled": true,
+		})
+		if updated.ProjectID != project.ID || !updated.SecretPushProtectionEnabled {
+			e.T.Errorf("security_settings_update answered %+v, want secret push protection on for project %d", updated, project.ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/protectedenvs_test.go
+++ b/test/e2e/gitlab/ee/protectedenvs_test.go
@@ -1,0 +1,139 @@
+//go:build e2e
+
+// protectedenvs_test.go covers a project's protected environments: protect,
+// list, get, update an access level in place, unprotect, and the not-found
+// a read gives afterwards; then the deployment approval flow a protected
+// environment with an approval rule gates.
+//
+// The approval is asserted as the refusal GitLab makes of it: the fixture
+// creates the deployment and then approves it as the same user, which
+// GitLab does not allow, so the answer is deterministic without a second
+// user and still goes through the whole approval path.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/deployments"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/protectedenvs"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The access levels the protection is created with and updated to:
+// Maintainer, then Developer.
+const (
+	accessLevelMaintainer = 40
+	accessLevelDeveloper  = 30
+)
+
+// protectEnvironment protects an environment of the project with a
+// Maintainer deploy access level, plus whatever extra the caller adds, and
+// answers the protection.
+func protectEnvironment(e *harness.Env, s *harness.Session, project fixture.Project, name string, extra map[string]any) protectedenvs.Output {
+	e.T.Helper()
+
+	params := withParams(map[string]any{
+		"project_id":           project.IDParam(),
+		"name":                 name,
+		"deploy_access_levels": []map[string]any{{"access_level": accessLevelMaintainer}},
+	}, extra)
+	protected := harness.Do[protectedenvs.Output](s, actionProtectedEnvProtect, params)
+	if protected.Name != name {
+		e.T.Fatalf("protect answered %+v, want the environment %q", protected, name)
+	}
+	return protected
+}
+
+// TestProtectedEnvironments_Lifecycle_ProtectsUpdatesAndUnprotects walks
+// one protected environment per surface on a shared project.
+//
+// Replaces: TestMeta_ProtectedEnvs, TestMeta_ProtectedEnvUpdate
+func TestProtectedEnvironments_Lifecycle_ProtectsUpdatesAndUnprotects(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("penv"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		name := e.Name("staging")
+
+		protected := protectEnvironment(e, s, project, name, nil)
+		if len(protected.DeployAccessLevels) == 0 || protected.DeployAccessLevels[0].ID == 0 {
+			e.T.Fatalf("protect answered no deploy access level with an ID: %+v", protected)
+		}
+		levelID := protected.DeployAccessLevels[0].ID
+
+		listed := harness.Do[protectedenvs.ListOutput](s, actionProtectedEnvList, map[string]any{"project_id": project.IDParam()})
+		found := false
+		for _, environment := range listed.Environments {
+			if environment.Name == name {
+				found = true
+			}
+		}
+		if !found {
+			e.T.Errorf("the listing does not hold the protected environment %q: %+v", name, listed.Environments)
+		}
+
+		got := harness.Do[protectedenvs.Output](s, actionProtectedEnvGet, map[string]any{"project_id": project.IDParam(), "environment": name})
+		if got.Name != name {
+			e.T.Errorf("get answered %+v, want the environment %q", got, name)
+		}
+
+		updated := harness.Do[protectedenvs.Output](s, actionProtectedEnvUpdate, map[string]any{
+			"project_id": project.IDParam(), "environment": name,
+			"deploy_access_levels": []map[string]any{{"id": levelID, "access_level": accessLevelDeveloper}},
+		})
+		lowered := false
+		for _, level := range updated.DeployAccessLevels {
+			if level.ID == levelID && level.AccessLevel == accessLevelDeveloper {
+				lowered = true
+			}
+		}
+		if updated.Name != name || !lowered {
+			e.T.Errorf("update answered %+v, want access level %d of %q lowered to %d", updated, levelID, name, accessLevelDeveloper)
+		}
+
+		harness.DoVoid(s, actionProtectedEnvUnprotect, map[string]any{"project_id": project.IDParam(), "environment": name})
+		refused := harness.Refused(s, actionProtectedEnvGet, map[string]any{"project_id": project.IDParam(), "environment": name}, harness.FailureNotFound)
+		e.T.Logf("the read after the unprotect is refused: %s", firstLine(refused))
+	})
+}
+
+// TestDeploymentApproval_ProtectedEnvironment_RefusesTheDeployer creates
+// an environment, protects it with a one-approval rule naming the run's
+// user, deploys to it, and asks that user to approve the deployment, which
+// GitLab refuses. The refusal is the whole approval path exercised end to
+// end, with the one answer a single credential can be sure of.
+//
+// Replaces: TestMeta_DeploymentApproveOrReject
+func TestDeploymentApproval_ProtectedEnvironment_RefusesTheDeployer(t *testing.T) {
+	e := harness.New(t)
+	user := e.Runtime().UserID
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("deployapp"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+
+		environment := fixture.NewEnvironment(e, project, "approval")
+		protectEnvironment(e, s, project, environment.Name, map[string]any{
+			"approval_rules": []map[string]any{{"user_id": user, "required_approvals": 1}},
+		})
+		commit := fixture.CommitFile(e, project, project.DefaultBranch, "deploy-"+string(surface)+".txt", "deployment approval fixture\n", "add the deployment approval fixture")
+
+		deployed := harness.Do[deployments.Output](s, actionDeploymentCreate, map[string]any{
+			"project_id": project.IDParam(), "environment": environment.Name, "ref": project.DefaultBranch,
+			"sha": commit.SHA, "tag": fixture.DeploymentRefIsBranch, "status": string(fixture.DeploymentStatus),
+		})
+		if deployed.ID == 0 {
+			e.T.Fatalf("deployment_create answered %+v, want a deployment with an ID", deployed)
+		}
+
+		refused := harness.ExpectToolError(s, actionDeploymentApproveOrReject, map[string]any{
+			"project_id": project.IDParam(), "deployment_id": deployed.ID, "status": "approved", "comment": "e2e deployment approval",
+		}, "deployment")
+		e.T.Logf("approving deployment %d (%s) as its deployer is refused: %s", deployed.ID, deployed.Status, firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/ee/pushrules_test.go
+++ b/test/e2e/gitlab/ee/pushrules_test.go
@@ -1,0 +1,56 @@
+//go:build e2e
+
+// pushrules_test.go covers a project's push rule: add, read, edit, delete,
+// and the not-found a read gives once the rule is gone. A project has at
+// most one rule, which is why the whole life fits one project per surface.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projects"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The file size limits the rule is created with and edited to, in MB.
+const (
+	pushRuleMaxFileSize       = int64(50)
+	pushRuleMaxFileSizeEdited = int64(100)
+)
+
+// TestPushRules_Lifecycle_AddsEditsAndDeletes walks the rule of a project
+// of the surface's own through its life.
+//
+// Replaces: TestIndividual_PushRules, TestMeta_PushRules
+func TestPushRules_Lifecycle_AddsEditsAndDeletes(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		project := fixture.NewProject(e, fixture.WithNamePrefix("pushrule"))
+		id := project.IDParam()
+
+		added := harness.Do[projects.PushRuleOutput](s, actionPushRuleAdd, map[string]any{
+			"project_id": id, "commit_message_regex": "^[A-Z].*", "max_file_size": pushRuleMaxFileSize,
+		})
+		if added.ID == 0 {
+			e.T.Fatalf("push_rule_add answered %+v, want a rule with an ID", added)
+		}
+
+		got := harness.Do[projects.PushRuleOutput](s, actionPushRuleGet, map[string]any{"project_id": id})
+		if got.ID != added.ID || got.MaxFileSize != pushRuleMaxFileSize {
+			e.T.Errorf("push_rule_get answered %+v, want rule %d with max_file_size %d", got, added.ID, pushRuleMaxFileSize)
+		}
+
+		edited := harness.Do[projects.PushRuleOutput](s, actionPushRuleEdit, map[string]any{"project_id": id, "max_file_size": pushRuleMaxFileSizeEdited})
+		if edited.MaxFileSize != pushRuleMaxFileSizeEdited {
+			e.T.Errorf("push_rule_edit answered max_file_size %d, want %d", edited.MaxFileSize, pushRuleMaxFileSizeEdited)
+		}
+
+		harness.DoVoid(s, actionPushRuleDelete, map[string]any{"project_id": id})
+		refused := harness.Refused(s, actionPushRuleGet, map[string]any{"project_id": id}, harness.FailureNotFound)
+		e.T.Logf("the read after the delete is refused: %s", firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/ee/runnercontrollers_test.go
+++ b/test/e2e/gitlab/ee/runnercontrollers_test.go
@@ -1,0 +1,159 @@
+//go:build e2e
+
+// runnercontrollers_test.go covers the runner controller family, an
+// administrator's experimental Ultimate API: the controller itself, its
+// tokens, and its scopes at the instance and at the runner level.
+//
+// The runner scopes name the instance runner the Docker stack registers,
+// which is the one shared thing here: two tests scoping it at once would
+// contend for it, so the test declares the runner lock and the runner need.
+
+package ee
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/runnercontrollers"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/runnercontrollerscopes"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/runnercontrollertokens"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The controller states the lifecycle moves through.
+const (
+	controllerStateDisabled = "disabled"
+	controllerStateDryRun   = "dry_run"
+)
+
+// controllerTokenIDs lists the IDs of a token listing.
+func controllerTokenIDs(out runnercontrollertokens.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Tokens))
+	for _, token := range out.Tokens {
+		ids = append(ids, token.ID)
+	}
+	return ids
+}
+
+// scopedRunnerIDs lists the runners a controller is scoped to.
+func scopedRunnerIDs(out runnercontrollerscopes.ScopesOutput) []int64 {
+	ids := make([]int64, 0, len(out.RunnerLevelScopings))
+	for _, scoping := range out.RunnerLevelScopings {
+		ids = append(ids, scoping.RunnerID)
+	}
+	return ids
+}
+
+// TestRunnerControllers_Lifecycle_TokensScopesAndDeletion creates one
+// controller per surface, updates it, walks its token through create,
+// list, get, rotate and revoke, walks its scopes at the instance level and
+// against the Docker runner, and deletes it. The listing and the read of a
+// controller that does not exist are asked alongside.
+//
+// Replaces: TestMeta_RunnerControllerLifecycle, TestEE_MetaRunnerManagement
+func TestRunnerControllers_Lifecycle_TokensScopesAndDeletion(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin, harness.NeedRunner, harness.Tier(edition.Ultimate)), harness.Locks(harness.LockRunner))
+	runnerID := fixture.DockerRunnerID(e)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+
+		listed := harness.Do[runnercontrollers.ListOutput](s, actionRunnerControllerList, nil)
+		e.T.Logf("%d runner controller(s) before the create", len(listed.Controllers))
+		refused := harness.Refused(s, actionRunnerControllerGet, map[string]any{"controller_id": missingID}, harness.FailureNotFound)
+		e.T.Logf("the read of a missing controller is refused: %s", firstLine(refused))
+
+		created := harness.Do[runnercontrollers.Output](s, actionRunnerControllerCreate, map[string]any{
+			"description": e.Name("controller"), "state": controllerStateDisabled,
+		})
+		if created.ID == 0 {
+			e.T.Fatalf("controller_create answered %+v, want a controller with an ID", created)
+		}
+		e.Defer("runner controller", func(ctx context.Context) error {
+			_, err := e.Client().GL().RunnerControllers.DeleteRunnerController(created.ID, gl.WithContext(ctx))
+			if err != nil && !fixture.IsStatus(err, http.StatusNotFound) {
+				return err
+			}
+			return nil
+		})
+		controller := map[string]any{"controller_id": created.ID}
+
+		updated := harness.Do[runnercontrollers.Output](s, actionRunnerControllerUpdate, withParams(controller, map[string]any{
+			"description": e.Name("controller-updated"), "state": controllerStateDryRun,
+		}))
+		if updated.ID != created.ID || updated.State != controllerStateDryRun {
+			e.T.Errorf("controller_update answered %+v, want controller %d in state %s", updated, created.ID, controllerStateDryRun)
+		}
+
+		walkControllerTokens(e, s, controller)
+		walkControllerScopes(e, s, controller, created.ID, runnerID)
+
+		harness.DoVoid(s, actionRunnerControllerDelete, controller)
+		gone := harness.Refused(s, actionRunnerControllerGet, controller, harness.FailureNotFound)
+		e.T.Logf("the read after the delete is refused: %s", firstLine(gone))
+	})
+}
+
+// walkControllerTokens takes one token of the controller through create,
+// list, get, rotate and revoke.
+func walkControllerTokens(e *harness.Env, s *harness.Session, controller map[string]any) {
+	e.T.Helper()
+
+	token := harness.Do[runnercontrollertokens.Output](s, actionRunnerControllerTokenCreate, withParams(controller, map[string]any{"description": "e2e controller token"}))
+	if token.ID == 0 {
+		e.T.Fatalf("controller_token_create answered %+v, want a token with an ID", token)
+	}
+	tokens := harness.Do[runnercontrollertokens.ListOutput](s, actionRunnerControllerTokenList, controller)
+	if !containsID(controllerTokenIDs(tokens), token.ID) {
+		e.T.Errorf("the token listing does not hold the created token %d: %v", token.ID, controllerTokenIDs(tokens))
+	}
+	got := harness.Do[runnercontrollertokens.Output](s, actionRunnerControllerTokenGet, withParams(controller, map[string]any{"token_id": token.ID}))
+	if got.ID != token.ID {
+		e.T.Errorf("controller_token_get answered token %d, want %d", got.ID, token.ID)
+	}
+	rotated := harness.Do[runnercontrollertokens.Output](s, actionRunnerControllerTokenRotate, withParams(controller, map[string]any{"token_id": token.ID}))
+	if rotated.ID == 0 {
+		e.T.Fatalf("controller_token_rotate answered %+v, want a token with an ID", rotated)
+	}
+	// A rotation may mint a new record, so the revoke names the current one.
+	harness.DoVoid(s, actionRunnerControllerTokenRevoke, withParams(controller, map[string]any{"token_id": rotated.ID}))
+	afterRevoke := harness.Do[runnercontrollertokens.ListOutput](s, actionRunnerControllerTokenList, controller)
+	if containsID(controllerTokenIDs(afterRevoke), rotated.ID) {
+		e.T.Errorf("the token listing still holds token %d after its revoke: %v", rotated.ID, controllerTokenIDs(afterRevoke))
+	}
+}
+
+// walkControllerScopes adds and removes the instance scope and the Docker
+// runner's scope, reading the listing back after each change so the effect
+// is observed and not only the answer.
+func walkControllerScopes(e *harness.Env, s *harness.Session, controller map[string]any, controllerID, runnerID int64) {
+	e.T.Helper()
+
+	scopes := harness.Do[runnercontrollerscopes.ScopesOutput](s, actionRunnerControllerScopeList, controller)
+	e.T.Logf("controller %d scopes before: %d instance, %d runner", controllerID, len(scopes.InstanceLevelScopings), len(scopes.RunnerLevelScopings))
+	harness.DoVoid(s, actionRunnerControllerScopeAddInstance, controller)
+	scopes = harness.Do[runnercontrollerscopes.ScopesOutput](s, actionRunnerControllerScopeList, controller)
+	if len(scopes.InstanceLevelScopings) == 0 {
+		e.T.Errorf("controller %d reports no instance-level scoping right after adding one", controllerID)
+	}
+	harness.DoVoid(s, actionRunnerControllerScopeRemoveInstance, controller)
+	scopes = harness.Do[runnercontrollerscopes.ScopesOutput](s, actionRunnerControllerScopeList, controller)
+	if len(scopes.InstanceLevelScopings) != 0 {
+		e.T.Errorf("controller %d still reports %d instance-level scoping(s) after removing them", controllerID, len(scopes.InstanceLevelScopings))
+	}
+
+	scoped := harness.Do[runnercontrollerscopes.RunnerScopeOutput](s, actionRunnerControllerScopeAddRunner, withParams(controller, map[string]any{"runner_id": runnerID}))
+	if scoped.RunnerID != runnerID {
+		e.T.Errorf("controller_scope_add_runner answered runner %d, want %d", scoped.RunnerID, runnerID)
+	}
+	harness.DoVoid(s, actionRunnerControllerScopeRemoveRunner, withParams(controller, map[string]any{"runner_id": runnerID}))
+	scopes = harness.Do[runnercontrollerscopes.ScopesOutput](s, actionRunnerControllerScopeList, controller)
+	if containsID(scopedRunnerIDs(scopes), runnerID) {
+		e.T.Errorf("controller %d is still scoped to runner %d after removing it", controllerID, runnerID)
+	}
+}

--- a/test/e2e/gitlab/ee/securityattributes_test.go
+++ b/test/e2e/gitlab/ee/securityattributes_test.go
@@ -1,0 +1,102 @@
+//go:build e2e
+
+// securityattributes_test.go covers the security attribute lifecycle under
+// a category of a top-level group, and the two ways an attribute is put on
+// a project: the project's own update, and the bulk update across projects.
+// Like a category, an attribute has no read of its own, so each step is
+// asserted on its answer.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securityattributes"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The two colors an attribute is created with and changed to.
+const (
+	attributeColor        = "#FF0000"
+	attributeUpdatedColor = "#00FF00"
+)
+
+// classificationFixture is a top-level group with a project in it, which is
+// what an attribute is assigned to.
+type classificationFixture struct {
+	group   fixture.Group
+	project fixture.Project
+}
+
+// buildClassificationFixture creates both.
+func buildClassificationFixture(e *harness.Env) classificationFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("secattr"))
+	return classificationFixture{group: group, project: fixture.NewProject(e, fixture.WithNamePrefix("secattr"), fixture.InGroup(group))}
+}
+
+// TestSecurityAttributes_Lifecycle_AssignsToAProjectAndDeletes creates a
+// category and an attribute in it on every surface, renames and recolors
+// the attribute, puts it on the project both ways, takes it off, and
+// deletes the attribute and then the category.
+//
+// Replaces: TestMeta_SecurityAttributes, TestMeta_SecurityClassifications
+func TestSecurityAttributes_Lifecycle_AssignsToAProjectAndDeletes(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, buildClassificationFixture, func(e *harness.Env, surface harness.Surface, f classificationFixture) {
+		s := e.On(surface)
+		category := newSecurityCategory(e, s, f.group, true)
+
+		name := e.Name("attribute")
+		created := harness.Do[securityattributes.CreateOutput](s, actionSecurityAttributeCreate, map[string]any{
+			"namespace_id": f.group.ID, "category_id": category.ID,
+			"attributes": []map[string]any{{"name": name, "description": "e2e security attribute", "color": attributeColor}},
+		})
+		if len(created.Attributes) != 1 || created.Attributes[0].ID == 0 {
+			e.T.Fatalf("create answered %+v, want exactly the one attribute with an ID", created.Attributes)
+		}
+		attribute := created.Attributes[0]
+		e.T.Cleanup(func() {
+			// The body deletes the attribute itself; this is the teardown an
+			// agent's session runs regardless, and a refusal of an attribute
+			// already gone is worth a line rather than a failure.
+			if _, err := harness.Try[securityattributes.Output](s, actionSecurityAttributeDelete,
+				map[string]any{"attribute_id": attribute.ID}, harness.For(harness.PurposeCleanup)); err != nil {
+				e.T.Logf("the cleanup delete of attribute %d answered: %v", attribute.ID, err)
+			}
+		})
+
+		updated := harness.Do[securityattributes.Output](s, actionSecurityAttributeUpdate, map[string]any{
+			"attribute_id": attribute.ID, "name": name + "-updated", "color": attributeUpdatedColor,
+		})
+		if updated.ID != attribute.ID || updated.Name != name+"-updated" || updated.Color != attributeUpdatedColor {
+			e.T.Errorf("update answered %+v, want attribute %d renamed to %q in %s", updated, attribute.ID, name+"-updated", attributeUpdatedColor)
+		}
+
+		added := harness.Do[securityattributes.ProjectUpdateOutput](s, actionSecurityAttributeProjectUpdate, map[string]any{
+			"project_id": f.project.ID, "add_attribute_ids": []int64{attribute.ID},
+		})
+		if added.AddedCount < 1 {
+			e.T.Errorf("the project update added %d attributes, want at least the one", added.AddedCount)
+		}
+
+		bulk := harness.Do[securityattributes.BulkUpdateOutput](s, actionSecurityAttributeBulkUpdate, map[string]any{
+			"project_ids": []int64{f.project.ID}, "attribute_ids": []int64{attribute.ID}, "mode": securityattributes.BulkUpdateModeAdd,
+		})
+		if bulk.Status != "success" {
+			e.T.Errorf("the bulk update answered status %q, want success: %+v", bulk.Status, bulk)
+		}
+
+		removed := harness.Do[securityattributes.ProjectUpdateOutput](s, actionSecurityAttributeProjectUpdate, map[string]any{
+			"project_id": f.project.ID, "remove_attribute_ids": []int64{attribute.ID},
+		})
+		if removed.RemovedCount < 1 {
+			e.T.Errorf("the project update removed %d attributes, want at least the one", removed.RemovedCount)
+		}
+
+		harness.DoVoid(s, actionSecurityAttributeDelete, map[string]any{"attribute_id": attribute.ID})
+		harness.DoVoid(s, actionSecurityCategoryDelete, map[string]any{"category_id": category.ID})
+	})
+}

--- a/test/e2e/gitlab/ee/securitycategories_test.go
+++ b/test/e2e/gitlab/ee/securitycategories_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+// securitycategories_test.go covers the security category lifecycle under a
+// top-level group: create, update, delete. The catalog offers no read of a
+// category, so what a step changed is read off its own answer, and the
+// delete is observable only by not failing.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securitycategories"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// newSecurityCategory creates a category in the group through the session
+// and registers a second delete of it as the test's own cleanup, through
+// the server, which is what an agent's session does with what it created
+// and what the old suite recorded as the category's teardown.
+func newSecurityCategory(e *harness.Env, s *harness.Session, group fixture.Group, multiple bool) securitycategories.Output {
+	e.T.Helper()
+
+	created := harness.Do[securitycategories.Output](s, actionSecurityCategoryCreate, map[string]any{
+		"namespace_id": group.ID, "name": e.Name("category"), "description": "e2e security category", "multiple_selection": multiple,
+	})
+	if created.ID == 0 {
+		e.T.Fatalf("create answered %+v, want a category with an ID", created)
+	}
+	e.T.Cleanup(func() {
+		// A refusal of a category the body already deleted is worth a line
+		// rather than a failure: the group goes with what is left.
+		if _, err := harness.Try[securitycategories.Output](s, actionSecurityCategoryDelete,
+			map[string]any{"category_id": created.ID}, harness.For(harness.PurposeCleanup)); err != nil {
+			e.T.Logf("the cleanup delete of category %d answered: %v", created.ID, err)
+		}
+	})
+	return created
+}
+
+// TestSecurityCategories_Lifecycle_CreatesUpdatesAndDeletes walks one
+// category per surface under a shared group.
+//
+// Replaces: TestMeta_SecurityCategories, TestMeta_SecurityClassifications
+func TestSecurityCategories_Lifecycle_CreatesUpdatesAndDeletes(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("seccat"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+
+		created := newSecurityCategory(e, s, group, true)
+		if !created.MultipleSelection {
+			e.T.Errorf("create answered multiple_selection=false after asking for true: %+v", created)
+		}
+
+		renamed := created.Name + "-updated"
+		updated := harness.Do[securitycategories.Output](s, actionSecurityCategoryUpdate, map[string]any{
+			"category_id": created.ID, "namespace_id": group.ID, "name": renamed, "description": "updated e2e security category",
+		})
+		if updated.ID != created.ID || updated.Name != renamed || updated.Description != "updated e2e security category" {
+			e.T.Errorf("update answered %+v, want category %d renamed to %q with the new description", updated, created.ID, renamed)
+		}
+
+		harness.DoVoid(s, actionSecurityCategoryDelete, map[string]any{"category_id": created.ID})
+	})
+}

--- a/test/e2e/gitlab/ee/securityscanprofiles_test.go
+++ b/test/e2e/gitlab/ee/securityscanprofiles_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+// securityscanprofiles_test.go covers the scan profile lifecycle on a
+// project in a group: attach the built-in dependency scanning profile by
+// its scan type, read the project's statuses to learn the persisted
+// profile's ID, and detach it by that ID.
+//
+// Three facts of GitLab's shape it: a profile attaches only to a project
+// under a group namespace, since a personal namespace has no shared root
+// for it; attach takes a scan type and finds or creates the namespace's
+// default profile; and detach takes the persisted profile's numeric ID,
+// which only the status listing reveals.
+
+package ee
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securityscanprofiles"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// dependencyScanning is the scan type whose default profile the test
+// attaches, and the one the provisioning script's feature flags enable.
+const dependencyScanning = "dependency_scanning"
+
+// TestSecurityScanProfiles_ProjectInGroup_AttachesListsAndDetaches walks
+// the lifecycle once per surface on a project of its own, since a profile
+// attached by one surface would already be present for the next.
+//
+// Replaces: TestMeta_SecurityScanProfiles
+func TestSecurityScanProfiles_ProjectInGroup_AttachesListsAndDetaches(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("scanprof"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		project := fixture.NewProject(e, fixture.WithNamePrefix("scanprof"), fixture.InGroup(group))
+		if !strings.HasPrefix(project.Path, group.Path+"/") {
+			e.T.Fatalf("project %s is not under group %s, which a scan profile needs", project.Path, group.Path)
+		}
+
+		attached := harness.Do[securityscanprofiles.MutationOutput](s, actionScanProfileAttach, map[string]any{
+			"security_scan_profile_id": dependencyScanning, "project_ids": []int64{project.ID},
+		})
+		if attached.Status != "success" {
+			e.T.Fatalf("attach answered status %q, want success: %+v", attached.Status, attached)
+		}
+
+		statuses := harness.Do[securityscanprofiles.ListProjectStatusesOutput](s, actionScanProfileListProjectStatuses,
+			map[string]any{"project_full_path": project.Path})
+		if statuses.ProjectFullPath != project.Path {
+			e.T.Errorf("the status listing echoes %q, want %q", statuses.ProjectFullPath, project.Path)
+		}
+		var profileID string
+		for _, status := range statuses.Statuses {
+			if strings.EqualFold(status.ScanProfile.ScanType, dependencyScanning) {
+				profileID = status.ScanProfile.ID
+			}
+		}
+		if profileID == "" {
+			e.T.Fatalf("the attached %s profile is not among the project's statuses: %+v", dependencyScanning, statuses.Statuses)
+		}
+
+		detached := harness.Do[securityscanprofiles.MutationOutput](s, actionScanProfileDetach, map[string]any{
+			"security_scan_profile_id": profileID, "project_ids": []int64{project.ID},
+		})
+		if detached.Status != "success" {
+			e.T.Errorf("detach answered status %q, want success: %+v", detached.Status, detached)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/vulnerabilities_test.go
+++ b/test/e2e/gitlab/ee/vulnerabilities_test.go
@@ -1,0 +1,385 @@
+//go:build e2e
+
+// vulnerabilities_test.go covers the vulnerability report of a project: the
+// counts and the listing of a project that has none, and the whole
+// lifecycle on one that has three.
+//
+// The three come from a pipeline the fixture commits, whose one job writes
+// a schema-valid SAST report naming three CRITICAL findings and publishes it
+// as artifacts:reports:sast. GitLab ingests it into the project's
+// Vulnerability Report exactly as it would a real scan, so what is tested is
+// this server's tools and GitLab's reporting path, and not an analyzer image
+// the ephemeral runner may fail to pull. The fixture is confirmed by asking
+// GitLab itself, over GraphQL, before any tool is asked: a tool whose
+// document GitLab refuses answers an empty list and no error, and a fixture
+// derived from that tool would skip the assertions in exactly the state they
+// were written to catch.
+
+package ee
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securityfindings"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/vulnerabilities"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// vulnerableSource is the file the SAST report points at. It is never
+// scanned, since the job clones nothing; it gives the report's locations a
+// real target and keeps the fixture self-describing.
+const vulnerableSource = `# E2E fixture: intentionally vulnerable code referenced by the SAST report.
+import os
+import sqlite3
+db = sqlite3.connect(":memory:")
+cur = db.cursor()
+
+# CWE-89: SQL injection.
+user = input("username: ")
+cur.execute("SELECT * FROM users WHERE name = '" + user + "'")
+
+# CWE-78: command injection.
+cmd = input("cmd: ")
+os.system("ls " + cmd)
+
+# CWE-95: code injection.
+expr = input("expr: ")
+result = eval(expr)
+`
+
+// sastReportPipeline is the pipeline that publishes the report: one job on
+// the alpine image the runner already holds, cloning nothing, writing the
+// minified report with printf and publishing it whatever happens next. The
+// report follows the secure-report schema 15.x and carries the findings
+// [sastIdentifiers] names.
+const sastReportPipeline = `stages:
+  - test
+
+sast:
+  stage: test
+  image: alpine:latest
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      printf '%s' '{"version":"15.0.6","scan":{"analyzer":{"id":"e2e-fixture","name":"E2E Fixture","version":"1.0.0","vendor":{"name":"gitlab-mcp-server"}},"scanner":{"id":"e2e-fixture","name":"E2E Fixture","version":"1.0.0","vendor":{"name":"gitlab-mcp-server"}},"type":"sast","start_time":"2026-01-01T00:00:00","end_time":"2026-01-01T00:00:01","status":"success"},"vulnerabilities":[{"id":"e2e-sast-sqli-0001","category":"sast","name":"SQL Injection","message":"SQL Injection","description":"User input concatenated into a SQL query (CWE-89).","severity":"Critical","scanner":{"id":"e2e-fixture","name":"E2E Fixture"},"location":{"file":"app.py","start_line":10,"end_line":10},"identifiers":[{"type":"cwe","name":"CWE-89","value":"89","url":"https://cwe.mitre.org/data/definitions/89.html"}]},{"id":"e2e-sast-cmdi-0002","category":"sast","name":"OS Command Injection","message":"OS Command Injection","description":"User input flows into os.system (CWE-78).","severity":"Critical","scanner":{"id":"e2e-fixture","name":"E2E Fixture"},"location":{"file":"app.py","start_line":14,"end_line":14},"identifiers":[{"type":"cwe","name":"CWE-78","value":"78","url":"https://cwe.mitre.org/data/definitions/78.html"}]},{"id":"e2e-sast-eval-0003","category":"sast","name":"Code Injection","message":"Code Injection","description":"User input passed to eval (CWE-95).","severity":"Critical","scanner":{"id":"e2e-fixture","name":"E2E Fixture"},"location":{"file":"app.py","start_line":18,"end_line":18},"identifiers":[{"type":"cwe","name":"CWE-95","value":"95","url":"https://cwe.mitre.org/data/definitions/95.html"}]}]}' > gl-sast-report.json
+      echo "wrote gl-sast-report.json ($(wc -c < gl-sast-report.json) bytes)"
+  artifacts:
+    when: always
+    reports:
+      sast: gl-sast-report.json
+`
+
+// sastFindingCount is how many findings the report publishes, and
+// sastIdentifiers the CWE identifiers they carry, which are what the
+// fixture owns: a finding's title is whatever the report says, while the
+// identifier is what a scanner and a consumer agree on.
+const sastFindingCount = 3
+
+var sastIdentifiers = []string{"CWE-78", "CWE-89", "CWE-95"}
+
+// The wait for GitLab to promote the published findings into the project's
+// report, which runs on Sidekiq behind whatever else the instance is doing.
+const (
+	vulnerabilityReportWait     = 4 * time.Minute
+	vulnerabilityReportInterval = 5 * time.Second
+)
+
+// The state names GitLab gives a vulnerability along the lifecycle.
+const (
+	stateConfirmed = "CONFIRMED"
+	stateResolved  = "RESOLVED"
+	stateDetected  = "DETECTED"
+	stateDismissed = "DISMISSED"
+)
+
+// TestVulnerabilities_FreshProject_ReportsNothing reads the severity counts
+// and the listing of a project nothing scanned, on every surface.
+//
+// Replaces: TestIndividual_Vulnerabilities, TestMeta_Vulnerabilities
+func TestVulnerabilities_FreshProject_ReportsNothing(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("vuln"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+
+		counts := harness.Do[vulnerabilities.SeverityCountOutput](s, actionVulnerabilitySeverityCount, map[string]any{"project_path": project.Path})
+		if counts.Total != 0 {
+			e.T.Errorf("a project nothing scanned counts %d vulnerabilities: %+v", counts.Total, counts)
+		}
+		listed := harness.Do[vulnerabilities.ListOutput](s, actionVulnerabilityList, map[string]any{"project_path": project.Path})
+		if len(listed.Vulnerabilities) != 0 {
+			e.T.Errorf("a project nothing scanned lists %d vulnerabilities: %+v", len(listed.Vulnerabilities), listed.Vulnerabilities)
+		}
+	})
+}
+
+// TestSecurityFindings_MissingPipeline_IsRefusedAsNotFound asks a fresh
+// project for the findings of a pipeline it never ran, plain and filtered,
+// on every surface: the action refuses a pipeline it cannot find rather
+// than answering an empty page a caller would read as no findings.
+//
+// Replaces: TestMeta_SecurityFindings
+func TestSecurityFindings_MissingPipeline_IsRefusedAsNotFound(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("findings"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		params := map[string]any{"project_path": project.Path, "pipeline_iid": "1"}
+
+		refused := harness.Refused(s, actionSecurityFindingList, params, harness.FailureNotFound)
+		assertMentions(e, "the findings of a missing pipeline", refused, "pipeline")
+		refused = harness.Refused(s, actionSecurityFindingList, withParams(params, map[string]any{
+			"severity": []string{"HIGH", "CRITICAL"}, "report_type": []string{"SAST"}, "first": 10,
+		}), harness.FailureNotFound)
+		assertMentions(e, "the filtered findings of a missing pipeline", refused, "pipeline")
+	})
+}
+
+// reportedVulnerability is what the lifecycle needs from GitLab's own
+// report: which vulnerability to act on and what it looked like first.
+type reportedVulnerability struct {
+	ID       string `json:"id"`
+	Severity string `json:"severity"`
+	State    string `json:"state"`
+}
+
+// vulnerabilityFixture is a project whose default-branch pipeline published
+// the SAST report, with the vulnerabilities GitLab ingested from it.
+type vulnerabilityFixture struct {
+	project     fixture.Project
+	pipelineIID string
+	reported    []reportedVulnerability
+}
+
+// buildVulnerabilityFixture commits the source and the pipeline, runs the
+// pipeline to success, and waits for GitLab's own report to hold the three
+// findings, failing with the pipeline's job diagnostics when it does not.
+func buildVulnerabilityFixture(e *harness.Env) vulnerabilityFixture {
+	project := fixture.NewProject(e, fixture.WithNamePrefix("vulnlife"))
+	fixture.CommitFile(e, project, project.DefaultBranch, "app.py", vulnerableSource, "add the intentionally vulnerable fixture source")
+	fixture.CommitFile(e, project, project.DefaultBranch, fixture.CIFilePath, sastReportPipeline, "add the SAST report publishing pipeline")
+
+	pipeline := fixture.NewPipeline(e, project, project.DefaultBranch)
+	if pipeline.Status != "success" {
+		logPipelineJobs(e, project, pipeline.ID)
+		e.T.Fatalf("the SAST report pipeline %d ended %s, want success", pipeline.ID, pipeline.Status)
+	}
+	detail, _, err := e.Client().GL().Pipelines.GetPipeline(project.ID, pipeline.ID, gl.WithContext(e.Ctx))
+	if err != nil {
+		e.T.Fatalf("reading pipeline %d for its iid: %v", pipeline.ID, err)
+	}
+
+	reported, err := waitForProjectVulnerabilities(e, project.Path)
+	if err != nil {
+		logPipelineJobs(e, project, pipeline.ID)
+		e.T.Fatalf("pipeline %d (%s) published a SAST report and GitLab's own vulnerability report of %s holds nothing after %s: %v",
+			pipeline.ID, pipeline.Status, project.Path, vulnerabilityReportWait, err)
+	}
+	if len(reported) < sastFindingCount {
+		e.T.Fatalf("GitLab's own report of %s holds %d vulnerabilities, want the %d the fixture published: %+v", project.Path, len(reported), sastFindingCount, reported)
+	}
+	return vulnerabilityFixture{project: project, pipelineIID: strconv.FormatInt(detail.IID, 10), reported: reported}
+}
+
+// projectVulnerabilitiesQuery is the document the fixture asks GitLab with,
+// deliberately written here rather than borrowed from the tool under test.
+const projectVulnerabilitiesQuery = `query($projectPath: ID!, $first: Int!) {
+  project(fullPath: $projectPath) {
+    vulnerabilities(first: $first) {
+      nodes { id severity state }
+    }
+  }
+}`
+
+// waitForProjectVulnerabilities polls GitLab's project vulnerability report
+// until it holds every published finding or the budget runs out. A query
+// GitLab refuses is reported as the reason rather than retried into a
+// silence.
+func waitForProjectVulnerabilities(e *harness.Env, projectPath string) ([]reportedVulnerability, error) {
+	e.T.Helper()
+
+	var found []reportedVulnerability
+	err := harness.Poll(e.Ctx, vulnerabilityReportInterval, vulnerabilityReportWait, func() (bool, string, error) {
+		var answer struct {
+			Data struct {
+				Project *struct {
+					Vulnerabilities struct {
+						Nodes []reportedVulnerability `json:"nodes"`
+					} `json:"vulnerabilities"`
+				} `json:"project"`
+			} `json:"data"`
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		_, queryErr := e.Client().GL().GraphQL.Do(gl.GraphQLQuery{
+			Query:     projectVulnerabilitiesQuery,
+			Variables: map[string]any{"projectPath": projectPath, "first": 20},
+		}, &answer, gl.WithContext(e.Ctx))
+		switch {
+		case queryErr != nil:
+			// A transport failure is the instance under load, which the next
+			// poll asks again; only GitLab's own refusal of the document ends
+			// the wait, since no later poll can change that answer.
+			return false, "the report query failed: " + queryErr.Error(), nil //nolint:nilerr // a failed poll is retried, not reported
+		case len(answer.Errors) > 0:
+			refusals, _ := json.Marshal(answer.Errors)
+			return false, "", fmt.Errorf("GitLab refused the fixture's own report query: %s", refusals)
+		case answer.Data.Project == nil:
+			return false, "the project is not visible to the report query yet", nil
+		}
+		found = answer.Data.Project.Vulnerabilities.Nodes
+		if len(found) < sastFindingCount {
+			return false, fmt.Sprintf("the report holds %d of %d findings", len(found), sastFindingCount), nil
+		}
+		return true, "", nil
+	})
+	return found, err
+}
+
+// logPipelineJobs logs every job of a pipeline with its status, so a runner
+// or fixture regression is diagnosable from the test log alone.
+func logPipelineJobs(e *harness.Env, project fixture.Project, pipelineID int64) {
+	e.T.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	jobs, _, err := e.Client().GL().Jobs.ListPipelineJobs(project.ID, pipelineID, nil, gl.WithContext(ctx))
+	if err != nil {
+		e.T.Logf("diagnostics: listing the jobs of pipeline %d: %v", pipelineID, err)
+		return
+	}
+	for _, job := range jobs {
+		e.T.Logf("diagnostics: job %d %q stage=%q status=%q allow_failure=%t", job.ID, job.Name, job.Stage, job.Status, job.AllowFailure)
+	}
+}
+
+// assertSASTFindings fails unless a findings listing holds exactly want of
+// the CRITICAL findings the report publishes, each carrying one of the
+// identifiers the report gives them and no two the same. A handler whose
+// document GitLab refused answers an empty list and no error, which a
+// length log cannot tell from a pipeline that found nothing, and this is
+// what tells them apart.
+func assertSASTFindings(e *harness.Env, scope string, out securityfindings.ListOutput, want int) {
+	e.T.Helper()
+	if len(out.Findings) != want {
+		e.T.Errorf("%s: %d findings, want %d: %+v", scope, len(out.Findings), want, out.Findings)
+		return
+	}
+	seen := make([]string, 0, want)
+	for _, finding := range out.Findings {
+		if finding.Severity != "CRITICAL" {
+			e.T.Errorf("%s: finding %s is %s, want CRITICAL", scope, finding.UUID, finding.Severity)
+		}
+		for _, identifier := range finding.Identifiers {
+			if !slices.Contains(sastIdentifiers, identifier.Name) {
+				e.T.Errorf("%s: finding %s carries %s, which the report never published", scope, finding.UUID, identifier.Name)
+			}
+			if slices.Contains(seen, identifier.Name) {
+				e.T.Errorf("%s: two findings carry %s", scope, identifier.Name)
+			}
+			seen = append(seen, identifier.Name)
+		}
+	}
+	if len(seen) != want {
+		e.T.Errorf("%s: the findings carry %v, want %d distinct identifiers", scope, seen, want)
+	}
+}
+
+// everyFindingState names every state a finding can be in, for a listing
+// that must hold the findings earlier surfaces dismissed: GitLab leaves a
+// dismissed finding out unless the filter asks for it.
+var everyFindingState = []string{stateDetected, stateConfirmed, stateResolved, stateDismissed}
+
+// assertVulnerabilityState fails unless a state mutation answered for the
+// vulnerability it was asked about, moved to the state the action names. A
+// mutation whose document GitLab refused answers an empty payload rather
+// than an error, so the returned state is what tells a working mutation
+// from a silently rejected one.
+func assertVulnerabilityState(e *harness.Env, action harness.ActionID, out vulnerabilities.MutationOutput, wantID, wantState string) {
+	e.T.Helper()
+	if out.Vulnerability.ID != wantID {
+		e.T.Errorf("%s answered for vulnerability %q, want %q", action, out.Vulnerability.ID, wantID)
+	}
+	if out.Vulnerability.State != wantState {
+		e.T.Errorf("%s left vulnerability %q in state %q, want %s", action, wantID, out.Vulnerability.State, wantState)
+	}
+}
+
+// TestVulnerabilityLifecycle_SASTReport_ReadsAndMovesEveryState builds the
+// report once and, on every surface, reads it back through the listing, the
+// pipeline's security summary and the findings listing, then walks one of
+// the three vulnerabilities, the surface's own, through get, confirm,
+// resolve, revert and dismiss. Each surface takes a different vulnerability
+// so that none finds the state another left.
+//
+// Replaces: TestMeta_VulnerabilityLifecycle
+func TestVulnerabilityLifecycle_SASTReport_ReadsAndMovesEveryState(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedRunner, harness.Tier(edition.Ultimate)), harness.Locks(harness.LockRunner))
+
+	harness.SurfacesWith(e, buildVulnerabilityFixture, func(e *harness.Env, surface harness.Surface, f vulnerabilityFixture) {
+		s := e.On(surface)
+		// The surfaces run in order and each ends by dismissing its own
+		// vulnerability, so this one finds the earlier ones' dismissed.
+		earlier := slices.Index(harness.AllSurfaces(), surface)
+		own := f.reported[earlier%len(f.reported)]
+		reportedIDs := make([]string, 0, len(f.reported))
+		for _, vulnerability := range f.reported {
+			reportedIDs = append(reportedIDs, vulnerability.ID)
+		}
+
+		listed := harness.Do[vulnerabilities.ListOutput](s, actionVulnerabilityList, map[string]any{"project_path": f.project.Path})
+		listedIDs := make([]string, 0, len(listed.Vulnerabilities))
+		for _, vulnerability := range listed.Vulnerabilities {
+			listedIDs = append(listedIDs, vulnerability.ID)
+		}
+		for _, id := range reportedIDs {
+			if !slices.Contains(listedIDs, id) {
+				e.T.Errorf("the listing does not report %q, which GitLab's own report holds among %d; it answered %v", id, len(reportedIDs), listedIDs)
+			}
+		}
+
+		summary := harness.Do[vulnerabilities.PipelineSecuritySummaryOutput](s, actionVulnerabilityPipelineSecuritySummary,
+			map[string]any{"project_path": f.project.Path, "pipeline_iid": f.pipelineIID})
+		if summary.Sast == nil {
+			e.T.Errorf("pipeline %s reports no SAST section, and the fixture published a SAST report", f.pipelineIID)
+		} else if summary.Sast.VulnerabilitiesCount != sastFindingCount {
+			e.T.Errorf("pipeline %s counts %d SAST vulnerabilities, want %d", f.pipelineIID, summary.Sast.VulnerabilitiesCount, sastFindingCount)
+		}
+
+		findings := map[string]any{"project_path": f.project.Path, "pipeline_iid": f.pipelineIID}
+		// GitLab leaves a dismissed finding out of a listing that names no
+		// state, so the plain listing shrinks by one per surface that ran.
+		assertSASTFindings(e, "the plain findings listing", harness.Do[securityfindings.ListOutput](s, actionSecurityFindingList, findings), sastFindingCount-earlier)
+		// Every published finding is CRITICAL SAST, so the severity and
+		// report filters ask for exactly what the pipeline holds and must
+		// narrow nothing, and naming every state brings the dismissed back.
+		assertSASTFindings(e, "the findings filtered to CRITICAL and HIGH SAST in every state", harness.Do[securityfindings.ListOutput](s, actionSecurityFindingList,
+			withParams(findings, map[string]any{"severity": []string{"HIGH", "CRITICAL"}, "report_type": []string{"SAST"}, "state": everyFindingState, "first": 10})), sastFindingCount)
+
+		got := harness.Do[vulnerabilities.GetOutput](s, actionVulnerabilityGet, map[string]any{"id": own.ID})
+		if got.Vulnerability.ID != own.ID {
+			e.T.Errorf("get answered %q, want %q", got.Vulnerability.ID, own.ID)
+		}
+		assertVulnerabilityState(e, actionVulnerabilityConfirm, harness.Do[vulnerabilities.MutationOutput](s, actionVulnerabilityConfirm, map[string]any{"id": own.ID}), own.ID, stateConfirmed)
+		assertVulnerabilityState(e, actionVulnerabilityResolve, harness.Do[vulnerabilities.MutationOutput](s, actionVulnerabilityResolve, map[string]any{"id": own.ID}), own.ID, stateResolved)
+		assertVulnerabilityState(e, actionVulnerabilityRevert, harness.Do[vulnerabilities.MutationOutput](s, actionVulnerabilityRevert, map[string]any{"id": own.ID}), own.ID, stateDetected)
+		assertVulnerabilityState(e, actionVulnerabilityDismiss, harness.Do[vulnerabilities.MutationOutput](s, actionVulnerabilityDismiss, map[string]any{
+			"id": own.ID, "comment": "e2e dismissal", "dismissal_reason": "USED_IN_TESTS",
+		}), own.ID, stateDismissed)
+	})
+}

--- a/test/e2e/internal/fixture/group.go
+++ b/test/e2e/internal/fixture/group.go
@@ -7,6 +7,7 @@ package fixture
 
 import (
 	"context"
+	"strconv"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
@@ -24,6 +25,15 @@ type Group struct {
 	Name string
 	// ParentID is the parent group's ID, zero for a top-level group.
 	ParentID int64
+}
+
+// IDParam spells the group's ID as a group_id parameter declared a string
+// takes it, for the same reason [Project.IDParam] exists: the dispatcher
+// surfaces coerce a number into the string, and the individual surface
+// refuses one against the schema. An action whose group_id is declared
+// numeric takes ID itself.
+func (g Group) IDParam() string {
+	return strconv.FormatInt(g.ID, 10)
 }
 
 // groupSpec is what a builder asks GitLab for.

--- a/test/e2e/internal/fixture/group_test.go
+++ b/test/e2e/internal/fixture/group_test.go
@@ -112,3 +112,12 @@ func TestGroupOf_Fields_ReadsWhatATestNeeds(t *testing.T) {
 		t.Errorf("groupOf() = %+v, want %+v", got, want)
 	}
 }
+
+// TestGroupIDParam_SpellsTheIDAsTheSchemaDeclaresIt pins the spelling of a
+// group ID for a group_id declared a string, the twin of the project's:
+// the individual surface refuses a number against that schema.
+func TestGroupIDParam_SpellsTheIDAsTheSchemaDeclaresIt(t *testing.T) {
+	if got, want := (Group{ID: 71}).IDParam(), "71"; got != want {
+		t.Errorf("IDParam() = %q, want %q", got, want)
+	}
+}

--- a/test/e2e/internal/fixture/iteration.go
+++ b/test/e2e/internal/fixture/iteration.go
@@ -1,0 +1,222 @@
+//go:build e2e
+
+// iteration.go builds an iteration, which GitLab offers no REST API to
+// create: a cadence and an iteration under it are made over GraphQL, and an
+// issue is put into the iteration the same way.
+//
+// Iterations are a licensed feature of a group namespace, so the builder
+// takes a group and skips on an instance that will not create a cadence,
+// naming the reason GitLab gave. The suite this replaces built the same
+// fixture inside one test body, returned false on every failure, and let the
+// test decide; here a fixture that cannot be built ends the test where it
+// fails.
+
+package fixture
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Iteration is an iteration a builder created in a group's cadence.
+type Iteration struct {
+	// GID is the GraphQL global ID, which the assignment mutation takes.
+	GID string
+	// IID is the number the REST listings report it under.
+	IID int64
+	// Title is what it was created as.
+	Title string
+	// GroupID is the group whose cadence holds it.
+	GroupID int64
+}
+
+// String names the iteration in a message.
+func (i Iteration) String() string {
+	return fmt.Sprintf("%s (iid %d, %s)", i.GID, i.IID, i.Title)
+}
+
+// iterationLength is how long a fixture iteration lasts. It starts today so
+// that it is current, which is what an issue assignment needs.
+const iterationLength = 7 * 24 * time.Hour
+
+// cadenceMutation creates a manual cadence, so the fixture controls the
+// iteration's dates rather than GitLab's scheduler.
+const cadenceMutation = `mutation($groupPath: ID!, $title: String!) {
+  iterationCadenceCreate(input: {
+    groupPath: $groupPath, title: $title, automatic: false, active: true,
+    durationInWeeks: 1, iterationsInAdvance: 1, rollOver: false
+  }) {
+    iterationCadence { id }
+    errors
+  }
+}`
+
+// iterationMutation creates one iteration in a cadence.
+const iterationMutation = `mutation($cadenceId: IterationsCadenceID!, $groupPath: ID!, $title: String!, $startDate: String!, $dueDate: String!) {
+  iterationCreate(input: {
+    iterationsCadenceId: $cadenceId, groupPath: $groupPath, title: $title,
+    startDate: $startDate, dueDate: $dueDate
+  }) {
+    iteration { id iid }
+    errors
+  }
+}`
+
+// issueIterationMutation puts an issue into an iteration. The mutation is
+// issueSetIteration, addressed by project path and issue iid rather than by
+// a global ID, which is the shape GitLab documents for it.
+const issueIterationMutation = `mutation($projectPath: ID!, $iid: String!, $iterationId: IterationID!) {
+  issueSetIteration(input: { projectPath: $projectPath, iid: $iid, iterationId: $iterationId }) {
+    issue { iid iteration { id } }
+    errors
+  }
+}`
+
+// NewIteration creates a manual cadence in the group and one current
+// iteration under it. Both go with the group, so nothing is registered. The
+// test is skipped when the instance refuses to create a cadence, since that
+// is the license or the feature flag rather than the test.
+func NewIteration(e *harness.Env, group Group) Iteration {
+	e.T.Helper()
+
+	var cadence struct {
+		IterationCadenceCreate struct {
+			IterationCadence struct {
+				ID string `json:"id"`
+			} `json:"iterationCadence"`
+			Errors []string `json:"errors"`
+		} `json:"iterationCadenceCreate"`
+	}
+	err := mutate(e, cadenceMutation, map[string]any{"groupPath": group.Path, "title": e.Name("cadence")}, &cadence)
+	if err != nil {
+		e.Skipf("creating an iteration cadence in group %s: %v", group.Path, err)
+	}
+	if errs := cadence.IterationCadenceCreate.Errors; len(errs) > 0 {
+		e.Skipf("GitLab refused an iteration cadence in group %s: %s", group.Path, strings.Join(errs, "; "))
+	}
+	cadenceGID := cadence.IterationCadenceCreate.IterationCadence.ID
+	if cadenceGID == "" {
+		e.T.Fatalf("the iteration cadence in group %s was created with no ID", group.Path)
+	}
+
+	title := e.Name("iteration")
+	start := time.Now().UTC()
+	var created struct {
+		IterationCreate struct {
+			Iteration struct {
+				ID  string `json:"id"`
+				IID string `json:"iid"`
+			} `json:"iteration"`
+			Errors []string `json:"errors"`
+		} `json:"iterationCreate"`
+	}
+	err = mutate(e, iterationMutation, map[string]any{
+		"cadenceId": cadenceGID,
+		"groupPath": group.Path,
+		"title":     title,
+		"startDate": start.Format(time.DateOnly),
+		"dueDate":   start.Add(iterationLength).Format(time.DateOnly),
+	}, &created)
+	if err != nil {
+		e.T.Fatalf("creating an iteration in cadence %s: %v", cadenceGID, err)
+	}
+	if errs := created.IterationCreate.Errors; len(errs) > 0 {
+		e.T.Fatalf("GitLab refused the iteration in cadence %s: %s", cadenceGID, strings.Join(errs, "; "))
+	}
+	iteration := created.IterationCreate.Iteration
+	if iteration.ID == "" {
+		e.T.Fatalf("the iteration in cadence %s was created with no ID", cadenceGID)
+	}
+	iid, err := strconv.ParseInt(iteration.IID, 10, 64)
+	if err != nil {
+		e.T.Fatalf("the iteration %s reports the iid %q, which is not a number: %v", iteration.ID, iteration.IID, err)
+	}
+	return Iteration{GID: iteration.ID, IID: iid, Title: title, GroupID: group.ID}
+}
+
+// AssignIssueIteration puts an issue into an iteration, which is what makes
+// GitLab record an iteration event on the issue.
+func AssignIssueIteration(e *harness.Env, project Project, issue Issue, iteration Iteration) {
+	e.T.Helper()
+
+	var assigned struct {
+		IssueSetIteration struct {
+			Issue *struct {
+				Iteration *struct {
+					ID string `json:"id"`
+				} `json:"iteration"`
+			} `json:"issue"`
+			Errors []string `json:"errors"`
+		} `json:"issueSetIteration"`
+	}
+	err := mutate(e, issueIterationMutation, map[string]any{
+		"projectPath": project.Path,
+		"iid":         strconv.FormatInt(issue.IID, 10),
+		"iterationId": iteration.GID,
+	}, &assigned)
+	if err != nil {
+		e.T.Fatalf("assigning issue #%d of %s to iteration %s: %v", issue.IID, project.Path, iteration.GID, err)
+	}
+	if errs := assigned.IssueSetIteration.Errors; len(errs) > 0 {
+		e.T.Fatalf("GitLab refused to put issue #%d of %s into iteration %s: %s", issue.IID, project.Path, iteration.GID, strings.Join(errs, "; "))
+	}
+	result := assigned.IssueSetIteration.Issue
+	if result == nil || result.Iteration == nil || result.Iteration.ID != iteration.GID {
+		e.T.Fatalf("issue #%d of %s is not in iteration %s after the assignment: %+v", issue.IID, project.Path, iteration.GID, result)
+	}
+}
+
+// graphQLEnvelope is the whole of a GraphQL answer: the data half, kept raw
+// for the caller's own shape, and the top-level errors GitLab reports
+// inside a 200 for a document it refused.
+type graphQLEnvelope struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// mutate sends one document on the test's own context and client.
+func mutate(e *harness.Env, query string, variables map[string]any, into any) error {
+	e.T.Helper()
+	return runGraphQL(e.Ctx, e.Client(), query, variables, into)
+}
+
+// errGraphQLNoData is a document GitLab answered with neither data nor
+// errors, which no GraphQL server does and a proxy in front of one might.
+var errGraphQLNoData = errors.New("GitLab answered the document with no data")
+
+// runGraphQL sends one document once and decodes its data into the caller's
+// shape, turning the document-level errors into an error of its own: a
+// refused document is otherwise a 200 with an empty data half, which reads
+// as a mutation that silently did nothing.
+func runGraphQL(ctx context.Context, client *gitlabclient.Client, query string, variables map[string]any, into any) error {
+	var envelope graphQLEnvelope
+	if _, err := client.GL().GraphQL.Do(gl.GraphQLQuery{Query: query, Variables: variables}, &envelope, gl.WithContext(ctx)); err != nil {
+		return err
+	}
+	if len(envelope.Errors) > 0 {
+		messages := make([]string, 0, len(envelope.Errors))
+		for _, refusal := range envelope.Errors {
+			messages = append(messages, refusal.Message)
+		}
+		return fmt.Errorf("GitLab refused the document: %s", strings.Join(messages, "; "))
+	}
+	if len(envelope.Data) == 0 || string(envelope.Data) == "null" {
+		return errGraphQLNoData
+	}
+	if err := json.Unmarshal(envelope.Data, into); err != nil {
+		return fmt.Errorf("decoding the document's data into %T: %w", into, err)
+	}
+	return nil
+}

--- a/test/e2e/internal/fixture/iteration_test.go
+++ b/test/e2e/internal/fixture/iteration_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+
+// iteration_test.go drives the GraphQL sender the iteration builder stands
+// on against the stub: one send per document, the mutation's own errors
+// surfaced, and a refused document told apart from an empty answer.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestRunGraphQL_Answers_AreDecodedFromTheDataHalf checks the happy path:
+// the document is sent exactly once and the data half lands in the caller's
+// own shape. Once matters because every document here is a mutation, and a
+// sender that asked twice would create two cadences and report one.
+func TestRunGraphQL_Answers_AreDecodedFromTheDataHalf(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.graphqlAnswers = []string{`{"data":{"iterationCreate":{"iteration":{"id":"gid://gitlab/Iteration/5","iid":"3"},"errors":[]}}}`}
+	})
+
+	var got struct {
+		IterationCreate struct {
+			Iteration struct {
+				ID  string `json:"id"`
+				IID string `json:"iid"`
+			} `json:"iteration"`
+			Errors []string `json:"errors"`
+		} `json:"iterationCreate"`
+	}
+	err := runGraphQL(context.Background(), client, iterationMutation, map[string]any{"title": "x"}, &got)
+	if err != nil {
+		t.Fatalf("runGraphQL() error = %v, want nil", err)
+	}
+	if got.IterationCreate.Iteration.ID != "gid://gitlab/Iteration/5" || got.IterationCreate.Iteration.IID != "3" {
+		t.Errorf("decoded %+v, want the iteration the stub answered", got.IterationCreate.Iteration)
+	}
+	if sent := len(stub.graphqlDocuments); sent != 1 {
+		t.Errorf("the document was sent %d times, want exactly once", sent)
+	}
+}
+
+// TestRunGraphQL_RefusedDocument_IsAnErrorNamingTheReason checks that the
+// top-level errors GitLab reports inside a 200 become an error, since a
+// caller reading only the data half would see an empty mutation payload and
+// conclude the mutation did nothing rather than that it was refused.
+func TestRunGraphQL_RefusedDocument_IsAnErrorNamingTheReason(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.graphqlAnswers = []string{`{"data":null,"errors":[{"message":"Field 'iterationCadenceCreate' doesn't exist on type 'Mutation'"}]}`}
+	})
+
+	var got map[string]any
+	err := runGraphQL(context.Background(), client, cadenceMutation, nil, &got)
+	if err == nil {
+		t.Fatal("runGraphQL() error = nil, want the refusal")
+	}
+	if !strings.Contains(err.Error(), "doesn't exist on type 'Mutation'") {
+		t.Errorf("runGraphQL() error = %q, want it to carry GitLab's own reason", err)
+	}
+}
+
+// TestRunGraphQL_EmptyAnswer_IsAnError checks that an answer with neither
+// data nor errors is reported rather than decoded into nothing.
+func TestRunGraphQL_EmptyAnswer_IsAnError(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.graphqlAnswers = []string{`{}`}
+	})
+
+	var got map[string]any
+	err := runGraphQL(context.Background(), client, cadenceMutation, nil, &got)
+	if !errors.Is(err, errGraphQLNoData) {
+		t.Errorf("runGraphQL() error = %v, want %v", err, errGraphQLNoData)
+	}
+}
+
+// TestRunGraphQL_UndecodableData_NamesTheShape checks that a data half the
+// caller's shape cannot hold is an error naming that shape, so a changed
+// schema fails where it is read rather than as a zero value downstream.
+func TestRunGraphQL_UndecodableData_NamesTheShape(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.graphqlAnswers = []string{`{"data":{"iterationCreate":"not an object"}}`}
+	})
+
+	var got struct {
+		IterationCreate struct {
+			Errors []string `json:"errors"`
+		} `json:"iterationCreate"`
+	}
+	err := runGraphQL(context.Background(), client, iterationMutation, nil, &got)
+	if err == nil || !strings.Contains(err.Error(), "decoding the document's data") {
+		t.Errorf("runGraphQL() error = %v, want a decoding error naming the shape", err)
+	}
+}
+
+// TestIteration_String_NamesEveryHalf checks that the message form of an
+// iteration carries the GID, the iid and the title, which are the three
+// things a failure about one needs to be looked up by.
+func TestIteration_String_NamesEveryHalf(t *testing.T) {
+	iteration := Iteration{GID: "gid://gitlab/Iteration/9", IID: 4, Title: "e2e-iteration"}
+	got := iteration.String()
+	for _, want := range []string{"gid://gitlab/Iteration/9", "iid 4", "e2e-iteration"} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("String() = %q, want it to carry %q", got, want)
+			}
+		})
+	}
+}

--- a/test/e2e/internal/fixture/license.go
+++ b/test/e2e/internal/fixture/license.go
@@ -1,0 +1,74 @@
+//go:build e2e
+
+// license.go reads the Enterprise license the provisioning script cached,
+// for the one test that installs a license through the server.
+//
+// The key is never a setting: setup-gitlab.sh exports the active license
+// from the instance it just activated and writes it to a file under
+// test/e2e, so a later run can reuse it without spending another activation.
+// The test that adds a duplicate of it and removes that duplicate reads the
+// same file, which is also why the test can only run where the script ran.
+
+package fixture
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// SettingEnterpriseLicenseFile is the setting that names another license
+// cache than the default, the same one the provisioning scripts read.
+const SettingEnterpriseLicenseFile = "E2E_ENTERPRISE_LICENSE_FILE"
+
+// defaultEnterpriseLicenseFile is where setup-gitlab.sh caches the license,
+// relative to the repository root.
+var defaultEnterpriseLicenseFile = filepath.Join("test", "e2e", ".enterprise-license")
+
+// errNoLicenseCached is a cache file that is missing or holds nothing.
+var errNoLicenseCached = errors.New("no Enterprise license is cached")
+
+// CachedEnterpriseLicense returns the Base64 license the provisioning script
+// cached for this checkout, skipping the test when there is none: a run
+// against an instance somebody else licensed has no key to add.
+func CachedEnterpriseLicense(e *harness.Env) string {
+	e.T.Helper()
+
+	path := licenseCachePath(e.Setting(SettingEnterpriseLicenseFile), e.RepoRoot())
+	key, err := readCachedLicense(path)
+	if err != nil {
+		e.Skipf("reading the cached Enterprise license: %v (provision one with test/e2e/scripts/setup-gitlab.sh, or name it with %s)", err, SettingEnterpriseLicenseFile)
+	}
+	return key
+}
+
+// licenseCachePath resolves the cache file: the configured path, made
+// absolute against the repository root when it is relative, and the default
+// location under the root otherwise.
+func licenseCachePath(configured, root string) string {
+	if configured == "" {
+		return filepath.Join(root, defaultEnterpriseLicenseFile)
+	}
+	if filepath.IsAbs(configured) {
+		return configured
+	}
+	return filepath.Join(root, configured)
+}
+
+// readCachedLicense reads the key out of one cache file, refusing an empty
+// one the same way as a missing one.
+func readCachedLicense(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("%w at %s: %w", errNoLicenseCached, path, err)
+	}
+	key := strings.TrimSpace(string(data))
+	if key == "" {
+		return "", fmt.Errorf("%w: %s is empty", errNoLicenseCached, path)
+	}
+	return key, nil
+}

--- a/test/e2e/internal/fixture/license_test.go
+++ b/test/e2e/internal/fixture/license_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+// license_test.go covers the license cache reader's pure halves: where the
+// file is looked for, and what an absent or empty one is reported as.
+
+package fixture
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLicenseCachePath_Configured_ResolvesAgainstTheRoot checks the three
+// spellings a cache path can have: none, which is the script's default under
+// the root; a relative one, which the scripts also read against the root;
+// and an absolute one, which is taken as it is.
+func TestLicenseCachePath_Configured_ResolvesAgainstTheRoot(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "repo")
+	absolute := filepath.Join(string(filepath.Separator), "elsewhere", "key")
+	cases := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{name: "default", configured: "", want: filepath.Join(root, "test", "e2e", ".enterprise-license")},
+		{name: "relative", configured: filepath.Join("var", "key"), want: filepath.Join(root, "var", "key")},
+		{name: "absolute", configured: absolute, want: absolute},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := licenseCachePath(testCase.configured, root); got != testCase.want {
+				t.Errorf("licenseCachePath(%q) = %q, want %q", testCase.configured, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestReadCachedLicense_Files_AreReadTrimmedOrRefused checks that a cached
+// key comes back without the newline the script may have left, and that a
+// missing or empty file is the same named refusal, since both mean there is
+// nothing to install.
+func TestReadCachedLicense_Files_AreReadTrimmedOrRefused(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "present")
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(present, []byte("  dGVzdA==\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(empty, []byte(" \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		path    string
+		want    string
+		refused bool
+	}{
+		{name: "present", path: present, want: "dGVzdA=="},
+		{name: "empty", path: empty, refused: true},
+		{name: "missing", path: filepath.Join(dir, "missing"), refused: true},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := readCachedLicense(testCase.path)
+			if testCase.refused {
+				if !errors.Is(err, errNoLicenseCached) {
+					t.Errorf("readCachedLicense(%s) error = %v, want %v", testCase.name, err, errNoLicenseCached)
+				}
+				return
+			}
+			if err != nil || got != testCase.want {
+				t.Errorf("readCachedLicense(%s) = (%q, %v), want (%q, nil)", testCase.name, got, err, testCase.want)
+			}
+		})
+	}
+}

--- a/test/e2e/internal/fixture/merge_request.go
+++ b/test/e2e/internal/fixture/merge_request.go
@@ -67,6 +67,32 @@ func NewMergeRequest(e *harness.Env, project Project, source, target, title stri
 	return mr
 }
 
+// EnableMergeTrains turns merged results pipelines and merge trains on for
+// a project and reports whether GitLab kept both.
+//
+// Both switches are needed, because setting merge_trains_enabled alone is
+// silently dropped. The report matters on a self-managed instance: GitLab
+// does not persist the flags on a project in a personal namespace, since the
+// namespace lacks the licensed feature, and answers the edit with 200 all
+// the same. A test that needs a train reads the answer and says what it can
+// assert when the flags did not stick.
+func EnableMergeTrains(e *harness.Env, project Project) bool {
+	e.T.Helper()
+
+	_, _, err := e.Client().GL().Projects.EditProject(project.ID, &gl.EditProjectOptions{
+		MergePipelinesEnabled: new(true),
+		MergeTrainsEnabled:    new(true),
+	}, gl.WithContext(e.Ctx))
+	if err != nil {
+		e.T.Fatalf("enabling merge trains on project %d: %v", project.ID, err)
+	}
+	current, _, err := e.Client().GL().Projects.GetProject(project.ID, nil, gl.WithContext(e.Ctx))
+	if err != nil {
+		e.T.Fatalf("reading project %d after enabling merge trains: %v", project.ID, err)
+	}
+	return current.MergePipelinesEnabled && current.MergeTrainsEnabled
+}
+
 // mergeRequestOf reads what a test needs out of what GitLab returned.
 func mergeRequestOf(mr *gl.MergeRequest) MergeRequest {
 	return MergeRequest{

--- a/test/e2e/internal/fixture/snippet.go
+++ b/test/e2e/internal/fixture/snippet.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+// snippet.go builds a personal snippet, which is the one object a snippet
+// storage move addresses and nothing else in the suite needs.
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Snippet is a personal snippet a builder created.
+type Snippet struct {
+	// ID is what the snippet actions take.
+	ID int64
+	// Title is what it was created as.
+	Title string
+}
+
+// NewSnippet creates a private personal snippet with one file and registers
+// its deletion on the Env.
+func NewSnippet(e *harness.Env) Snippet {
+	e.T.Helper()
+
+	title := e.Name("snippet")
+	snippet, err := retryTransient(e, "create snippet "+title, createRetries, func() (Snippet, error) {
+		created, _, err := e.Client().GL().Snippets.CreateSnippet(&gl.CreateSnippetOptions{
+			Title:       new(title),
+			FileName:    new("e2e.txt"),
+			Description: new("e2e: " + e.T.Name()),
+			Content:     new("e2e snippet fixture\n"),
+			Visibility:  new(gl.PrivateVisibility),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Snippet{}, err
+		}
+		return Snippet{ID: created.ID, Title: created.Title}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating snippet %q: %v", title, err)
+	}
+
+	e.Defer("snippet "+title, func(ctx context.Context) error {
+		ctx, cancel := withCleanupTimeout(ctx)
+		defer cancel()
+		_, deleteErr := e.Client().GL().Snippets.DeleteSnippet(snippet.ID, gl.WithContext(ctx))
+		if deleteErr != nil && !IsStatus(deleteErr, http.StatusNotFound) {
+			return fmt.Errorf("deleting snippet %d: %w", snippet.ID, deleteErr)
+		}
+		return nil
+	})
+	return snippet
+}

--- a/test/e2e/internal/fixture/stub_test.go
+++ b/test/e2e/internal/fixture/stub_test.go
@@ -74,6 +74,11 @@ type stubGitLab struct {
 	runners []*gl.Runner
 	// state is what the World's readers see, keyed by the request path.
 	state map[string]any
+	// graphqlAnswers are answered one per document, the last repeating,
+	// each the raw body of a GraphQL response.
+	graphqlAnswers []string
+	// graphqlDocuments records every document the stub was sent.
+	graphqlDocuments []string
 
 	server *httptest.Server
 }
@@ -104,6 +109,7 @@ func newStubGitLab(t *testing.T) (*stubGitLab, *gitlabclient.Client) {
 	mux.HandleFunc("/api/v4/projects/{id}/issues/{iid}", stub.stateAnswer)
 	mux.HandleFunc("/api/v4/projects/{id}/labels/{label}", stub.stateAnswer)
 	mux.HandleFunc("/api/v4/projects/{id}/milestones/{milestone}", stub.stateAnswer)
+	mux.HandleFunc("/api/graphql", stub.graphql)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("stub GitLab: unexpected %s %s", r.Method, r.URL.Path)
 		http.NotFound(w, r)
@@ -421,6 +427,26 @@ func (s *stubGitLab) stateAnswer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeError(w, http.StatusNotFound, "404 Not Found")
+}
+
+// graphql answers the next scripted body to any document, recording the
+// document it was sent.
+func (s *stubGitLab) graphql(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var document struct {
+		Query string `json:"query"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&document); err != nil {
+		writeError(w, http.StatusBadRequest, "malformed document: "+err.Error())
+		return
+	}
+	s.graphqlDocuments = append(s.graphqlDocuments, document.Query)
+	body := nextStatus(&s.graphqlAnswers)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(body))
 }
 
 // nextStatus pops the next status of a sequence, keeping the last one.

--- a/test/e2e/internal/fixture/user.go
+++ b/test/e2e/internal/fixture/user.go
@@ -176,6 +176,68 @@ func NewToken(e *harness.Env, user User, scopes ...string) Token {
 	return token
 }
 
+// GroupToken is a group access token a builder minted, and the bot user
+// GitLab created to hold it.
+type GroupToken struct {
+	// ID is what the group token actions take.
+	ID int64
+	// Value is the secret itself, shown once at creation.
+	Value string
+	// UserID is the bot user the token belongs to, which is what an approval
+	// rule names to make the bot an approver.
+	UserID int64
+	// GroupID is the group the token was minted in.
+	GroupID int64
+}
+
+// NewGroupToken mints a group access token at accessLevel with the given
+// scopes and registers its revocation on the Env. With no scopes, "api" is
+// assumed.
+//
+// It is the one way to get a bot user out of GitLab without an administrator,
+// and the one credential some endpoints accept: resetting a merge request's
+// approvals is refused to a person and allowed to a project or group bot,
+// so a test of that action runs a session on this token.
+func NewGroupToken(e *harness.Env, group Group, accessLevel gl.AccessLevelValue, scopes ...string) GroupToken {
+	e.T.Helper()
+
+	if len(scopes) == 0 {
+		scopes = []string{"api"}
+	}
+	name := e.Name("grptok")
+	expiry := gl.ISOTime(time.Now().Add(tokenLifetime))
+
+	token, err := retryTransient(e, "create group token "+name, createRetries, func() (GroupToken, error) {
+		created, _, err := e.Client().GL().GroupAccessTokens.CreateGroupAccessToken(group.ID, &gl.CreateGroupAccessTokenOptions{
+			Name:        new(name),
+			Scopes:      &scopes,
+			AccessLevel: new(accessLevel),
+			ExpiresAt:   &expiry,
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return GroupToken{}, err
+		}
+		if created.Token == "" {
+			return GroupToken{}, fmt.Errorf("group token %q was created without a value", name)
+		}
+		return GroupToken{ID: created.ID, Value: created.Token, UserID: created.UserID, GroupID: group.ID}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("minting a group token in group %d: %v", group.ID, err)
+	}
+
+	e.Defer("group token "+name, func(ctx context.Context) error {
+		ctx, cancel := withCleanupTimeout(ctx)
+		defer cancel()
+		_, revokeErr := e.Client().GL().GroupAccessTokens.RevokeGroupAccessToken(group.ID, token.ID, gl.WithContext(ctx))
+		if revokeErr != nil && !IsStatus(revokeErr, http.StatusNotFound) {
+			return fmt.Errorf("revoking group token %d of group %d: %w", token.ID, group.ID, revokeErr)
+		}
+		return nil
+	})
+	return token
+}
+
 // SSHPublicKey generates a fresh ED25519 key pair and returns the public half
 // in authorized_keys form, for a deploy key or a user key. The private half
 // is discarded: nothing in a test ever connects with it.

--- a/test/e2e/internal/harness/access.go
+++ b/test/e2e/internal/harness/access.go
@@ -16,6 +16,7 @@
 package harness
 
 import (
+	"context"
 	"errors"
 	"log"
 	"slices"
@@ -90,6 +91,35 @@ func (e *Env) Package() string { return e.inst.pkg }
 // per process. It is the same answer NeedRunner gives, offered to a fixture
 // that would otherwise wait a whole budget for a pipeline nothing will run.
 func (e *Env) HasRunner() bool { return e.inst.hasRunner() }
+
+// RepoRoot returns the repository root every path the harness resolves
+// starts from, for a fixture that reads a file the provisioning scripts left
+// there. A path relative to the working directory would name a different
+// file for each of the three packages, which is why the root is the one
+// place to resolve from.
+func (e *Env) RepoRoot() string {
+	e.T.Helper()
+	root, err := repoRoot()
+	if err != nil {
+		e.T.Fatalf("resolving the repository root: %v", err)
+	}
+	return root
+}
+
+// ReprobeTier asks the instance what tier it is now, the way the bootstrap
+// asked, and returns the answer beside what the bootstrap found.
+//
+// It exists for the one test that changes the license: adding and removing
+// one changes what every later session is served, so that test says
+// afterwards that the instance is where it was found. Nothing here updates
+// the harness's own record, on purpose: a tier that changed is a failure of
+// the test that changed it, not a new fact for the next test to be built on.
+func (e *Env) ReprobeTier() (now, before edition.Tier) {
+	e.T.Helper()
+	ctx, cancel := context.WithTimeout(e.Ctx, probeTimeout)
+	defer cancel()
+	return e.inst.client.DetectTier(ctx), e.inst.facts.Tier
+}
 
 // exitHooks is what runs after the last test of the package and before Main
 // returns.

--- a/test/e2e/internal/harness/access_test.go
+++ b/test/e2e/internal/harness/access_test.go
@@ -7,7 +7,12 @@ package harness
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
@@ -69,6 +74,67 @@ func TestEnvRuntime_Scopes_AreACopy(t *testing.T) {
 
 	if got := inst.facts.Scopes[0]; got != "api" {
 		t.Errorf("the harness's scopes were changed through the copy: %q", got)
+	}
+}
+
+// TestEnvRepoRoot_FromAPackageDirectory_IsTheModuleRoot checks that the root
+// a fixture resolves a file from is the directory holding go.mod, whatever
+// package directory the test binary runs in.
+func TestEnvRepoRoot_FromAPackageDirectory_IsTheModuleRoot(t *testing.T) {
+	env := newEnv(t, stubInstance(t))
+
+	root := env.RepoRoot()
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Errorf("RepoRoot() = %q, which holds no go.mod: %v", root, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "test", "e2e", "internal", "harness")); err != nil {
+		t.Errorf("RepoRoot() = %q, under which this package is not found: %v", root, err)
+	}
+}
+
+// TestEnvReprobeTier_AnswersFromTheInstance_NotFromTheRecord checks that a
+// re-probe asks the instance again and leaves the harness's own record as it
+// was: a license test that changed the tier must be told so by the answer,
+// and must not be able to make the change the new baseline by asking.
+func TestEnvReprobeTier_AnswersFromTheInstance_NotFromTheRecord(t *testing.T) {
+	licensed := atomic.Bool{}
+	licensed.Store(true)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		writeStubJSON(w, map[string]any{"version": "18.0.0", "revision": "abcdef", "enterprise": true})
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		writeStubJSON(w, map[string]any{"id": 7, "username": "harness", "name": "Harness", "is_admin": true})
+	})
+	mux.HandleFunc("/api/v4/license", func(w http.ResponseWriter, _ *http.Request) {
+		if !licensed.Load() {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		writeStubJSON(w, map[string]any{"id": 1, "plan": "premium"})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	stub := httptest.NewServer(mux)
+	t.Cleanup(stub.Close)
+
+	env := newEnv(t, instanceForStub(t, stub))
+
+	now, before := env.ReprobeTier()
+	if now != edition.Premium || before != edition.Premium {
+		t.Fatalf("ReprobeTier() = (%s, %s) on a Premium stub, want (premium, premium)", now, before)
+	}
+
+	// The license goes away underneath the run: the re-probe reports it, and
+	// the record the next test reads still says Premium.
+	licensed.Store(false)
+	now, before = env.ReprobeTier()
+	if now != edition.Free {
+		t.Errorf("ReprobeTier() now = %s after the license was removed, want free", now)
+	}
+	if before != edition.Premium || env.Runtime().Tier != edition.Premium {
+		t.Errorf("ReprobeTier() before = %s and Runtime().Tier = %s, want the bootstrap's premium in both: a re-probe must not rewrite the record", before, env.Runtime().Tier)
 	}
 }
 


### PR DESCRIPTION
Step S14 of the e2e rebuild (issue 704), first half: the project, merge request, security, admin, runner and user families of the old EE suite, rewritten against the harness.

The scenarios of 21 old `_ee_test.go` files (49 Test functions) and the Premium code that sat behind enterprise guards in the CE files of those families (issues, merge requests, projects, approvals, users, where it never ran on either Docker runtime) are rewritten as `Test<Family>_<Scenario>` tests driving the real binary on the three surfaces, each carrying a `// Replaces:` line; `-port-map` resolves all 52 old Test functions of these files. Premium and Ultimate actions live in `test/e2e/gitlab/ee` (25 new files, the Ultimate ones declaring `harness.Needs(harness.Tier(edition.Ultimate))`); the Free actions the old EE half held (project and instance service accounts, project and snippet storage moves, the archived flag of a group label, the runner reads) live in `common` and run on both runtimes; the Free actions only a licensed instance answers (license lifecycle, approval reset, group Datadog) stay in `ee`. The license lifecycle is ported with `Locks(LockInstanceLicense)`, `Serial()` and a tier re-probe afterwards. After the licensed run the audit shows 155 actions asserted on `ee`, all 19 previously stranded actions among them (the project and group iteration lists and events, the whole approval family, the user service accounts), and the actions whose only correct answer on a Docker instance is a refusal are asserted as such.

Two defects found and fixed here. `mrapprovals.CreateRuleInput` and `UpdateRuleInput` lacked `omitempty` on their optional fields, so the individual surface, which validates the raw arguments against the reflected schema, refused every rule create and update that named no source rule or approvers; the live API record confirms the create requires `name` and `approvals_required` and the update only the rule id, and a test pins the schemas through the individual projection. And `cmd/audit_e2e_coverage`'s `-baseline` comparison was vacuous: the S09 shards carry no test verdicts, so the baseline classified every call as failed and reached zero keys; it now joins a verdict-less baseline with the gotestsum stream beside it, refuses one with no stream, and treats a cleanup or sweep credit of the old suite as met by the same cell asserted.

Harness additions: `Env.RepoRoot` and `Env.ReprobeTier`. Fixture additions: `NewIteration` and `AssignIssueIteration` over GraphQL, `NewGroupToken`, `NewSnippet`, `CachedEnterpriseLicense`, `EnableMergeTrains`, `Group.IDParam`. Verified on truenas: `make test-e2e-ee` 223 tests and no failure, twice on the committed tree; `make test-e2e-ce` 67 tests and no failure; `-static` and `-port-map` clean.
