### PR TITLE
test(e2e): port the second half of the old EE suite, the group and epic families

### DIFF
--- a/cmd/audit_e2e_coverage/portmap.go
+++ b/cmd/audit_e2e_coverage/portmap.go
@@ -43,11 +43,41 @@ const (
 // declaredDrops holds every old Test function that no new test replaces,
 // each with a category and a reason.
 //
-// It ships empty and fills as the port proceeds. A drop naming a test the
-// old suite does not have is a finding, and so is one naming a test that a
-// Replaces line also claims: the two are different answers to where a
-// scenario went, and both cannot be true.
-var declaredDrops = map[string]dropDeclaration{}
+// It fills as the port proceeds. A drop naming a test the old suite does
+// not have is a finding, and so is one naming a test that a Replaces line
+// also claims: the two are different answers to where a scenario went, and
+// both cannot be true.
+var declaredDrops = map[string]dropDeclaration{
+	// The old suite's own baseline recorder, instrumented in S09 to record
+	// the baseline the port is compared with. Its stack-walking attribution,
+	// its source index of subtest literals, its outcome classifier and its
+	// argument reader exist only because that suite drove an in-process
+	// transport where no test frame was on the handler's stack; the harness
+	// attributes every call on the caller's goroutine and asserts the
+	// dispatched route on every call at flush, and its recorder is tested in
+	// test/e2e/internal/harness against the real binary. The one test of
+	// the ten that reached GitLab, the join of user.current, is replaced
+	// rather than dropped.
+	"TestBaseline_Attribution_NamesTheRunningSubtest":                  baselineRecorderDrop,
+	"TestBaseline_Attribution_ReadsTheContextFirst":                    baselineRecorderDrop,
+	"TestBaseline_SubtestIndex_ParsesThisFile":                         baselineRecorderDrop,
+	"TestBaseline_DeclaredFunctionName_StripsWhatTheRuntimeAppends":    baselineRecorderDrop,
+	"TestBaseline_ParseGoroutineDump_ReadsFramesAndCreators":           baselineRecorderDrop,
+	"TestBaseline_MergeNameParts_DropsTheSharedLiteral":                baselineRecorderDrop,
+	"TestBaseline_RewriteSubtestName_SpellsNamesLikeTheTestingPackage": baselineRecorderDrop,
+	"TestBaseline_Outcome_ClassifiesLikeTheHarness":                    baselineRecorderDrop,
+	"TestBaseline_Arguments_NamesTypedAndUntypedInputs":                baselineRecorderDrop,
+}
+
+// baselineRecorderDrop is the one reason the old suite's recorder tests
+// share: they test the instrument that produced the baseline, which goes
+// with the suite it instrumented.
+var baselineRecorderDrop = dropDeclaration{
+	Category: dropSuperseded,
+	Reason: "a unit test of the old suite's baseline recorder, whose stack-walking attribution and " +
+		"in-process dispatch join the harness's own recorder replaces (test/e2e/internal/harness/record.go " +
+		"and otlp.go, tested there against the real binary); the recorder is deleted with the suite it instrumented",
+}
 
 // declaredDropCategories is the set a category must belong to.
 var declaredDropCategories = map[string]bool{

--- a/cmd/audit_edition_tier/tier_exceptions.go
+++ b/cmd/audit_edition_tier/tier_exceptions.go
@@ -99,8 +99,11 @@ var acceptedTierExceptions = map[string]tierException{
 	"group.list_provisioned_users":                 {tierPremium, "provisioned users = Premium"},
 
 	// Group issue board create/delete — group_boards.md page is Free but the
-	// create/delete sections are Premium-overridden.
+	// create/delete sections are Premium-overridden. The delete was missing
+	// here while its action was tagged Free, so the auditor and the catalog
+	// agreed with each other and not with the page.
 	"group.group_board_create": {tierPremium, "group_boards.md 'Create' section = Premium override"},
+	"group.group_board_delete": {tierPremium, "group_boards.md 'Delete' section = Premium override"},
 
 	// Group milestone burndown events — group_milestones.md page is Free but the
 	// burndown-chart-events section carries a Premium override badge.

--- a/docs/development/upstream-bugs.md
+++ b/docs/development/upstream-bugs.md
@@ -110,10 +110,12 @@ readable without opening the tracker:
 | 42 | client-go | [MemberRole models twenty of the forty-five permissions GitLab sends](#memberrole-models-twenty-of-the-forty-five-permissions-gitlab-sends) | No | No | No | No | Yes |
 | 43 | client-go | [PipelineInfo decodes two entities and models only the smaller one](#pipelineinfo-decodes-two-entities-and-models-only-the-smaller-one) | No | No | No | No | Yes |
 | 44 | client-go | [Group, Project and Issue each model one entity where GitLab renders two](#group-project-and-issue-each-model-one-entity-where-gitlab-renders-two) | No | No | No | No | Yes |
+| 45 | client-go | [The work item get, create and update documents select licensed fields](#the-work-item-get-create-and-update-documents-select-licensed-fields) | No | No | No | Yes, on Community Edition | None possible |
 
 States verified against the upstream trackers on 2026-09-12. Rows 39 to 44
 were added that day: each entry existed with its five fields and the table had
-never listed it, which is the drift this table exists to prevent.
+never listed it, which is the drift this table exists to prevent. Row 45 is the
+entry the e2e rebuild's EE port found the same day.
 
 ## GitLab (`gitlab-org/gitlab`)
 
@@ -1689,6 +1691,48 @@ resolves both to Ultimate from the next expose's `external_status_checks` and
 struct that keeps serving both entities cannot answer the pointer question,
 which is why this server split each of the three into one output type per
 entity before surfacing anything.
+
+### The work item get, create and update documents select licensed fields
+
+- **Reported**: no.
+- **In review**: no.
+- **Merged**: no.
+- **Blocking**: yes, on Community Edition. `issue.work_item_get`,
+  `issue.work_item_create` and `issue.work_item_update` cannot answer there:
+  GitLab refuses the whole document, so the three actions fail on every call
+  a Free instance is given, while the listing and the type listing work.
+- **Workaround**: none possible without replacing the SDK's documents. The
+  selection set is built inside `GetWorkItem`, `CreateWorkItem` and
+  `UpdateWorkItem` from one template, and nothing a caller passes changes it.
+  The e2e suite records the state instead: `test/e2e/gitlab/common`'s work
+  item lifecycle skips on a Free runtime naming this entry, and its type
+  listing runs on both.
+
+**Where**: `workitems.go`, `workItemTemplate`, which `getWorkItemTemplate`,
+`createWorkItemTemplate` and `updateWorkItemTemplate` clone.
+
+**What**: the shared template selects five widgets that exist only in the
+Enterprise schema: `color`, `healthStatus`, `iteration`, `status` and
+`weight`. A Community Edition instance answers the whole document with
+`Field 'color' doesn't exist on type 'WorkItemFeatures'` and the four
+siblings, and the SDK surfaces that as `Mutation.workItemCreate failed`, so a
+caller on Free cannot read, create or update a work item at all. The SDK
+knows the problem: `ListWorkItemsOptions.ReturnedFields` exists precisely so
+the listing can leave those five out, its comment says the five "error
+against Community Edition instances", and `WorkItemDefaultListFields` is
+documented as CE-safe. The other three operations were given no such
+selector and select everything.
+
+**How we found it**: the rebuilt e2e suite drove the work item lifecycle on
+the Community runtime for the first time (the old suite kept it in its
+Enterprise half), and `work_item_create` failed on all three surfaces with
+the five field errors above; verified against v3.0.0 and against `main` on
+2026-09-12, where the three functions still execute the full template.
+
+**Effort**: small. Either the three operations take the same `ReturnedFields`
+the listing takes, with the same CE-safe default, or the template drops the
+five widgets into fragments the caller opts into. The decoder already
+tolerates their absence, since the listing runs without them today.
 
 ## MCP Go SDK (`github.com/modelcontextprotocol/go-sdk`)
 

--- a/internal/tools/action_catalog_test.go
+++ b/internal/tools/action_catalog_test.go
@@ -785,11 +785,14 @@ func assertCatalogMissingAction(t *testing.T, catalog *actioncatalog.Catalog, ac
 
 const (
 	// expectedBaseDynamicCatalogActions identifies the expected base (Free tier)
-	// dynamic catalog actions. 870 = 858 + 12 achievement actions (Free,
-	// client-go v2.64.0). The 858 was 872 −11 group webhooks −3 MR dependencies
+	// dynamic catalog actions. 869 = 870 −1 group board delete gated to
+	// Premium (group_boards.md states the tier on the delete as on the
+	// create, and GitLab refuses both on a group that may not hold several
+	// boards). The 870 was 858 + 12 achievement actions (Free, client-go
+	// v2.64.0), and the 858 was 872 −11 group webhooks −3 MR dependencies
 	// gated to Premium (group_webhooks.md and merge request dependencies are
 	// Premium/Ultimate). See cmd/audit_edition_tier.
-	expectedBaseDynamicCatalogActions = 870
+	expectedBaseDynamicCatalogActions = 869
 	// expectedEnterpriseDynamicCatalogActions identifies the expected enterprise dynamic catalog actions constant used by this package.
 	// 1089 = 1077 + 12 achievement actions (Free, client-go v2.64.0). The 1077
 	// was 1069 + 7 work item saved view actions (get/list/create/update/

--- a/internal/tools/groupboards/action_specs.go
+++ b/internal/tools/groupboards/action_specs.go
@@ -26,10 +26,10 @@ func ActionSpecs(client *gitlabclient.Client) []toolutil.ActionSpec {
 			"Update a group issue board's name and scope (assignee, milestone, labels, weight). Returns: the updated board with its group, milestone, labels, and lists. See also: gitlab_group_board_get, gitlab_group_board_list.",
 			"Rename a group issue board or retune its assignee, milestone, label, and weight scope.",
 			[]string{"update a group issue board", "rename a group board", "change a group board scope"}),
-		groupBoardDeleteSpec("group_board_delete", toolutil.DestructiveAction(client, deleteGroupBoardOutput), "gitlab_group_board_delete",
-			"Delete a group issue board permanently. Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.",
+		groupBoardPremiumSpec(groupBoardDeleteSpec("group_board_delete", toolutil.DestructiveAction(client, deleteGroupBoardOutput), "gitlab_group_board_delete",
+			"Delete a group issue board permanently (Premium/Ultimate). Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.",
 			"Permanently remove an issue board from a group when the team no longer needs it.",
-			[]string{"delete a group issue board", "remove a board from a group", "drop a group kanban board"}),
+			[]string{"delete a group issue board", "remove a board from a group", "drop a group kanban board"})),
 		groupBoardReadSpec("group_board_list_lists", toolutil.RouteAction(client, ListGroupBoardLists), "gitlab_group_board_list_lists",
 			"List the lists (columns) of a group issue board with pagination. Returns: each list with its assignee, label, iteration, and milestone scope plus pagination metadata. See also: gitlab_group_board_list_get, gitlab_group_board_list_create, gitlab_group_board_get.",
 			"Enumerate the columns of a group issue board to see how its workflow stages are arranged.",
@@ -68,8 +68,12 @@ func deleteGroupBoardListOutput(ctx context.Context, client *gitlabclient.Client
 }
 
 // groupBoardPremiumSpec marks a group board action as Premium/Ultimate so the
-// individual catalog hides it from CE clients. Creating additional group issue
-// boards (beyond the single CE board) is a GitLab Premium feature.
+// individual catalog hides it from CE clients. Creating and deleting group
+// issue boards through the API are GitLab Premium features: group_boards.md
+// states the tier on both, and lib/api/boards_responses.rb guards create_board
+// and delete_board alike with a forbidden! unless the group may hold several
+// boards, which a Free group may not. The delete was tagged Free until the
+// e2e port drove it on a Free catalog.
 func groupBoardPremiumSpec(spec toolutil.ActionSpec) toolutil.ActionSpec {
 	spec.Edition = "premium"
 	return spec

--- a/internal/tools/groupboards/action_specs_test.go
+++ b/internal/tools/groupboards/action_specs_test.go
@@ -199,6 +199,28 @@ func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
 	}
 }
 
+// TestActionSpecs_Editions_BoardCreateAndDeleteArePremium pins the tier of
+// every group board action: the board create and delete are Premium, since
+// GitLab's API refuses both on a group that may not hold several boards and
+// group_boards.md states the tier on both, and everything else is Free. The
+// delete was tagged Free until the e2e port drove it on a Free catalog.
+func TestActionSpecs_Editions_BoardCreateAndDeleteArePremium(t *testing.T) {
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
+	premium := map[string]bool{"group_board_create": true, "group_board_delete": true}
+
+	for _, spec := range ActionSpecs(client) {
+		t.Run(spec.Name, func(t *testing.T) {
+			want := ""
+			if premium[spec.Name] {
+				want = "premium"
+			}
+			if spec.Edition != want {
+				t.Errorf("%s has Edition %q, want %q", spec.Name, spec.Edition, want)
+			}
+		})
+	}
+}
+
 func groupBoardSpecsByTool(t *testing.T, specs []toolutil.ActionSpec) map[string]toolutil.ActionSpec {
 	t.Helper()
 	byTool := make(map[string]toolutil.ActionSpec, len(specs))

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -345,12 +345,14 @@ func TestRegisterAll_ToolCount(t *testing.T) {
 			t.Fatalf(fmtListToolsErr, err)
 		}
 		t.Logf("CE tool count: %d", len(result.Tools))
-		// 866 = 854 + 12 achievement actions (Free, client-go v2.64.0). The 854
-		// was 868 −11 group webhooks −3 MR dependencies gated to Premium
+		// 865 = 866 −1 group board delete gated to Premium (group_boards.md
+		// states the tier on the delete as on the create). The 866 was 854 +
+		// 12 achievement actions (Free, client-go v2.64.0), and the 854 was
+		// 868 −11 group webhooks −3 MR dependencies gated to Premium
 		// (group_webhooks.md and merge request dependencies are
 		// Premium/Ultimate). See cmd/audit_edition_tier. The base moved from
 		// 861 with the 7 work item saved view actions, which are Free.
-		const expectedTools = 866
+		const expectedTools = 865
 		if len(result.Tools) != expectedTools {
 			t.Errorf("tool count = %d, want %d", len(result.Tools), expectedTools)
 			for _, tool := range result.Tools {

--- a/test/e2e/gitlab/common/actions_test.go
+++ b/test/e2e/gitlab/common/actions_test.go
@@ -80,6 +80,73 @@ const (
 	actionGroupLabelDelete harness.ActionID = "group.group_label_delete"
 )
 
+// The group's own lifecycle and one membership write, which the old suite
+// drove only to build the state its Enterprise scenarios stood on.
+const (
+	actionGroupCreate    harness.ActionID = "group.create"
+	actionGroupGet       harness.ActionID = "group.get"
+	actionGroupUpdate    harness.ActionID = "group.update"
+	actionGroupDelete    harness.ActionID = "group.delete"
+	actionGroupMemberAdd harness.ActionID = "group.group_member_add"
+)
+
+// A project's own lifecycle, and the objects the old suite created in one
+// through the server before every Enterprise scenario: a branch, a commit,
+// a merge request, an environment, an issue and its update, a pipeline.
+const (
+	actionProjectCreate          harness.ActionID = "project.create"
+	actionProjectUpdate          harness.ActionID = "project.update"
+	actionBranchCreate           harness.ActionID = "branch.create"
+	actionRepositoryCommitCreate harness.ActionID = "repository.commit_create"
+	actionMergeRequestCreate     harness.ActionID = "merge_request.create"
+	actionEnvironmentCreate      harness.ActionID = "environment.create"
+	actionIssueUpdate            harness.ActionID = "issue.update"
+	actionPipelineCreate         harness.ActionID = "pipeline.create"
+)
+
+// A snippet's create and delete, and the read that proves the delete.
+const (
+	actionSnippetCreate harness.ActionID = "snippet.create"
+	actionSnippetGet    harness.ActionID = "snippet.get"
+	actionSnippetDelete harness.ActionID = "snippet.delete"
+)
+
+// The Free half of the group board family: the reads and the rename of a
+// board the fixture library built, and the label columns of one. The
+// create and the delete are Premium and live in the ee package.
+const (
+	actionGroupBoardList       harness.ActionID = "group.group_board_list"
+	actionGroupBoardGet        harness.ActionID = "group.group_board_get"
+	actionGroupBoardUpdate     harness.ActionID = "group.group_board_update"
+	actionGroupBoardListLists  harness.ActionID = "group.group_board_list_lists"
+	actionGroupBoardCreateList harness.ActionID = "group.group_board_create_list"
+	actionGroupBoardGetList    harness.ActionID = "group.group_board_get_list"
+	actionGroupBoardUpdateList harness.ActionID = "group.group_board_update_list"
+	actionGroupBoardDeleteList harness.ActionID = "group.group_board_delete_list"
+)
+
+// A group's service accounts and their tokens, Free like the project's.
+const (
+	actionGroupServiceAccountList      harness.ActionID = "group.service_account_list"
+	actionGroupServiceAccountCreate    harness.ActionID = "group.service_account_create"
+	actionGroupServiceAccountUpdate    harness.ActionID = "group.service_account_update"
+	actionGroupServiceAccountDelete    harness.ActionID = "group.service_account_delete"
+	actionGroupServiceAccountPATCreate harness.ActionID = "group.service_account_pat_create"
+	actionGroupServiceAccountPATList   harness.ActionID = "group.service_account_pat_list"
+	actionGroupServiceAccountPATRotate harness.ActionID = "group.service_account_pat_rotate"
+	actionGroupServiceAccountPATRevoke harness.ActionID = "group.service_account_pat_revoke"
+)
+
+// Work items, the Free half of the issue tool's GraphQL surface.
+const (
+	actionWorkItemTypeList harness.ActionID = "issue.work_item_type_list"
+	actionWorkItemCreate   harness.ActionID = "issue.work_item_create"
+	actionWorkItemList     harness.ActionID = "issue.work_item_list"
+	actionWorkItemGet      harness.ActionID = "issue.work_item_get"
+	actionWorkItemUpdate   harness.ActionID = "issue.work_item_update"
+	actionWorkItemDelete   harness.ActionID = "issue.work_item_delete"
+)
+
 // The runner reads and the two project-scoped writes an instance runner
 // refuses.
 const (

--- a/test/e2e/gitlab/common/environments_test.go
+++ b/test/e2e/gitlab/common/environments_test.go
@@ -1,0 +1,38 @@
+//go:build e2e
+
+// environments_test.go covers the creation of an environment through the
+// server, which the old suite made only to build the environment its
+// deployment approval scenario stood on.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/environments"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestEnvironment_Create_AnswersTheEnvironment creates an environment on
+// every surface in a shared project and reads its name and slug off the
+// answer.
+//
+// Replaces: TestMeta_DeploymentApproveOrReject
+func TestEnvironment_Create_AnswersTheEnvironment(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("envcreate"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		name := e.Name("env")
+
+		created := harness.Do[environments.Output](s, actionEnvironmentCreate, map[string]any{
+			"project_id": project.IDParam(), "name": name, "description": "created by the e2e suite",
+		})
+		if created.ID == 0 || created.Name != name || created.Slug == "" {
+			e.T.Errorf("environment create answered %+v, want the environment %q with an ID and a slug", created, name)
+		}
+	})
+}

--- a/test/e2e/gitlab/common/groupboards_test.go
+++ b/test/e2e/gitlab/common/groupboards_test.go
@@ -1,0 +1,138 @@
+//go:build e2e
+
+// groupboards_test.go covers the Free half of the group board family: the
+// reads and the rename of a board, and the label columns on one. The board
+// itself comes from the fixture library, which makes it the way the boards
+// page does, since every group may have one board on every edition and
+// only a second one is Premium; the Premium create and delete live in the
+// ee package.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupboards"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// firstPosition is where the reorder puts the second column: the front.
+const firstPosition = int64(0)
+
+// groupBoardIDs lists the ids of a board listing.
+func groupBoardIDs(boards []groupboards.GroupBoardOutput) []int64 {
+	ids := make([]int64, 0, len(boards))
+	for _, board := range boards {
+		ids = append(ids, board.ID)
+	}
+	return ids
+}
+
+// boardListIDs lists the ids of a column listing.
+func boardListIDs(lists []groupboards.BoardListOutput) []int64 {
+	ids := make([]int64, 0, len(lists))
+	for _, list := range lists {
+		ids = append(ids, list.ID)
+	}
+	return ids
+}
+
+// boardFixture is a group with the one board the fixture library made in
+// it and two labels for its columns.
+type boardFixture struct {
+	group  fixture.Group
+	board  fixture.GroupBoard
+	first  fixture.GroupLabel
+	second fixture.GroupLabel
+}
+
+// buildBoardFixture creates the group, the board and the labels.
+func buildBoardFixture(e *harness.Env) boardFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("board"))
+	return boardFixture{
+		group:  group,
+		board:  fixture.NewGroupBoard(e, group, "board"),
+		first:  fixture.NewGroupLabel(e, group, "first"),
+		second: fixture.NewGroupLabel(e, group, "second"),
+	}
+}
+
+// TestGroupBoards_FixtureBoard_ListGetAndRename lists the boards of a
+// group holding one, reads it back and renames it, on every surface
+// against a board of the surface's own.
+//
+// Replaces: TestEE_MetaGroupEnterpriseOperations
+func TestGroupBoards_FixtureBoard_ListGetAndRename(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("boardread"))
+		board := fixture.NewGroupBoard(e, group, "board")
+		params := map[string]any{"group_id": group.IDParam()}
+		byID := withParams(params, map[string]any{"board_id": board.ID})
+
+		listed := harness.Do[groupboards.ListGroupBoardsOutput](s, actionGroupBoardList, params)
+		if ids := groupBoardIDs(listed.Boards); len(ids) != 1 || ids[0] != board.ID {
+			e.T.Errorf("the group lists the boards %v, want exactly the fixture's %d", ids, board.ID)
+		}
+		got := harness.Do[groupboards.GroupBoardOutput](s, actionGroupBoardGet, byID)
+		if got.ID != board.ID || got.Name != board.Name {
+			e.T.Errorf("group_board_get answered board %d %q, want %d %q", got.ID, got.Name, board.ID, board.Name)
+		}
+
+		renamed := harness.Do[groupboards.GroupBoardOutput](s, actionGroupBoardUpdate, withParams(byID, map[string]any{"name": "Renamed " + board.Name}))
+		if renamed.ID != board.ID || renamed.Name != "Renamed "+board.Name {
+			e.T.Errorf("group_board_update answered board %d %q, want %d renamed", renamed.ID, renamed.Name, board.ID)
+		}
+	})
+}
+
+// TestGroupBoardLists_LabelColumns_CreateGetReorderDelete adds two label
+// columns to the fixture board per surface, reads the first back, moves
+// the second to the front, deletes the first and checks the column listing
+// lets it go.
+//
+// Replaces: TestMeta_GroupBoardListColumns
+func TestGroupBoardLists_LabelColumns_CreateGetReorderDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		f := buildBoardFixture(e)
+		board := map[string]any{"group_id": f.group.IDParam(), "board_id": f.board.ID}
+
+		first := harness.Do[groupboards.BoardListOutput](s, actionGroupBoardCreateList, withParams(board, map[string]any{"label_id": f.first.ID}))
+		if first.ID == 0 {
+			e.T.Fatalf("group_board_create_list answered %+v, want a column with an ID", first)
+		}
+		// A second column is what makes the reorder mean something: GitLab
+		// refuses to move a board's only column, having nothing to move it
+		// against.
+		second := harness.Do[groupboards.BoardListOutput](s, actionGroupBoardCreateList, withParams(board, map[string]any{"label_id": f.second.ID}))
+		if second.ID == 0 {
+			e.T.Fatalf("group_board_create_list answered %+v for the second column, want one with an ID", second)
+		}
+
+		got := harness.Do[groupboards.BoardListOutput](s, actionGroupBoardGetList, withParams(board, map[string]any{"list_id": first.ID}))
+		if got.ID != first.ID {
+			e.T.Errorf("group_board_get_list answered column %d, want %d", got.ID, first.ID)
+		}
+		columns := harness.Do[groupboards.ListBoardListsOutput](s, actionGroupBoardListLists, board)
+		if ids := boardListIDs(columns.Lists); !containsID(ids, first.ID) || !containsID(ids, second.ID) {
+			e.T.Errorf("the board lists the columns %v, want the two just created, %d and %d", ids, first.ID, second.ID)
+		}
+
+		moved := harness.Do[groupboards.BoardListOutput](s, actionGroupBoardUpdateList, withParams(board, map[string]any{"list_id": second.ID, "position": firstPosition}))
+		if moved.ID != second.ID || moved.Position != firstPosition {
+			e.T.Errorf("group_board_update_list answered column %d at %d, want %d at the front", moved.ID, moved.Position, second.ID)
+		}
+
+		harness.DoVoid(s, actionGroupBoardDeleteList, withParams(board, map[string]any{"list_id": first.ID}))
+		after := harness.Do[groupboards.ListBoardListsOutput](s, actionGroupBoardListLists, board)
+		if containsID(boardListIDs(after.Lists), first.ID) {
+			e.T.Errorf("the board still lists column %d after its delete", first.ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/common/groups_test.go
+++ b/test/e2e/gitlab/common/groups_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+// groups_test.go covers a group's own lifecycle through the server, and the
+// one membership write the old suite drove: create a group, read it, rename
+// it, delete it and check the read is then refused; and add a user to one
+// as a Developer. The old suite made these calls before nearly every
+// Enterprise scenario, to build the group that scenario stood on, and never
+// as a scenario of their own.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupmembers"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groups"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestGroup_Lifecycle_CreateGetUpdateDelete creates a private group on
+// every surface, reads it back, renames it, deletes it and checks the read
+// is then refused. The fixture library's deletion is registered behind the
+// server's, for a delete that only marked the group.
+//
+// Replaces: TestEE_MetaGroupEnterpriseOperations, TestMeta_Epics, TestIndividual_GroupCreateUltimateFields
+func TestGroup_Lifecycle_CreateGetUpdateDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		name := e.Name("grp")
+
+		created := harness.Do[groups.DetailOutput](s, actionGroupCreate, map[string]any{"name": name, "path": name, "visibility": "private"})
+		if created.ID == 0 || created.Path != name || created.Visibility != "private" {
+			e.T.Fatalf("group create answered %+v, want a private group at %q with an ID", created, name)
+		}
+		e.Defer("group "+created.FullPath, func(ctx context.Context) error {
+			return fixture.DeleteGroup(ctx, e.Client(), created.ID, created.FullPath)
+		})
+		group := fixture.Group{ID: created.ID, Path: created.FullPath, Name: created.Name}
+		params := map[string]any{"group_id": group.IDParam()}
+
+		got := harness.Do[groups.DetailOutput](s, actionGroupGet, params)
+		if got.ID != created.ID || got.FullPath != created.FullPath {
+			e.T.Errorf("group get answered %d at %q, want %d at %q", got.ID, got.FullPath, created.ID, created.FullPath)
+		}
+
+		updated := harness.Do[groups.DetailOutput](s, actionGroupUpdate, withParams(params, map[string]any{"name": "Renamed " + name, "description": "renamed by the e2e suite"}))
+		if updated.ID != created.ID || updated.Name != "Renamed "+name || updated.Description != "renamed by the e2e suite" {
+			e.T.Errorf("group update answered %+v, want group %d renamed with the new description", updated, created.ID)
+		}
+
+		harness.DoVoid(s, actionGroupDelete, params)
+		// A delete on an instance with delayed deletion marks the group and
+		// renames its path, so the read by id is what tells the two apart:
+		// gone, or marked and still readable under the new path.
+		if remaining, err := harness.Try[groups.DetailOutput](s, actionGroupGet, params); err == nil {
+			if remaining.MarkedForDeletion == "" {
+				e.T.Errorf("the group still reads as %+v after its delete, and is not marked for deletion", remaining)
+			}
+			e.T.Logf("the delete marked the group for deletion on %s", remaining.MarkedForDeletion)
+		}
+	})
+}
+
+// TestGroupMembers_AddDeveloper_AnswersTheMembership adds a disposable user
+// to a fresh group on every surface as a Developer and reads the access
+// level off the answer.
+//
+// Replaces: TestMeta_GroupBillableMembers
+func TestGroupMembers_AddDeveloper_AnswersTheMembership(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("members"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		user := fixture.NewUser(e, "member")
+
+		added := harness.Do[groupmembers.Output](s, actionGroupMemberAdd, map[string]any{
+			"group_id": group.IDParam(), "user_id": user.ID, "access_level": int64(gl.DeveloperPermissions),
+		})
+		if added.ID != user.ID || added.AccessLevel != int(gl.DeveloperPermissions) {
+			e.T.Errorf("group_member_add answered user %d at level %d, want %d as a Developer", added.ID, added.AccessLevel, user.ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/common/groupserviceaccounts_test.go
+++ b/test/e2e/gitlab/common/groupserviceaccounts_test.go
@@ -1,0 +1,101 @@
+//go:build e2e
+
+// groupserviceaccounts_test.go covers a group's service accounts and their
+// tokens: a fresh group has none, one is created, renamed and listed, a
+// token is minted for it, listed, rotated and revoked, and the account is
+// deleted. The actions are Free in the catalog and the endpoints answer on
+// every edition, so the scenario runs on both runtimes; the old suite kept
+// all but the rotation in its Enterprise half.
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupserviceaccounts"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// activeTokenIDs lists the ids of the tokens of a listing that are still
+// usable, which is what a revocation takes away.
+func activeTokenIDs(tokens []groupserviceaccounts.PATOutput) []int64 {
+	ids := make([]int64, 0, len(tokens))
+	for _, token := range tokens {
+		if token.Active && !token.Revoked {
+			ids = append(ids, token.ID)
+		}
+	}
+	return ids
+}
+
+// TestGroupServiceAccounts_Lifecycle_AccountAndToken walks one service
+// account per surface, in a group of the surface's own so the empty listing
+// before is exact, through its whole life and its token's.
+//
+// Replaces: TestMeta_GroupServiceAccounts
+func TestGroupServiceAccounts_Lifecycle_AccountAndToken(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("grpsa"))
+		params := map[string]any{"group_id": group.IDParam()}
+
+		empty := harness.Do[groupserviceaccounts.ListOutput](s, actionGroupServiceAccountList, params)
+		if len(empty.Accounts) != 0 {
+			e.T.Errorf("a fresh group lists %d service account(s): %+v", len(empty.Accounts), empty.Accounts)
+		}
+
+		name := e.Name("sa")
+		created := harness.Do[groupserviceaccounts.Output](s, actionGroupServiceAccountCreate, withParams(params, map[string]any{"name": name, "username": name}))
+		if created.ID == 0 || created.Username != name {
+			e.T.Fatalf("service_account_create answered %+v, want the account %q with an ID", created, name)
+		}
+		// The account is a user, and outlives its group: the fixture's user
+		// deletion is the safety net for a delete the test did not reach.
+		e.Defer("service account "+name, func(ctx context.Context) error {
+			return fixture.DeleteUser(ctx, e.Client(), created.ID)
+		})
+		account := withParams(params, map[string]any{"service_account_id": created.ID})
+
+		updated := harness.Do[groupserviceaccounts.Output](s, actionGroupServiceAccountUpdate, withParams(account, map[string]any{"name": "Updated " + name}))
+		if updated.ID != created.ID || updated.Name != "Updated "+name {
+			e.T.Errorf("service_account_update answered %+v, want account %d renamed", updated, created.ID)
+		}
+		listed := harness.Do[groupserviceaccounts.ListOutput](s, actionGroupServiceAccountList, params)
+		if len(listed.Accounts) != 1 || listed.Accounts[0].ID != created.ID {
+			e.T.Errorf("the group lists the service accounts %+v, want exactly the created %d", listed.Accounts, created.ID)
+		}
+
+		token := harness.Do[groupserviceaccounts.PATOutput](s, actionGroupServiceAccountPATCreate, withParams(account, map[string]any{
+			"name": e.Name("pat"), "scopes": []string{"api"},
+		}))
+		if token.ID == 0 || token.Token == "" {
+			e.T.Fatalf("service_account_pat_create answered %+v, want a token with an ID and its secret", token)
+		}
+		tokens := harness.Do[groupserviceaccounts.ListPATOutput](s, actionGroupServiceAccountPATList, account)
+		if !containsID(activeTokenIDs(tokens.Tokens), token.ID) {
+			e.T.Errorf("the account's active tokens %v do not hold the minted %d", activeTokenIDs(tokens.Tokens), token.ID)
+		}
+
+		// A rotation revokes the token and mints another in its place, so
+		// the revocation below is of the replacement.
+		rotated := harness.Do[groupserviceaccounts.PATOutput](s, actionGroupServiceAccountPATRotate, withParams(account, map[string]any{
+			"token_id": token.ID, "expires_at": time.Now().Add(serviceAccountRotatedLife).Format(time.DateOnly),
+		}))
+		if rotated.ID == 0 || rotated.ID == token.ID || rotated.Token == "" {
+			e.T.Fatalf("service_account_pat_rotate answered %+v, want a new token with an ID and its secret", rotated)
+		}
+
+		harness.DoVoid(s, actionGroupServiceAccountPATRevoke, withParams(account, map[string]any{"token_id": rotated.ID}))
+		after := harness.Do[groupserviceaccounts.ListPATOutput](s, actionGroupServiceAccountPATList, account)
+		if active := activeTokenIDs(after.Tokens); containsID(active, rotated.ID) || containsID(active, token.ID) {
+			e.T.Errorf("the account's active tokens %v still hold %d or %d after the rotation and the revocation", active, token.ID, rotated.ID)
+		}
+
+		harness.DoVoid(s, actionGroupServiceAccountDelete, withParams(account, map[string]any{"hard_delete": true}))
+	})
+}

--- a/test/e2e/gitlab/common/helpers_test.go
+++ b/test/e2e/gitlab/common/helpers_test.go
@@ -2,15 +2,22 @@
 
 // helpers_test.go holds the two things every file here says about a
 // refusal: that it names what a caller needs to act on it, and how it is
-// quoted in a log line.
+// quoted in a log line; and the one question every listing here is asked.
 
 package common
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
 )
+
+// containsID reports whether an ID is among those listed. It is a name for
+// the question every listing here is asked, so an assertion reads as one.
+func containsID(ids []int64, want int64) bool {
+	return slices.Contains(ids, want)
+}
 
 // assertMentions checks that a refusal carries every substring, without
 // regard to case. The substrings are what the tool promises a caller: the

--- a/test/e2e/gitlab/common/issues_test.go
+++ b/test/e2e/gitlab/common/issues_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+// issues_test.go covers an issue's create and update through the server,
+// which the old suite made only to build the issue its Enterprise
+// scenarios stood on: the one an epic collects, the one whose weight
+// events are listed.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/issues"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestIssue_CreateAndUpdate_TitleFollows creates an issue on every surface
+// in a shared project, then retitles it and reads the new title off the
+// answer.
+//
+// Replaces: TestMeta_EpicIssues, TestMeta_IssueWeightEvents
+func TestIssue_CreateAndUpdate_TitleFollows(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("issuecreate"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		params := map[string]any{"project_id": project.IDParam()}
+		title := e.Name("issue")
+
+		created := harness.Do[issues.Output](s, actionIssueCreate, withParams(params, map[string]any{"title": title, "description": "created by the e2e suite"}))
+		if created.IID == 0 || created.Title != title {
+			e.T.Fatalf("issue create answered %+v, want the issue %q with an iid", created, title)
+		}
+
+		updated := harness.Do[issues.Output](s, actionIssueUpdate, withParams(params, map[string]any{"issue_iid": created.IID, "title": "Updated " + title}))
+		if updated.IID != created.IID || updated.Title != "Updated "+title {
+			e.T.Errorf("issue update answered %+v, want issue #%d retitled", updated, created.IID)
+		}
+	})
+}

--- a/test/e2e/gitlab/common/mergerequests_test.go
+++ b/test/e2e/gitlab/common/mergerequests_test.go
@@ -1,0 +1,56 @@
+//go:build e2e
+
+// mergerequests_test.go covers the three writes that open a merge request
+// through the server: a branch created from the default one, a commit made
+// on it, and the merge request from it. The old suite made these calls to
+// build the merge request its Enterprise scenarios stood on, and never as a
+// scenario of their own.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/branches"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/commits"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/mergerequests"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestMergeRequest_Create_FromABranchWithACommit creates a branch on every
+// surface in a shared project, commits a file on it and opens a merge
+// request from it, reading each object back off the answer that made it.
+//
+// Replaces: TestMeta_MergeTrains, TestMeta_ExternalStatusChecks, TestIndividual_MRDependenciesList
+func TestMergeRequest_Create_FromABranchWithACommit(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("mrcreate"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		params := map[string]any{"project_id": project.IDParam()}
+		branch := "feature/" + e.Name("mr")
+
+		created := harness.Do[branches.Output](s, actionBranchCreate, withParams(params, map[string]any{"branch_name": branch, "ref": project.DefaultBranch}))
+		if created.Name != branch {
+			e.T.Fatalf("branch create answered %+v, want the branch %q", created, branch)
+		}
+
+		commit := harness.Do[commits.Output](s, actionRepositoryCommitCreate, withParams(params, map[string]any{
+			"branch": branch, "commit_message": "docs: add the merge request file",
+			"actions": []map[string]any{{"action": "create", "file_path": "docs/" + string(surface) + ".md", "content": "# " + string(surface) + "\n"}},
+		}))
+		if commit.ID == "" || commit.Title != "docs: add the merge request file" {
+			e.T.Fatalf("commit create answered %+v, want a commit with an ID carrying the message", commit)
+		}
+
+		opened := harness.Do[mergerequests.Output](s, actionMergeRequestCreate, withParams(params, map[string]any{
+			"source_branch": branch, "target_branch": project.DefaultBranch, "title": e.Name("mr"),
+		}))
+		if opened.IID == 0 || opened.SourceBranch != branch || opened.TargetBranch != project.DefaultBranch || opened.State != "opened" {
+			e.T.Errorf("merge request create answered %+v, want an opened merge request from %q into %q", opened, branch, project.DefaultBranch)
+		}
+	})
+}

--- a/test/e2e/gitlab/common/pipelines_test.go
+++ b/test/e2e/gitlab/common/pipelines_test.go
@@ -1,0 +1,39 @@
+//go:build e2e
+
+// pipelines_test.go covers the creation of a pipeline through the server,
+// which the old suite made only to build the pipeline its vulnerability
+// scenario stood on. The pipeline is waited for, so it never contends with
+// the next test's for the one runner the Docker stack registers.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/pipelines"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestPipeline_Create_RunsOnTheDefaultBranch creates a pipeline on every
+// surface in a shared project carrying the e2e CI configuration, reads the
+// ref and the commit off the answer, and waits for it to finish.
+//
+// Replaces: TestMeta_VulnerabilityLifecycle
+func TestPipeline_Create_RunsOnTheDefaultBranch(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedRunner), harness.Locks(harness.LockRunner))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		project := fixture.NewProject(e, fixture.WithNamePrefix("pipecreate"))
+		fixture.CIFile(e, project)
+		return project
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+
+		created := harness.Do[pipelines.DetailOutput](s, actionPipelineCreate, map[string]any{"project_id": project.IDParam(), "ref": project.DefaultBranch})
+		if created.ID == 0 || created.Ref != project.DefaultBranch || created.SHA == "" {
+			e.T.Fatalf("pipeline create answered %+v, want a pipeline on %q with an ID and a commit", created, project.DefaultBranch)
+		}
+		e.T.Logf("pipeline %d ended in %q", created.ID, fixture.WaitForPipeline(e, project, created.ID, 0))
+	})
+}

--- a/test/e2e/gitlab/common/projects_test.go
+++ b/test/e2e/gitlab/common/projects_test.go
@@ -1,0 +1,72 @@
+//go:build e2e
+
+// projects_test.go covers a project's own lifecycle through the server:
+// create one with a README, read it, change its description, delete it
+// and check what the read answers afterwards. The old suite made these
+// calls before nearly every scenario, to build the project that scenario
+// stood on, and never as a scenario of their own.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projects"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestProject_Lifecycle_CreateGetUpdateDelete creates a private project on
+// every surface, reads it back, changes its description, deletes it and
+// checks the read is refused or answers a project marked for deletion. The
+// fixture library's deletion is registered behind the server's, for a
+// delete that only marked the project.
+//
+// Replaces: TestMeta_EpicIssues, TestIndividual_PushRules, TestMeta_IssueWorkItems
+func TestProject_Lifecycle_CreateGetUpdateDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		name := e.Name("proj")
+
+		created := harness.Do[projects.Output](s, actionProjectCreate, map[string]any{
+			"name": name, "visibility": "private", "initialize_with_readme": true, "default_branch": fixture.DefaultBranch,
+		})
+		if created.ID == 0 || created.Name != name {
+			e.T.Fatalf("project create answered %+v, want a project named %q with an ID", created, name)
+		}
+		e.Defer("project "+created.PathWithNamespace, func(ctx context.Context) error {
+			return fixture.DeleteProject(ctx, e.Client(), created.ID, created.PathWithNamespace)
+		})
+		project := fixture.Project{ID: created.ID, Path: created.PathWithNamespace, Name: created.Name, DefaultBranch: fixture.DefaultBranch}
+		params := map[string]any{"project_id": project.IDParam()}
+
+		got := harness.Do[projects.Output](s, actionProjectGet, params)
+		if got.ID != created.ID || got.PathWithNamespace != created.PathWithNamespace {
+			e.T.Errorf("project get answered %d at %q, want %d at %q", got.ID, got.PathWithNamespace, created.ID, created.PathWithNamespace)
+		}
+
+		updated := harness.Do[projects.Output](s, actionProjectUpdate, withParams(params, map[string]any{"description": "updated by the e2e suite"}))
+		if updated.ID != created.ID || updated.Description != "updated by the e2e suite" {
+			e.T.Errorf("project update answered %+v, want project %d with the new description", updated, created.ID)
+		}
+
+		// The delete answers what the instance did: removed it, or marked it
+		// for a delayed deletion, which the read afterwards agrees with.
+		deleted := harness.Do[projects.DeleteOutput](s, actionProjectDelete, params)
+		if deleted.Status != "success" && deleted.Status != "scheduled" {
+			e.T.Errorf("project delete answered %+v, want a success or a scheduled deletion", deleted)
+		}
+		remaining, err := harness.Try[projects.Output](s, actionProjectGet, params)
+		switch {
+		case err != nil && deleted.Status == "scheduled":
+			e.T.Errorf("the delete reported a deletion scheduled on %s, and the read answers: %v", deleted.MarkedForDeletionOn, err)
+		case err == nil && remaining.MarkedForDeletionOn == "":
+			e.T.Errorf("the project still reads as %+v after its delete, and is not marked for deletion", remaining)
+		case err == nil:
+			e.T.Logf("the delete marked the project for deletion on %s", remaining.MarkedForDeletionOn)
+		}
+	})
+}

--- a/test/e2e/gitlab/common/snippets_test.go
+++ b/test/e2e/gitlab/common/snippets_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+// snippets_test.go covers a personal snippet's create and delete through
+// the server, which the old suite made only to build the snippet its
+// storage move scenario stood on.
+
+package common
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/snippets"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// TestSnippet_CreateAndDelete_GoneAfterwards creates a private personal
+// snippet with one file on every surface, deletes it and checks the read
+// is then refused. The fixture library's deletion is registered behind the
+// server's, for a delete that did not happen.
+//
+// Replaces: TestMeta_StorageMoves
+func TestSnippet_CreateAndDelete_GoneAfterwards(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		title := e.Name("snippet")
+
+		created := harness.Do[snippets.Output](s, actionSnippetCreate, map[string]any{
+			"title": title, "visibility": "private",
+			"files": []map[string]any{{"file_path": "notes.md", "content": "# " + title + "\n"}},
+		})
+		if created.ID == 0 || created.Title != title {
+			e.T.Fatalf("snippet create answered %+v, want the snippet %q with an ID", created, title)
+		}
+		e.Defer("snippet "+title, func(ctx context.Context) error {
+			_, err := e.Client().GL().Snippets.DeleteSnippet(created.ID, gl.WithContext(ctx))
+			if err != nil && !fixture.IsStatus(err, http.StatusNotFound) {
+				return err
+			}
+			return nil
+		})
+
+		harness.DoVoid(s, actionSnippetDelete, map[string]any{"snippet_id": created.ID})
+		refused := harness.Refused(s, actionSnippetGet, map[string]any{"snippet_id": created.ID}, harness.FailureNotFound)
+		e.T.Logf("the read of the deleted snippet was refused: %s", firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/common/users_test.go
+++ b/test/e2e/gitlab/common/users_test.go
@@ -1,9 +1,10 @@
 //go:build e2e
 
-// users_test.go covers the instance-level service accounts of the user
-// group: list them, create one, update it. The account is a user, so it is
-// removed through the fixture library's user deletion rather than through
-// a delete of its own, which the group has none for.
+// users_test.go covers the read of the authenticated user, and the
+// instance-level service accounts of the user group: list them, create
+// one, update it. The account is a user, so it is removed through the
+// fixture library's user deletion rather than through a delete of its own,
+// which the group has none for.
 
 package common
 
@@ -15,6 +16,24 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
 	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
 )
+
+// TestUserCurrent_RunToken_NamesTheRunUser reads the authenticated user on
+// every surface and checks it is the user the run's token belongs to, by
+// id and by username, which is the one fact every other test's writes are
+// attributed by.
+//
+// Replaces: TestBaseline_Recorder_JoinsTheDispatchedAction
+func TestUserCurrent_RunToken_NamesTheRunUser(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		me := harness.Do[users.Output](s, actionUserCurrent, nil)
+		if me.ID != e.Runtime().UserID || me.Username != e.Runtime().Username {
+			e.T.Errorf("user current answered %d %q, want the run's user %d %q", me.ID, me.Username, e.Runtime().UserID, e.Runtime().Username)
+		}
+	})
+}
 
 // TestUserServiceAccounts_Instance_ListsCreatesAndUpdates creates one
 // instance service account per surface, finds it in the listing and

--- a/test/e2e/gitlab/common/workitems_test.go
+++ b/test/e2e/gitlab/common/workitems_test.go
@@ -1,0 +1,117 @@
+//go:build e2e
+
+// workitems_test.go covers the Free half of the issue tool's work items:
+// the type listing that says what a project may hold, and the lifecycle of
+// one work item of the Issue type. The old suite kept the lifecycle in its
+// Enterprise half, and on a Free runtime it still cannot run, for a reason
+// that is client-go's rather than GitLab's: the SDK's get, create and
+// update documents select five licensed widgets that Community Edition
+// refuses, so the lifecycle skips there and names the register entry.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/workitems"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// issueTypeName is the name of the work item type every project holds.
+const issueTypeName = "Issue"
+
+// workItemTypeID finds the global ID of a type by name in a type listing.
+func workItemTypeID(types []workitems.WorkItemTypeOutput, name string) (string, bool) {
+	for _, workItemType := range types {
+		if workItemType.Name == name {
+			return workItemType.ID, true
+		}
+	}
+	return "", false
+}
+
+// lookUpIssueType lists the work item types of a project through the server
+// and returns the Issue type's global ID, failing the test when the
+// listing does not hold it.
+func lookUpIssueType(e *harness.Env, s *harness.Session, project fixture.Project) string {
+	e.T.Helper()
+	types := harness.Do[workitems.WorkItemTypeListOutput](s, actionWorkItemTypeList, map[string]any{"full_path": project.Path})
+	typeID, found := workItemTypeID(types.Types, issueTypeName)
+	if !found {
+		e.T.Fatalf("the project's work item types do not hold %s: %+v", issueTypeName, types.Types)
+	}
+	return typeID
+}
+
+// TestWorkItemTypes_List_HoldsTheIssueType lists the work item types of a
+// shared project on every surface and finds the Issue type among them,
+// which is the one read of the family that answers on every edition.
+//
+// Replaces: TestMeta_IssueWorkItems
+func TestWorkItemTypes_List_HoldsTheIssueType(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("witypes"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		e.T.Logf("the Issue type is %s", lookUpIssueType(e, e.On(surface), project))
+	})
+}
+
+// TestWorkItems_Lifecycle_IssueTypeCreateListGetUpdateDelete looks the
+// Issue type up in a shared project on every surface, creates a work item
+// of it, finds it in the listing by its title, reads it back, retitles it,
+// deletes it and checks the read is then refused.
+//
+// Replaces: TestMeta_IssueWorkItems
+func TestWorkItems_Lifecycle_IssueTypeCreateListGetUpdateDelete(t *testing.T) {
+	e := harness.New(t)
+	// The edition decides, not the tier: an Enterprise image carries the
+	// widgets in its schema whether or not a license activates them, and a
+	// Community image does not carry them at all.
+	if !e.Runtime().Enterprise {
+		e.Skipf("client-go v3.0.0's work item get, create and update documents select five licensed widgets " +
+			"that Community Edition's schema does not have (docs/development/upstream-bugs.md, entry 45)," +
+			"so the lifecycle cannot run on a Community image")
+	}
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Project {
+		return fixture.NewProject(e, fixture.WithNamePrefix("workitems"))
+	}, func(e *harness.Env, surface harness.Surface, project fixture.Project) {
+		s := e.On(surface)
+		params := map[string]any{"full_path": project.Path}
+		typeID := lookUpIssueType(e, s, project)
+
+		title := e.Name("item")
+		created := harness.Do[workitems.GetOutput](s, actionWorkItemCreate, withParams(params, map[string]any{"work_item_type_id": typeID, "title": title}))
+		if created.WorkItem.IID == 0 || created.WorkItem.Title != title {
+			e.T.Fatalf("work_item_create answered %+v, want the item %q with an iid", created.WorkItem, title)
+		}
+		item := withParams(params, map[string]any{"work_item_iid": created.WorkItem.IID})
+
+		listed := harness.Do[workitems.ListOutput](s, actionWorkItemList, withParams(params, map[string]any{"search": title, "first": int64(5)}))
+		found := false
+		for _, listedItem := range listed.WorkItems {
+			if listedItem.IID == created.WorkItem.IID {
+				found = true
+			}
+		}
+		if !found {
+			e.T.Errorf("the listing by %q does not hold the created item #%d: %+v", title, created.WorkItem.IID, listed.WorkItems)
+		}
+		got := harness.Do[workitems.GetOutput](s, actionWorkItemGet, item)
+		if got.WorkItem.IID != created.WorkItem.IID || got.WorkItem.Title != title {
+			e.T.Errorf("work_item_get answered #%d %q, want #%d %q", got.WorkItem.IID, got.WorkItem.Title, created.WorkItem.IID, title)
+		}
+
+		updated := harness.Do[workitems.GetOutput](s, actionWorkItemUpdate, withParams(item, map[string]any{"title": "Updated " + title}))
+		if updated.WorkItem.Title != "Updated "+title {
+			e.T.Errorf("work_item_update answered the title %q, want the one just written", updated.WorkItem.Title)
+		}
+
+		harness.DoVoid(s, actionWorkItemDelete, item)
+		refused := harness.Refused(s, actionWorkItemGet, item, harness.FailureNotFound)
+		e.T.Logf("the read of the deleted work item was refused: %s", firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/ee/actions_test.go
+++ b/test/e2e/gitlab/ee/actions_test.go
@@ -165,6 +165,145 @@ const (
 	actionGroupDatadogDelete          harness.ActionID = "project.integration_delete_group_datadog"
 )
 
+// The group create, update and read, Free in the catalog and driven here for
+// the Ultimate download-limit fields only an Ultimate schema carries.
+const (
+	actionGroupCreate harness.ActionID = "group.create"
+	actionGroupUpdate harness.ActionID = "group.update"
+	actionGroupGet    harness.ActionID = "group.get"
+)
+
+// Epics, their notes, their discussions, their child issues and their
+// links, all reached through the group tool.
+const (
+	actionEpicCreate               harness.ActionID = "group.epic_create"
+	actionEpicList                 harness.ActionID = "group.epic_list"
+	actionEpicGet                  harness.ActionID = "group.epic_get"
+	actionEpicUpdate               harness.ActionID = "group.epic_update"
+	actionEpicDelete               harness.ActionID = "group.epic_delete"
+	actionEpicGetLinks             harness.ActionID = "group.epic_get_links"
+	actionEpicNoteCreate           harness.ActionID = "group.epic_note_create"
+	actionEpicNoteList             harness.ActionID = "group.epic_note_list"
+	actionEpicNoteGet              harness.ActionID = "group.epic_note_get"
+	actionEpicNoteUpdate           harness.ActionID = "group.epic_note_update"
+	actionEpicNoteDelete           harness.ActionID = "group.epic_note_delete"
+	actionEpicDiscussionCreate     harness.ActionID = "group.epic_discussion_create"
+	actionEpicDiscussionList       harness.ActionID = "group.epic_discussion_list"
+	actionEpicDiscussionGet        harness.ActionID = "group.epic_discussion_get"
+	actionEpicDiscussionAddNote    harness.ActionID = "group.epic_discussion_add_note"
+	actionEpicDiscussionUpdateNote harness.ActionID = "group.epic_discussion_update_note"
+	actionEpicDiscussionDeleteNote harness.ActionID = "group.epic_discussion_delete_note"
+	actionEpicIssueAssign          harness.ActionID = "group.epic_issue_assign"
+	actionEpicIssueList            harness.ActionID = "group.epic_issue_list"
+	actionEpicIssueUpdate          harness.ActionID = "group.epic_issue_update"
+	actionEpicIssueRemove          harness.ActionID = "group.epic_issue_remove"
+	actionEpicBoardList            harness.ActionID = "group.epic_board_list"
+	actionEpicBoardGet             harness.ActionID = "group.epic_board_get"
+	actionEpicLabelEventList       harness.ActionID = "group.event_epic_label_list"
+	actionEpicLabelEventGet        harness.ActionID = "group.event_epic_label_get"
+)
+
+// The group board create, the one Premium action of the board family; the
+// reads and the column actions are Free and live in the common package.
+const (
+	actionGroupBoardCreate harness.ActionID = "group.group_board_create"
+	actionGroupBoardList   harness.ActionID = "group.group_board_list"
+	actionGroupBoardGet    harness.ActionID = "group.group_board_get"
+	actionGroupBoardDelete harness.ActionID = "group.group_board_delete"
+)
+
+// Group wikis.
+const (
+	actionGroupWikiCreate harness.ActionID = "group.wiki_create"
+	actionGroupWikiList   harness.ActionID = "group.wiki_list"
+	actionGroupWikiGet    harness.ActionID = "group.wiki_get"
+	actionGroupWikiEdit   harness.ActionID = "group.wiki_edit"
+	actionGroupWikiDelete harness.ActionID = "group.wiki_delete"
+)
+
+// Group LDAP links and the LDAP sync.
+const (
+	actionGroupLDAPLinkAdd               harness.ActionID = "group.ldap_link_add"
+	actionGroupLDAPLinkList              harness.ActionID = "group.ldap_link_list"
+	actionGroupLDAPLinkDelete            harness.ActionID = "group.ldap_link_delete"
+	actionGroupLDAPLinkDeleteForProvider harness.ActionID = "group.ldap_link_delete_for_provider"
+	actionGroupLDAPSync                  harness.ActionID = "group.ldap_sync"
+)
+
+// Group SAML links and the SAML user listing.
+const (
+	actionGroupSAMLLinkList   harness.ActionID = "group.saml_link_list"
+	actionGroupSAMLLinkAdd    harness.ActionID = "group.saml_link_add"
+	actionGroupSAMLLinkGet    harness.ActionID = "group.saml_link_get"
+	actionGroupSAMLLinkDelete harness.ActionID = "group.saml_link_delete"
+	actionGroupSAMLUsersList  harness.ActionID = "group.saml_users_list"
+)
+
+// Group SSH certificates.
+const (
+	actionGroupSSHCertCreate harness.ActionID = "group.ssh_cert_create"
+	actionGroupSSHCertList   harness.ActionID = "group.ssh_cert_list"
+	actionGroupSSHCertDelete harness.ActionID = "group.ssh_cert_delete"
+)
+
+// The group credential inventory.
+const (
+	actionGroupCredentialListPATs     harness.ActionID = "group.credential_list_pats"
+	actionGroupCredentialListSSHKeys  harness.ActionID = "group.credential_list_ssh_keys"
+	actionGroupCredentialRevokePAT    harness.ActionID = "group.credential_revoke_pat"
+	actionGroupCredentialDeleteSSHKey harness.ActionID = "group.credential_delete_ssh_key"
+)
+
+// Group protected branches and protected environments.
+const (
+	actionGroupProtectedBranchProtect   harness.ActionID = "group.protected_branch_protect"
+	actionGroupProtectedBranchList      harness.ActionID = "group.protected_branch_list"
+	actionGroupProtectedBranchGet       harness.ActionID = "group.protected_branch_get"
+	actionGroupProtectedBranchUpdate    harness.ActionID = "group.protected_branch_update"
+	actionGroupProtectedBranchUnprotect harness.ActionID = "group.protected_branch_unprotect"
+	actionGroupProtectedEnvProtect      harness.ActionID = "group.protected_env_protect"
+	actionGroupProtectedEnvList         harness.ActionID = "group.protected_env_list"
+	actionGroupProtectedEnvGet          harness.ActionID = "group.protected_env_get"
+	actionGroupProtectedEnvUpdate       harness.ActionID = "group.protected_env_update"
+	actionGroupProtectedEnvUnprotect    harness.ActionID = "group.protected_env_unprotect"
+)
+
+// Group push rules.
+const (
+	actionGroupPushRuleAdd    harness.ActionID = "group.push_rule_add"
+	actionGroupPushRuleGet    harness.ActionID = "group.push_rule_get"
+	actionGroupPushRuleEdit   harness.ActionID = "group.push_rule_edit"
+	actionGroupPushRuleDelete harness.ActionID = "group.push_rule_delete"
+)
+
+// Billable members and provisioned users.
+const (
+	actionGroupBillableMembersList           harness.ActionID = "group.group_billable_members_list"
+	actionGroupBillableMemberMembershipsList harness.ActionID = "group.group_billable_member_memberships_list"
+	actionGroupBillableMemberRemove          harness.ActionID = "group.group_billable_member_remove"
+	actionGroupListProvisionedUsers          harness.ActionID = "group.list_provisioned_users"
+)
+
+// Group webhooks and their sub-operations.
+const (
+	actionGroupHookAdd                harness.ActionID = "group.hook_add"
+	actionGroupHookList               harness.ActionID = "group.hook_list"
+	actionGroupHookGet                harness.ActionID = "group.hook_get"
+	actionGroupHookEdit               harness.ActionID = "group.hook_edit"
+	actionGroupHookDelete             harness.ActionID = "group.hook_delete"
+	actionGroupHookSetCustomHeader    harness.ActionID = "group.hook_set_custom_header"
+	actionGroupHookDeleteCustomHeader harness.ActionID = "group.hook_delete_custom_header"
+	actionGroupHookSetURLVariable     harness.ActionID = "group.hook_set_url_variable"
+	actionGroupHookDeleteURLVariable  harness.ActionID = "group.hook_delete_url_variable"
+	actionGroupHookTest               harness.ActionID = "group.hook_test"
+	actionGroupHookResendEvent        harness.ActionID = "group.hook_resend_event"
+)
+
+// The group milestone burndown, the one licensed read of the group
+// milestone family, which the old suite kept behind an enterprise guard in
+// its Community group file.
+const actionGroupMilestoneBurndown harness.ActionID = "group.group_milestone_burndown"
+
 // Protected environments and the deployment approval they gate.
 const (
 	actionProtectedEnvProtect       harness.ActionID = "environment.protected_protect"

--- a/test/e2e/gitlab/ee/epics_test.go
+++ b/test/e2e/gitlab/ee/epics_test.go
@@ -1,0 +1,378 @@
+//go:build e2e
+
+// epics_test.go covers the epic family of the group tool: an epic's own
+// lifecycle, its notes, its discussions, the issues it collects, its child
+// links, the epic boards of its group and the label events GitLab records
+// on it. Every scenario runs on the three surfaces against an epic the
+// fixture library built over the work items API, which is the only route
+// GitLab 19 leaves to one.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/epicdiscussions"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/epicissues"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/epicnotes"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/epics"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupepicboards"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/resourceevents"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// missingBoardID is a board number no fresh group has, for the refusal of a
+// read that names one.
+const missingBoardID = int64(999999999)
+
+// epicParams names one epic the way every epic action does.
+func epicParams(epic fixture.Epic) map[string]any {
+	return map[string]any{"full_path": epic.GroupPath, "epic_iid": epic.IID}
+}
+
+// epicIIDs lists the iids of an epic listing.
+func epicIIDs(listed []epics.Output) []int64 {
+	ids := make([]int64, 0, len(listed))
+	for _, epic := range listed {
+		ids = append(ids, epic.IID)
+	}
+	return ids
+}
+
+// TestEpics_Lifecycle_CreateListGetUpdateDelete creates an epic on every
+// surface in a shared group, finds it in the listing, reads it back,
+// changes its description, deletes it and checks the read is then refused.
+//
+// Replaces: TestMeta_Epics
+func TestEpics_Lifecycle_CreateListGetUpdateDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("epics"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		title := e.Name("epic")
+
+		created := harness.Do[epics.Output](s, actionEpicCreate, map[string]any{
+			"full_path": group.Path, "title": title, "description": "created by the e2e suite",
+		})
+		if created.IID == 0 || created.Title != title {
+			e.T.Fatalf("epic_create answered %+v, want an epic titled %q with an iid", created, title)
+		}
+		epic := fixture.Epic{IID: created.IID, ID: created.ID, Title: title, GroupPath: group.Path}
+
+		listed := harness.Do[epics.ListOutput](s, actionEpicList, map[string]any{"full_path": group.Path})
+		if !containsID(epicIIDs(listed.Epics), epic.IID) {
+			e.T.Errorf("the group's epics do not hold the created epic %d: %v", epic.IID, epicIIDs(listed.Epics))
+		}
+
+		got := harness.Do[epics.Output](s, actionEpicGet, epicParams(epic))
+		if got.IID != epic.IID || got.Title != title {
+			e.T.Errorf("epic_get answered epic %d %q, want %d %q", got.IID, got.Title, epic.IID, title)
+		}
+
+		updated := harness.Do[epics.Output](s, actionEpicUpdate, withParams(epicParams(epic), map[string]any{"description": "updated by the e2e suite"}))
+		if updated.Description != "updated by the e2e suite" {
+			e.T.Errorf("epic_update answered the description %q, want the one just written", updated.Description)
+		}
+
+		harness.DoVoid(s, actionEpicDelete, epicParams(epic))
+		refused := harness.Refused(s, actionEpicGet, epicParams(epic), harness.FailureNotFound)
+		e.T.Logf("the read of the deleted epic was refused: %s", firstLine(refused))
+	})
+}
+
+// TestEpicBoards_FreshGroup_ListsAndRefusesAMissingBoard lists the epic
+// boards of a fresh group on every surface, reads the first one back when
+// the instance seeded one, and asks for a board number nothing has, which
+// is refused with the hint naming the listing to consult.
+//
+// Replaces: TestMeta_EpicBoards, TestMeta_GroupEpicBoards, TestMeta_Epics
+func TestEpicBoards_FreshGroup_ListsAndRefusesAMissingBoard(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("epicboards"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		params := map[string]any{"group_id": group.IDParam()}
+
+		listed := harness.Do[groupepicboards.ListOutput](s, actionEpicBoardList, params)
+		e.T.Logf("the fresh group lists %d epic board(s)", len(listed.Boards))
+		if len(listed.Boards) > 0 {
+			got := harness.Do[groupepicboards.Output](s, actionEpicBoardGet, withParams(params, map[string]any{"board_id": listed.Boards[0].ID}))
+			if got.ID != listed.Boards[0].ID {
+				e.T.Errorf("epic_board_get answered board %d, want the listed %d", got.ID, listed.Boards[0].ID)
+			}
+		}
+
+		refused := harness.Refused(s, actionEpicBoardGet, withParams(params, map[string]any{"board_id": missingBoardID}), harness.FailureNotFound)
+		assertMentions(e, "the read of a missing epic board", refused, "epic_board_list", "gitlab_group", "configure an epic board")
+	})
+}
+
+// epicFixture is a group with one epic the fixture library built in it.
+type epicFixture struct {
+	group fixture.Group
+	epic  fixture.Epic
+}
+
+// buildEpicFixture creates the group and the epic.
+func buildEpicFixture(prefix string) func(*harness.Env) epicFixture {
+	return func(e *harness.Env) epicFixture {
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix(prefix))
+		return epicFixture{group: group, epic: fixture.NewEpic(e, group, e.Name("epic"))}
+	}
+}
+
+// epicNoteIDs lists the ids of an epic note listing.
+func epicNoteIDs(notes []epicnotes.Output) []int64 {
+	ids := make([]int64, 0, len(notes))
+	for _, note := range notes {
+		ids = append(ids, note.ID)
+	}
+	return ids
+}
+
+// TestEpicNotes_Lifecycle_CreateListGetUpdateDelete writes one note on the
+// fixture epic per surface, finds it in the listing, reads it back, edits
+// it, deletes it and checks the listing no longer holds it.
+//
+// Replaces: TestMeta_EpicNotes
+func TestEpicNotes_Lifecycle_CreateListGetUpdateDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildEpicFixture("epicnotes"), func(e *harness.Env, surface harness.Surface, f epicFixture) {
+		s := e.On(surface)
+		params := epicParams(f.epic)
+		body := "note from the " + string(surface) + " surface"
+
+		created := harness.Do[epicnotes.Output](s, actionEpicNoteCreate, withParams(params, map[string]any{"body": body}))
+		if created.ID == 0 || created.Body != body {
+			e.T.Fatalf("epic_note_create answered %+v, want a note with an ID carrying %q", created, body)
+		}
+		note := withParams(params, map[string]any{"note_id": created.ID})
+
+		listed := harness.Do[epicnotes.ListOutput](s, actionEpicNoteList, params)
+		if !containsID(epicNoteIDs(listed.Notes), created.ID) {
+			e.T.Errorf("the epic's notes do not hold the created note %d: %v", created.ID, epicNoteIDs(listed.Notes))
+		}
+		got := harness.Do[epicnotes.Output](s, actionEpicNoteGet, note)
+		if got.ID != created.ID {
+			e.T.Errorf("epic_note_get answered note %d, want %d", got.ID, created.ID)
+		}
+		updated := harness.Do[epicnotes.Output](s, actionEpicNoteUpdate, withParams(note, map[string]any{"body": "updated " + body}))
+		if updated.Body != "updated "+body {
+			e.T.Errorf("epic_note_update answered the body %q, want the one just written", updated.Body)
+		}
+
+		harness.DoVoid(s, actionEpicNoteDelete, note)
+		after := harness.Do[epicnotes.ListOutput](s, actionEpicNoteList, params)
+		if containsID(epicNoteIDs(after.Notes), created.ID) {
+			e.T.Errorf("the epic's notes still hold note %d after its delete", created.ID)
+		}
+	})
+}
+
+// discussionNoteIDs lists the ids of the notes of one discussion.
+func discussionNoteIDs(notes []epicdiscussions.NoteOutput) []int64 {
+	ids := make([]int64, 0, len(notes))
+	for _, note := range notes {
+		ids = append(ids, note.ID)
+	}
+	return ids
+}
+
+// TestEpicDiscussions_Lifecycle_ThreadAndReply opens a discussion on the
+// fixture epic per surface, finds it in the listing, reads it back, replies
+// in it, edits the reply, deletes the reply and checks the thread no longer
+// holds it.
+//
+// Replaces: TestMeta_EpicDiscussions
+func TestEpicDiscussions_Lifecycle_ThreadAndReply(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildEpicFixture("epicdisc"), func(e *harness.Env, surface harness.Surface, f epicFixture) {
+		s := e.On(surface)
+		params := epicParams(f.epic)
+
+		created := harness.Do[epicdiscussions.Output](s, actionEpicDiscussionCreate, withParams(params, map[string]any{"body": "thread from " + string(surface)}))
+		if created.ID == "" || len(created.Notes) == 0 {
+			e.T.Fatalf("epic_discussion_create answered %+v, want a discussion with an ID and its first note", created)
+		}
+		thread := withParams(params, map[string]any{"discussion_id": created.ID})
+
+		listed := harness.Do[epicdiscussions.ListOutput](s, actionEpicDiscussionList, params)
+		found := false
+		for _, discussion := range listed.Discussions {
+			if discussion.ID == created.ID {
+				found = true
+			}
+		}
+		if !found {
+			e.T.Errorf("the epic's discussions do not hold the created thread %s among %d", created.ID, len(listed.Discussions))
+		}
+		got := harness.Do[epicdiscussions.Output](s, actionEpicDiscussionGet, thread)
+		if got.ID != created.ID {
+			e.T.Errorf("epic_discussion_get answered thread %s, want %s", got.ID, created.ID)
+		}
+
+		reply := harness.Do[epicdiscussions.NoteOutput](s, actionEpicDiscussionAddNote, withParams(thread, map[string]any{"body": "reply"}))
+		if reply.ID == 0 || reply.Body != "reply" {
+			e.T.Fatalf("epic_discussion_add_note answered %+v, want a reply with an ID", reply)
+		}
+		note := withParams(params, map[string]any{"note_id": reply.ID})
+		updated := harness.Do[epicdiscussions.NoteOutput](s, actionEpicDiscussionUpdateNote, withParams(note, map[string]any{"body": "updated reply"}))
+		if updated.Body != "updated reply" {
+			e.T.Errorf("epic_discussion_update_note answered the body %q, want the one just written", updated.Body)
+		}
+
+		harness.DoVoid(s, actionEpicDiscussionDeleteNote, note)
+		after := harness.Do[epicdiscussions.Output](s, actionEpicDiscussionGet, thread)
+		if containsID(discussionNoteIDs(after.Notes), reply.ID) {
+			e.T.Errorf("the thread still holds the reply %d after its delete", reply.ID)
+		}
+	})
+}
+
+// epicIssueFixture is a group with a project in it, so the issues an epic
+// collects have somewhere to live.
+type epicIssueFixture struct {
+	group   fixture.Group
+	project fixture.Project
+}
+
+// buildEpicIssueFixture creates the group and the project.
+func buildEpicIssueFixture(e *harness.Env) epicIssueFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("epiciss"))
+	project := fixture.NewProject(e, fixture.WithNamePrefix("epiciss"), fixture.InGroup(group))
+	return epicIssueFixture{group: group, project: project}
+}
+
+// childByIID finds one child of an epic by the issue's iid.
+func childByIID(children []epicissues.ChildOutput, iid int64) (epicissues.ChildOutput, bool) {
+	for _, child := range children {
+		if child.IID == iid {
+			return child, true
+		}
+	}
+	return epicissues.ChildOutput{}, false
+}
+
+// TestEpicIssues_AssignRemoveAndReorder_ChildrenFollow puts an issue into
+// an epic of its own per surface, lists it as a child, takes it out again,
+// then puts two issues in and reorders them.
+//
+// Replaces: TestMeta_EpicIssues
+func TestEpicIssues_AssignRemoveAndReorder_ChildrenFollow(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildEpicIssueFixture, func(e *harness.Env, surface harness.Surface, f epicIssueFixture) {
+		s := e.On(surface)
+		epic := fixture.NewEpic(e, f.group, e.Name("epic"))
+		first := fixture.NewIssue(e, f.project, e.Name("first"))
+		second := fixture.NewIssue(e, f.project, e.Name("second"))
+		params := epicParams(epic)
+		child := func(issue fixture.Issue) map[string]any {
+			return withParams(params, map[string]any{"child_project_path": f.project.Path, "child_iid": issue.IID})
+		}
+
+		assigned := harness.Do[epicissues.AssignOutput](s, actionEpicIssueAssign, child(first))
+		if assigned.EpicGID == "" || assigned.ChildGID == "" {
+			e.T.Fatalf("epic_issue_assign answered %+v, want both global IDs", assigned)
+		}
+		listed := harness.Do[epicissues.ListOutput](s, actionEpicIssueList, params)
+		if _, found := childByIID(listed.Issues, first.IID); !found {
+			e.T.Errorf("the epic's children do not hold issue #%d: %+v", first.IID, listed.Issues)
+		}
+
+		removed := harness.Do[epicissues.AssignOutput](s, actionEpicIssueRemove, child(first))
+		if removed.EpicGID == "" {
+			e.T.Errorf("epic_issue_remove answered %+v, want the epic's global ID", removed)
+		}
+		empty := harness.Do[epicissues.ListOutput](s, actionEpicIssueList, params)
+		if len(empty.Issues) != 0 {
+			e.T.Errorf("the epic still has %d child issue(s) after the remove: %+v", len(empty.Issues), empty.Issues)
+		}
+
+		harness.DoVoid(s, actionEpicIssueAssign, child(first))
+		harness.DoVoid(s, actionEpicIssueAssign, child(second))
+		both := harness.Do[epicissues.ListOutput](s, actionEpicIssueList, params)
+		firstChild, foundFirst := childByIID(both.Issues, first.IID)
+		secondChild, foundSecond := childByIID(both.Issues, second.IID)
+		if !foundFirst || !foundSecond {
+			e.T.Fatalf("the epic's children do not hold both issues #%d and #%d: %+v", first.IID, second.IID, both.Issues)
+		}
+		reordered := harness.Do[epicissues.ListOutput](s, actionEpicIssueUpdate, withParams(params, map[string]any{
+			"child_id": firstChild.ID, "adjacent_id": secondChild.ID, "relative_position": "AFTER",
+		}))
+		if len(reordered.Issues) < 2 {
+			e.T.Errorf("epic_issue_update answered %d child issue(s), want both", len(reordered.Issues))
+		}
+	})
+}
+
+// TestEpicLinks_FreshEpic_HasNoChildEpics reads the child epics of a fresh
+// epic on every surface and checks there are none.
+//
+// Replaces: TestMeta_EpicLinks
+func TestEpicLinks_FreshEpic_HasNoChildEpics(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildEpicFixture("epiclinks"), func(e *harness.Env, surface harness.Surface, f epicFixture) {
+		s := e.On(surface)
+		links := harness.Do[epics.LinksOutput](s, actionEpicGetLinks, epicParams(f.epic))
+		if len(links.ChildEpics) != 0 {
+			e.T.Errorf("a fresh epic reports %d child epic(s), want none: %+v", len(links.ChildEpics), links.ChildEpics)
+		}
+	})
+}
+
+// epicLabelFixture is a group with a label to put on epics.
+type epicLabelFixture struct {
+	group fixture.Group
+	label fixture.GroupLabel
+}
+
+// buildEpicLabelFixture creates the group and the label.
+func buildEpicLabelFixture(e *harness.Env) epicLabelFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("epiclabel"))
+	return epicLabelFixture{group: group, label: fixture.NewGroupLabel(e, group, "epic")}
+}
+
+// TestEpicLabelEvents_LabelAddedAndRemoved_EventsOrTheDocumentedRefusal
+// puts the fixture label on an epic of its own per surface and takes it
+// off, then asks for the label events. On GitLab 19 and later the epic
+// REST endpoints are gone, so the listing and the read are refused with
+// the hint that says where epics went; on an earlier release the two
+// events are listed and the first is read back.
+//
+// Replaces: TestMeta_GroupEpicLabelEvents
+func TestEpicLabelEvents_LabelAddedAndRemoved_EventsOrTheDocumentedRefusal(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildEpicLabelFixture, func(e *harness.Env, surface harness.Surface, f epicLabelFixture) {
+		s := e.On(surface)
+		epic := fixture.NewEpic(e, f.group, e.Name("epic"))
+		harness.DoVoid(s, actionEpicUpdate, withParams(epicParams(epic), map[string]any{"add_label_ids": []int64{f.label.ID}}))
+		harness.DoVoid(s, actionEpicUpdate, withParams(epicParams(epic), map[string]any{"remove_label_ids": []int64{f.label.ID}}))
+
+		params := map[string]any{"group_id": f.group.IDParam(), "epic_iid": epic.IID}
+		if fixture.LegacyEpicRESTRemoved(e) {
+			hint := []string{"GitLab 19", "work item"}
+			refused := harness.Refused(s, actionEpicLabelEventList, params, harness.FailureNotFound)
+			assertMentions(e, "the epic label event listing", refused, hint...)
+			refused = harness.Refused(s, actionEpicLabelEventGet, withParams(params, map[string]any{"label_event_id": int64(1)}), harness.FailureNotFound)
+			assertMentions(e, "the epic label event read", refused, hint...)
+			return
+		}
+
+		events := harness.Eventually(s, actionEpicLabelEventList, params, resourceEventInterval, resourceEventWait,
+			func(out resourceevents.ListLabelEventsOutput) bool { return len(out.Events) >= 2 })
+		got := harness.Do[resourceevents.LabelEventOutput](s, actionEpicLabelEventGet, withParams(params, map[string]any{"label_event_id": events.Events[0].ID}))
+		if got.ID != events.Events[0].ID {
+			e.T.Errorf("event_epic_label_get answered event %d, want the listed %d", got.ID, events.Events[0].ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupboards_test.go
+++ b/test/e2e/gitlab/ee/groupboards_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+// groupboards_test.go covers the one Premium action of the group board
+// family, the create, and the three Free reads and writes that prove what
+// it made: the listing holds the board, the read answers it, the delete
+// takes it out of the listing. The column actions and the reads on a board
+// the fixture library built are Free and live in the common package.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupboards"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// groupBoardIDs lists the ids of a board listing.
+func groupBoardIDs(boards []groupboards.GroupBoardOutput) []int64 {
+	ids := make([]int64, 0, len(boards))
+	for _, board := range boards {
+		ids = append(ids, board.ID)
+	}
+	return ids
+}
+
+// TestGroupBoards_Create_ListsReadsAndDeletesTheBoard creates a group issue
+// board on every surface, in a group of the surface's own since the create
+// is what a second board on one group needs the license for, checks the
+// listing holds exactly it, reads it back and deletes it.
+//
+// Replaces: TestEE_MetaGroupEnterpriseOperations
+func TestGroupBoards_Create_ListsReadsAndDeletesTheBoard(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("boards"))
+		params := map[string]any{"group_id": group.IDParam()}
+		name := e.Name("board")
+
+		created := harness.Do[groupboards.GroupBoardOutput](s, actionGroupBoardCreate, withParams(params, map[string]any{"name": name}))
+		if created.ID == 0 || created.Name != name {
+			e.T.Fatalf("group_board_create answered %+v, want a board named %q with an ID", created, name)
+		}
+		board := withParams(params, map[string]any{"board_id": created.ID})
+
+		// The listing is asserted exactly: the group is fresh, so the board
+		// just created is the only one it can hold. The old suite's Enterprise
+		// copy of this step accepted an empty listing on the theory that the
+		// list might lag the create, and that hedge is what let a listing that
+		// answered nothing pass.
+		listed := harness.Do[groupboards.ListGroupBoardsOutput](s, actionGroupBoardList, params)
+		if ids := groupBoardIDs(listed.Boards); len(ids) != 1 || ids[0] != created.ID {
+			e.T.Errorf("the fresh group lists the boards %v, want exactly the created %d", ids, created.ID)
+		}
+
+		got := harness.Do[groupboards.GroupBoardOutput](s, actionGroupBoardGet, board)
+		if got.ID != created.ID || got.Name != name {
+			e.T.Errorf("group_board_get answered board %d %q, want %d %q", got.ID, got.Name, created.ID, name)
+		}
+
+		harness.DoVoid(s, actionGroupBoardDelete, board)
+		after := harness.Do[groupboards.ListGroupBoardsOutput](s, actionGroupBoardList, params)
+		if containsID(groupBoardIDs(after.Boards), created.ID) {
+			e.T.Errorf("the group still lists board %d after its delete", created.ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupcredentials_test.go
+++ b/test/e2e/gitlab/ee/groupcredentials_test.go
@@ -1,0 +1,48 @@
+//go:build e2e
+
+// groupcredentials_test.go covers the group credential inventory on an
+// instance that does not expose it, which a self-managed Ultimate instance
+// does not: the four actions are refused as not found, and each refusal is
+// held to the hint that says the endpoints may be absent and what the
+// inventory needs when they are there.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// missingCredentialID is a token or key number nothing has, for the two
+// writes that name one.
+const missingCredentialID = int64(999999)
+
+// TestGroupCredentials_InventoryUnserved_EveryActionIsRefusedWithTheHint
+// drives the two listings and the two revocations of the credential
+// inventory on a fresh group on every surface and checks each is refused
+// as not found with the hint naming the endpoints, the tier and the access.
+//
+// Replaces: TestEE_MetaGroupEnterpriseOperations
+func TestGroupCredentials_InventoryUnserved_EveryActionIsRefusedWithTheHint(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("creds"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		params := map[string]any{"group_id": group.IDParam()}
+		hint := []string{"group credential inventory", "/groups/:id/manage", "Ultimate", "Owner or admin"}
+
+		refused := harness.Refused(s, actionGroupCredentialListPATs, params, harness.FailureNotFound)
+		assertMentions(e, "the token inventory listing", refused, hint...)
+		refused = harness.Refused(s, actionGroupCredentialListSSHKeys, params, harness.FailureNotFound)
+		assertMentions(e, "the key inventory listing", refused, hint...)
+		refused = harness.Refused(s, actionGroupCredentialRevokePAT, withParams(params, map[string]any{"token_id": missingCredentialID}), harness.FailureNotFound)
+		assertMentions(e, "the token revocation", refused, "credential_list_pats", "group credential inventory", "Ultimate", "Owner or admin")
+		refused = harness.Refused(s, actionGroupCredentialDeleteSSHKey, withParams(params, map[string]any{"key_id": missingCredentialID}), harness.FailureNotFound)
+		assertMentions(e, "the key deletion", refused, "credential_list_ssh_keys", "group credential inventory", "Ultimate", "Owner or admin")
+	})
+}

--- a/test/e2e/gitlab/ee/grouphooks_test.go
+++ b/test/e2e/gitlab/ee/grouphooks_test.go
@@ -1,0 +1,192 @@
+//go:build e2e
+
+// grouphooks_test.go covers a group's webhooks: the lifecycle of one, with
+// the event flags a group hook carries beyond a project's, and the
+// sub-operations on one that delivers somewhere, which is where the
+// fixture service comes in: its custom headers, its URL variables, a test
+// delivery and the resend of a recorded one.
+
+package ee
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groups"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The two URLs the lifecycle hook is written with, so the edit is told
+// apart from the add by what a read answers. Neither is ever delivered to.
+const (
+	hookInitialURL = "https://example.com/hook"
+	hookEditedURL  = "https://example.com/hook-updated"
+)
+
+// The custom header and the two URL variable keys the extras scenario
+// uses: one GitLab accepts, and one it refuses for the digit it carries.
+const (
+	hookCustomHeaderKey    = "X-E2E-Group"
+	hookURLVariableKey     = "hook_token"
+	hookIllegalVariableKey = "e2e_var"
+)
+
+// hookIDs lists the ids of a hook listing.
+func hookIDs(hooks []groups.HookOutput) []int64 {
+	ids := make([]int64, 0, len(hooks))
+	for _, hook := range hooks {
+		ids = append(ids, hook.ID)
+	}
+	return ids
+}
+
+// customHeaderKeys lists the custom header keys a hook carries; GitLab
+// masks the values on read and keeps the keys.
+func customHeaderKeys(hook groups.HookOutput) []string {
+	keys := make([]string, 0, len(hook.CustomHeaders))
+	for _, header := range hook.CustomHeaders {
+		keys = append(keys, header.Key)
+	}
+	return keys
+}
+
+// urlVariableKeys lists the URL variable keys a hook carries, masked the
+// same way.
+func urlVariableKeys(hook groups.HookOutput) []string {
+	keys := make([]string, 0, len(hook.URLVariables))
+	for _, variable := range hook.URLVariables {
+		keys = append(keys, variable.Key)
+	}
+	return keys
+}
+
+// TestGroupHooks_Lifecycle_AddListGetEditDelete walks one hook per surface
+// through its whole life in a shared group, and checks the event flags of a
+// group hook round-trip through an edit and a read: the emoji, access
+// token and project events, and the branch filter with its strategy.
+//
+// Replaces: TestEE_MetaGroupEnterpriseOperations
+func TestGroupHooks_Lifecycle_AddListGetEditDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("hooks"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		params := map[string]any{"group_id": group.IDParam()}
+
+		added := harness.Do[groups.HookOutput](s, actionGroupHookAdd, withParams(params, map[string]any{"url": hookInitialURL, "push_events": true}))
+		if added.ID == 0 || added.URL != hookInitialURL {
+			e.T.Fatalf("hook_add answered %+v, want a hook on %s with an ID", added, hookInitialURL)
+		}
+		hook := withParams(params, map[string]any{"hook_id": added.ID})
+
+		listed := harness.Do[groups.HookListOutput](s, actionGroupHookList, params)
+		if !containsID(hookIDs(listed.Hooks), added.ID) {
+			e.T.Errorf("the group's hooks do not hold the added hook %d: %v", added.ID, hookIDs(listed.Hooks))
+		}
+		got := harness.Do[groups.HookOutput](s, actionGroupHookGet, hook)
+		if got.ID != added.ID || !got.PushEvents {
+			e.T.Errorf("hook_get answered %+v, want hook %d with push events on", got, added.ID)
+		}
+
+		edited := harness.Do[groups.HookOutput](s, actionGroupHookEdit, withParams(hook, map[string]any{"url": hookEditedURL, "issues_events": true}))
+		if edited.ID != added.ID || edited.URL != hookEditedURL || !edited.IssuesEvents {
+			e.T.Errorf("hook_edit answered %+v, want hook %d on %s with issue events on", edited, added.ID, hookEditedURL)
+		}
+
+		flagged := harness.Do[groups.HookOutput](s, actionGroupHookEdit, withParams(hook, map[string]any{
+			"emoji_events": true, "resource_access_token_events": true, "project_events": true,
+			"push_events_branch_filter": fixture.DefaultBranch, "branch_filter_strategy": "wildcard",
+		}))
+		assertGroupHookFlags(e, "hook_edit", flagged)
+		// The read is what proves the flags were stored rather than echoed.
+		reread := harness.Do[groups.HookOutput](s, actionGroupHookGet, hook)
+		assertGroupHookFlags(e, "hook_get after the edit", reread)
+
+		harness.DoVoid(s, actionGroupHookDelete, hook)
+		after := harness.Do[groups.HookListOutput](s, actionGroupHookList, params)
+		if containsID(hookIDs(after.Hooks), added.ID) {
+			e.T.Errorf("the group's hooks still hold hook %d after its delete", added.ID)
+		}
+	})
+}
+
+// assertGroupHookFlags checks the five event fields the flag edit set.
+func assertGroupHookFlags(e *harness.Env, what string, hook groups.HookOutput) {
+	e.T.Helper()
+	if !hook.EmojiEvents || !hook.ResourceAccessTokenEvents || !hook.ProjectEvents {
+		e.T.Errorf("%s answers emoji=%t access_token=%t project=%t, want all three on", what, hook.EmojiEvents, hook.ResourceAccessTokenEvents, hook.ProjectEvents)
+	}
+	if hook.PushEventsBranchFilter != fixture.DefaultBranch || hook.BranchFilterStrategy != "wildcard" {
+		e.T.Errorf("%s answers the branch filter %q with strategy %q, want %q with wildcard", what, hook.PushEventsBranchFilter, hook.BranchFilterStrategy, fixture.DefaultBranch)
+	}
+}
+
+// deliveringHookFixture is a group with a project in it, so a test push
+// event has a commit to describe, and the hook is added per surface.
+type deliveringHookFixture struct {
+	group fixture.Group
+}
+
+// buildDeliveringHookFixture creates the group and the project.
+func buildDeliveringHookFixture(e *harness.Env) deliveringHookFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("hookxtra"))
+	fixture.NewProject(e, fixture.WithNamePrefix("hookxtra"), fixture.InGroup(group))
+	return deliveringHookFixture{group: group}
+}
+
+// TestGroupHooks_Extras_HeadersVariablesTestAndResend adds a hook per
+// surface that delivers to the fixture service, sets and removes a custom
+// header, refuses a URL variable whose key carries a digit and accepts one
+// that does not, refuses the removal of a variable never set, fires a test
+// push event and resends the delivery GitLab recorded for it.
+//
+// Replaces: TestMeta_GroupHookExtras
+func TestGroupHooks_Extras_HeadersVariablesTestAndResend(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedFixtureService))
+
+	harness.SurfacesWith(e, buildDeliveringHookFixture, func(e *harness.Env, surface harness.Surface, f deliveringHookFixture) {
+		s := e.On(surface)
+		params := map[string]any{"group_id": f.group.IDParam()}
+
+		added := harness.Do[groups.HookOutput](s, actionGroupHookAdd, withParams(params, map[string]any{
+			"url": fixture.ServiceURL(e, "/group-hook"), "push_events": true,
+		}))
+		if added.ID == 0 {
+			e.T.Fatalf("hook_add answered %+v, want a hook with an ID", added)
+		}
+		hook := withParams(params, map[string]any{"hook_id": added.ID})
+
+		harness.DoVoid(s, actionGroupHookSetCustomHeader, withParams(hook, map[string]any{"key": hookCustomHeaderKey, "value": "e2e-group-value"}))
+		withHeader := harness.Do[groups.HookOutput](s, actionGroupHookGet, hook)
+		if !slices.Contains(customHeaderKeys(withHeader), hookCustomHeaderKey) {
+			e.T.Errorf("the hook carries the custom headers %v after the set, want %s among them", customHeaderKeys(withHeader), hookCustomHeaderKey)
+		}
+		harness.DoVoid(s, actionGroupHookDeleteCustomHeader, withParams(hook, map[string]any{"key": hookCustomHeaderKey}))
+		withoutHeader := harness.Do[groups.HookOutput](s, actionGroupHookGet, hook)
+		if slices.Contains(customHeaderKeys(withoutHeader), hookCustomHeaderKey) {
+			e.T.Errorf("the hook still carries the custom header %s after its delete", hookCustomHeaderKey)
+		}
+
+		refused := harness.ExpectToolError(s, actionGroupHookSetURLVariable, withParams(hook, map[string]any{"key": hookIllegalVariableKey, "value": "e2e-value"}), "letters and underscores")
+		e.T.Logf("the URL variable with a digit in its key was refused: %s", firstLine(refused))
+		harness.DoVoid(s, actionGroupHookSetURLVariable, withParams(hook, map[string]any{"key": hookURLVariableKey, "value": "e2e-value"}))
+		withVariable := harness.Do[groups.HookOutput](s, actionGroupHookGet, hook)
+		if !slices.Contains(urlVariableKeys(withVariable), hookURLVariableKey) {
+			e.T.Errorf("the hook carries the URL variables %v after the set, want %s among them", urlVariableKeys(withVariable), hookURLVariableKey)
+		}
+		refused = harness.Refused(s, actionGroupHookDeleteURLVariable, withParams(hook, map[string]any{"key": hookIllegalVariableKey}), harness.FailureNotFound)
+		assertMentions(e, "the removal of a variable never set", refused, "not currently set")
+		harness.DoVoid(s, actionGroupHookDeleteURLVariable, withParams(hook, map[string]any{"key": hookURLVariableKey}))
+		withoutVariable := harness.Do[groups.HookOutput](s, actionGroupHookGet, hook)
+		if slices.Contains(urlVariableKeys(withoutVariable), hookURLVariableKey) {
+			e.T.Errorf("the hook still carries the URL variable %s after its delete", hookURLVariableKey)
+		}
+
+		harness.DoVoid(s, actionGroupHookTest, withParams(hook, map[string]any{"trigger": "push_events"}))
+		eventID := fixture.WaitForGroupHookEvent(e, f.group, added.ID)
+		harness.DoVoid(s, actionGroupHookResendEvent, withParams(hook, map[string]any{"hook_event_id": eventID}))
+	})
+}

--- a/test/e2e/gitlab/ee/groupiterations_test.go
+++ b/test/e2e/gitlab/ee/groupiterations_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+
+// groupiterations_test.go covers the one answer of the group iteration
+// listing that issues_test.go does not: a group that does not exist is
+// refused as not found, with the hint naming the read that finds one.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// missingGroupID is the group number GitLab never assigns.
+const missingGroupID = "0"
+
+// TestGroupIterations_MissingGroup_IsRefusedAsNotFound lists the
+// iterations of group 0 on every surface and checks the refusal names
+// the group read to verify the id with.
+//
+// Replaces: TestMeta_GroupIterations
+func TestGroupIterations_MissingGroup_IsRefusedAsNotFound(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		refused := harness.Refused(s, actionIterationListGroup, map[string]any{"group_id": missingGroupID, "state": "opened"}, harness.FailureNotFound)
+		assertMentions(e, "the iteration listing of a missing group", refused, "gitlab_group_get", "Premium")
+	})
+}

--- a/test/e2e/gitlab/ee/groupldap_test.go
+++ b/test/e2e/gitlab/ee/groupldap_test.go
@@ -1,0 +1,108 @@
+//go:build e2e
+
+// groupldap_test.go covers a group's LDAP links and the LDAP sync. A link
+// is a record GitLab keeps about a provider it will consult later, so the
+// link actions answer on any licensed instance whether or not a directory
+// is reachable; the sync is what needs group sync configured on the
+// instance, and the Docker stack does not configure it, so it is refused
+// and the refusal is asserted.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupldap"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The provider the Docker stack configures and the access a link grants.
+const (
+	ldapProvider    = "ldapmain"
+	ldapGroupAccess = int64(30)
+)
+
+// ldapLinkCNs lists the common names of a link listing.
+func ldapLinkCNs(links []groupldap.Output) []string {
+	cns := make([]string, 0, len(links))
+	for _, link := range links {
+		cns = append(cns, link.CN)
+	}
+	return cns
+}
+
+// containsCN reports whether a listing holds a link by common name.
+func containsCN(links []groupldap.Output, cn string) bool {
+	for _, link := range links {
+		if link.CN == cn {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGroupLDAPLinks_Lifecycle_AddListDeleteAndDeleteForProvider adds a
+// link on every surface in a group of its own, finds it in the listing,
+// deletes it by common name, then adds another and deletes it by provider.
+//
+// Replaces: TestMeta_GroupLDAPLinks, TestEE_MetaGroupEnterpriseOperations
+func TestGroupLDAPLinks_Lifecycle_AddListDeleteAndDeleteForProvider(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("ldap"))
+		params := map[string]any{"group_id": group.IDParam()}
+		cn := e.Name("cn")
+
+		empty := harness.Do[groupldap.ListOutput](s, actionGroupLDAPLinkList, params)
+		if len(empty.Links) != 0 {
+			e.T.Errorf("a fresh group lists %d LDAP link(s): %v", len(empty.Links), ldapLinkCNs(empty.Links))
+		}
+
+		added := harness.Do[groupldap.Output](s, actionGroupLDAPLinkAdd, withParams(params, map[string]any{
+			"cn": cn, "group_access": ldapGroupAccess, "provider": ldapProvider,
+		}))
+		if added.CN != cn || added.Provider != ldapProvider {
+			e.T.Errorf("ldap_link_add answered %+v, want the link %q on %q", added, cn, ldapProvider)
+		}
+		listed := harness.Do[groupldap.ListOutput](s, actionGroupLDAPLinkList, params)
+		if !containsCN(listed.Links, cn) {
+			e.T.Errorf("the group's LDAP links do not hold %q: %v", cn, ldapLinkCNs(listed.Links))
+		}
+
+		harness.DoVoid(s, actionGroupLDAPLinkDelete, withParams(params, map[string]any{"cn": cn, "provider": ldapProvider}))
+		after := harness.Do[groupldap.ListOutput](s, actionGroupLDAPLinkList, params)
+		if containsCN(after.Links, cn) {
+			e.T.Errorf("the group's LDAP links still hold %q after its delete", cn)
+		}
+
+		byProvider := e.Name("provider-cn")
+		harness.DoVoid(s, actionGroupLDAPLinkAdd, withParams(params, map[string]any{
+			"cn": byProvider, "group_access": ldapGroupAccess, "provider": ldapProvider,
+		}))
+		harness.DoVoid(s, actionGroupLDAPLinkDeleteForProvider, withParams(params, map[string]any{"cn": byProvider, "provider": ldapProvider}))
+		final := harness.Do[groupldap.ListOutput](s, actionGroupLDAPLinkList, params)
+		if containsCN(final.Links, byProvider) {
+			e.T.Errorf("the group's LDAP links still hold %q after the delete by provider", byProvider)
+		}
+	})
+}
+
+// TestGroupLDAPSync_NoGroupSync_IsRefusedWithTheProviderHint asks a fresh
+// group to sync with LDAP on every surface and checks the refusal names
+// what a caller has to have for it: the provider, the tier and the access.
+//
+// Replaces: TestMeta_GroupLDAPSync
+func TestGroupLDAPSync_NoGroupSync_IsRefusedWithTheProviderHint(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("ldapsync"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		refused := harness.Refused(s, actionGroupLDAPSync, map[string]any{"group_id": group.IDParam()}, harness.FailureNotFound)
+		assertMentions(e, "the LDAP sync refusal", refused, "LDAP provider", "Premium/Ultimate", "Owner access")
+	})
+}

--- a/test/e2e/gitlab/ee/groupmembers_test.go
+++ b/test/e2e/gitlab/ee/groupmembers_test.go
@@ -1,0 +1,160 @@
+//go:build e2e
+
+// groupmembers_test.go covers the two licensed listings of a group's
+// people: the billable members, with the memberships of one of them and
+// the removal of one, and the users an identity provider provisioned,
+// which on a stack with no provider is nobody.
+
+package ee
+
+import (
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupmembers"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groups"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The wait for a new membership to reach the billable listing, which
+// GitLab serves from a count it updates a moment after the add.
+const (
+	billableInterval = 2 * time.Second
+	billableWait     = 60 * time.Second
+)
+
+// The wait for a removal to leave the billable listing. GitLab documents
+// the removal as asynchronous and completing in a few minutes: the API
+// schedules the deletion and a worker performs it, so the wait is sized to
+// the documentation and made once for every surface's member rather than
+// once per surface.
+const (
+	billableRemovalInterval = 5 * time.Second
+	billableRemovalWait     = 5 * time.Minute
+)
+
+// billableFixture is a group with one Developer per surface in it, so each
+// surface has a member of its own to remove and the one wait for the
+// removals covers all three.
+type billableFixture struct {
+	group fixture.Group
+	users map[harness.Surface]fixture.User
+}
+
+// buildBillableFixture creates the group and adds the users.
+func buildBillableFixture(e *harness.Env) billableFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("billable"))
+	users := map[harness.Surface]fixture.User{}
+	for _, surface := range harness.AllSurfaces() {
+		user := fixture.NewUser(e, "billable-"+string(surface))
+		fixture.AddGroupMember(e, group, user, gl.DeveloperPermissions)
+		users[surface] = user
+	}
+	return billableFixture{group: group, users: users}
+}
+
+// containsAnyUsername reports whether a billable listing holds any of the
+// users.
+func containsAnyUsername(members []groupmembers.BillableMemberOutput, users map[harness.Surface]fixture.User) bool {
+	for _, user := range users {
+		if containsUsername(members, user.Username) {
+			return true
+		}
+	}
+	return false
+}
+
+// billableUsernames lists the usernames of a billable member listing.
+func billableUsernames(members []groupmembers.BillableMemberOutput) []string {
+	names := make([]string, 0, len(members))
+	for _, member := range members {
+		names = append(names, member.Username)
+	}
+	return names
+}
+
+// containsUsername reports whether a billable listing holds a member.
+func containsUsername(members []groupmembers.BillableMemberOutput, username string) bool {
+	for _, member := range members {
+		if member.Username == username {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGroupBillableMembers_DeveloperAdded_ListedWithMembershipsAndRemoved
+// gives each surface a Developer of its own in a shared group, waits for
+// the billable listing to show them beside the owner, lists their
+// memberships and asks for their removal; then waits, once for all three,
+// for the listing to let them go, which GitLab does in the background. The
+// owner cannot be the one removed: GitLab keeps the last owner, which is
+// why the scenario needs the other users.
+//
+// Replaces: TestMeta_GroupBillableMembers
+func TestGroupBillableMembers_DeveloperAdded_ListedWithMembershipsAndRemoved(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.NeedAdmin))
+
+	// Built on the parent's Env rather than through SurfacesWith, because the
+	// wait for the removals comes after the surfaces and needs the users.
+	f := buildBillableFixture(e)
+	params := map[string]any{"group_id": f.group.IDParam()}
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		user := f.users[surface]
+
+		before := harness.Do[groupmembers.BillableMembersOutput](s, actionGroupBillableMembersList, params)
+		if !containsUsername(before.Members, e.Runtime().Username) {
+			e.T.Errorf("the group's billable members do not hold its owner %q: %v", e.Runtime().Username, billableUsernames(before.Members))
+		}
+		listed := harness.Eventually(s, actionGroupBillableMembersList, withParams(params, map[string]any{"search": user.Username}),
+			billableInterval, billableWait,
+			func(out groupmembers.BillableMembersOutput) bool { return containsUsername(out.Members, user.Username) })
+		if !listed.Members[0].Removable {
+			e.T.Errorf("the billable member %q is listed as not removable, and a Developer is", user.Username)
+		}
+
+		memberships := harness.Do[groupmembers.BillableMembershipsOutput](s, actionGroupBillableMemberMembershipsList, withParams(params, map[string]any{"user_id": user.ID}))
+		if len(memberships.Memberships) == 0 {
+			e.T.Errorf("the billable member %q has no memberships listed, and was just added to the group", user.Username)
+		}
+
+		harness.DoVoid(s, actionGroupBillableMemberRemove, withParams(params, map[string]any{"user_id": user.ID}))
+	})
+
+	// The removal is acknowledged before it is done: the API schedules the
+	// deletion and a worker performs it, in a few minutes by GitLab's own
+	// account. The three removals are waited for together, and the owner is
+	// what must remain.
+	s := e.On(harness.SurfaceDynamic)
+	fixture.DrainSidekiq(e.Ctx, e.Client())
+	after := harness.Eventually(s, actionGroupBillableMembersList, params, billableRemovalInterval, billableRemovalWait,
+		func(out groupmembers.BillableMembersOutput) bool { return !containsAnyUsername(out.Members, f.users) })
+	if !containsUsername(after.Members, e.Runtime().Username) {
+		e.T.Errorf("the group's billable members no longer hold its owner %q after the removals: %v", e.Runtime().Username, billableUsernames(after.Members))
+	}
+}
+
+// TestGroupProvisionedUsers_NoProvider_ListsNobody lists the provisioned
+// users of a fresh group on every surface, ordered the way the action
+// offers, and checks the answer names nobody.
+//
+// Replaces: TestMeta_GroupProvisionedUsers
+func TestGroupProvisionedUsers_NoProvider_ListsNobody(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("provisioned"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		listed := harness.Do[groups.ProvisionedUsersListOutput](s, actionGroupListProvisionedUsers, map[string]any{
+			"group_id": group.IDParam(), "order_by": "id", "sort": "asc",
+		})
+		if len(listed.Users) != 0 {
+			e.T.Errorf("a group with no identity provider lists %d provisioned user(s): %+v", len(listed.Users), listed.Users)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupmilestones_test.go
+++ b/test/e2e/gitlab/ee/groupmilestones_test.go
@@ -1,0 +1,65 @@
+//go:build e2e
+
+// groupmilestones_test.go covers the one licensed read of a group's
+// milestones, the burndown chart events, which the old suite kept behind
+// an enterprise guard in its Community group file, where it never ran. The
+// events come from an issue put into the milestone, since a milestone
+// nothing was ever assigned to has no chart to draw.
+
+package ee
+
+import (
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupmilestones"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// burndownFixture is a group with a milestone and one issue assigned to
+// it, in a project of the group.
+type burndownFixture struct {
+	group     fixture.Group
+	milestone fixture.GroupMilestone
+}
+
+// buildBurndownFixture creates the group, the project, the milestone and
+// the issue, and puts the issue into the milestone through client-go.
+func buildBurndownFixture(e *harness.Env) burndownFixture {
+	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("burndown"))
+	project := fixture.NewProject(e, fixture.WithNamePrefix("burndown"), fixture.InGroup(group))
+	milestone := fixture.NewGroupMilestone(e, group, "sprint")
+	issue := fixture.NewIssue(e, project, "burndown fixture")
+	if _, _, err := e.Client().GL().Issues.UpdateIssue(project.ID, issue.IID, &gl.UpdateIssueOptions{MilestoneID: new(milestone.ID)}, gl.WithContext(e.Ctx)); err != nil {
+		e.T.Fatalf("putting issue #%d into milestone %d: %v", issue.IID, milestone.ID, err)
+	}
+	return burndownFixture{group: group, milestone: milestone}
+}
+
+// burndownCreated is the action a burndown chart records for an issue that
+// entered the milestone open: the chart is drawn from the issues' own
+// creation, closing and reopening, and an open issue contributes its
+// creation.
+const burndownCreated = "created"
+
+// TestGroupMilestoneBurndown_IssueAssigned_RecordsAnEvent reads the
+// burndown chart events of the fixture milestone on every surface, waiting
+// for GitLab to record the assignment, and checks the first event is the
+// creation of the open issue the milestone holds.
+//
+// Replaces: TestMeta_GroupDeep
+func TestGroupMilestoneBurndown_IssueAssigned_RecordsAnEvent(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, buildBurndownFixture, func(e *harness.Env, surface harness.Surface, f burndownFixture) {
+		s := e.On(surface)
+		events := harness.Eventually(s, actionGroupMilestoneBurndown,
+			map[string]any{"group_id": f.group.IDParam(), "milestone_iid": f.milestone.IID}, resourceEventInterval, resourceEventWait,
+			func(out groupmilestones.BurndownChartEventsOutput) bool { return len(out.Events) > 0 })
+		if events.Events[0].Action != burndownCreated {
+			e.T.Errorf("the first burndown event is %q, want the creation of the open issue: %+v", events.Events[0].Action, events.Events)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupprotectedbranches_test.go
+++ b/test/e2e/gitlab/ee/groupprotectedbranches_test.go
@@ -1,0 +1,86 @@
+//go:build e2e
+
+// groupprotectedbranches_test.go covers a group's protected branch rules:
+// protect a wildcard, find it in the listing, read it, allow force pushes
+// on it, unprotect it and check the read is then refused.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupprotectedbranches"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// maintainerAccessLevel is the access every side of the fixture rule is
+// given: Maintainer, which GitLab accepts for push, merge and unprotect.
+const maintainerAccessLevel = int64(40)
+
+// protectedBranchNames lists the names of a rule listing.
+func protectedBranchNames(branches []groupprotectedbranches.Output) []string {
+	names := make([]string, 0, len(branches))
+	for _, branch := range branches {
+		names = append(names, branch.Name)
+	}
+	return names
+}
+
+// containsBranchName reports whether a rule listing holds one by name.
+func containsBranchName(branches []groupprotectedbranches.Output, name string) bool {
+	for _, branch := range branches {
+		if branch.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGroupProtectedBranches_Lifecycle_ProtectListGetUpdateUnprotect walks
+// one wildcard rule per surface through its whole life in a shared group.
+// The wildcards carry the surface's name, so the three rules never collide.
+//
+// Replaces: TestMeta_GroupProtectedBranchesEE, TestEE_MetaGroupEnterpriseOperations
+func TestGroupProtectedBranches_Lifecycle_ProtectListGetUpdateUnprotect(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("gpb"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		params := map[string]any{"group_id": group.IDParam()}
+		wildcard := e.Name("release") + "/*"
+		rule := withParams(params, map[string]any{"branch": wildcard})
+
+		protected := harness.Do[groupprotectedbranches.Output](s, actionGroupProtectedBranchProtect, withParams(params, map[string]any{
+			"name": wildcard, "push_access_level": maintainerAccessLevel, "merge_access_level": maintainerAccessLevel,
+			"unprotect_access_level": maintainerAccessLevel, "allow_force_push": false,
+		}))
+		if protected.Name != wildcard || protected.AllowForcePush {
+			e.T.Fatalf("protected_branch_protect answered %+v, want the rule %q with force pushes off", protected, wildcard)
+		}
+
+		listed := harness.Do[groupprotectedbranches.ListOutput](s, actionGroupProtectedBranchList, withParams(params, map[string]any{"search": wildcard}))
+		if !containsBranchName(listed.Branches, wildcard) {
+			e.T.Errorf("the group's protected branches do not hold %q: %v", wildcard, protectedBranchNames(listed.Branches))
+		}
+		got := harness.Do[groupprotectedbranches.Output](s, actionGroupProtectedBranchGet, rule)
+		if got.Name != wildcard {
+			e.T.Errorf("protected_branch_get answered %q, want %q", got.Name, wildcard)
+		}
+
+		updated := harness.Do[groupprotectedbranches.Output](s, actionGroupProtectedBranchUpdate, withParams(rule, map[string]any{"allow_force_push": true}))
+		if updated.Name != wildcard || !updated.AllowForcePush {
+			e.T.Errorf("protected_branch_update answered %+v, want %q with force pushes on", updated, wildcard)
+		}
+
+		harness.DoVoid(s, actionGroupProtectedBranchUnprotect, rule)
+		refused := harness.Refused(s, actionGroupProtectedBranchGet, rule, harness.FailureNotFound)
+		e.T.Logf("the read of the unprotected rule was refused: %s", firstLine(refused))
+		after := harness.Do[groupprotectedbranches.ListOutput](s, actionGroupProtectedBranchList, params)
+		if containsBranchName(after.Branches, wildcard) {
+			e.T.Errorf("the group's protected branches still hold %q after its unprotect", wildcard)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupprotectedenvs_test.go
+++ b/test/e2e/gitlab/ee/groupprotectedenvs_test.go
@@ -1,0 +1,121 @@
+//go:build e2e
+
+// groupprotectedenvs_test.go covers a group's protected environments, which
+// are named by deployment tier rather than by environment: a name outside
+// the five tiers is refused with the list of them, and the production tier
+// is protected, listed, read, given a wider deploy access level and
+// unprotected.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupprotectedenvs"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The tier the fixture rule protects and the access it widens to.
+const (
+	productionTier       = "production"
+	developerAccessLevel = int64(30)
+)
+
+// protectedEnvNames lists the names of a protected environment listing.
+func protectedEnvNames(environments []groupprotectedenvs.Output) []string {
+	names := make([]string, 0, len(environments))
+	for _, environment := range environments {
+		names = append(names, environment.Name)
+	}
+	return names
+}
+
+// containsEnvName reports whether a listing holds a protected environment
+// by name.
+func containsEnvName(environments []groupprotectedenvs.Output, name string) bool {
+	for _, environment := range environments {
+		if environment.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hasDeployAccessLevel reports whether a rule grants the given access level
+// on any of its deploy access levels.
+func hasDeployAccessLevel(rule groupprotectedenvs.Output, level int64) bool {
+	for _, access := range rule.DeployAccessLevels {
+		if int64(access.AccessLevel) == level {
+			return true
+		}
+	}
+	return false
+}
+
+// The five deployment tiers a group protected environment may be named
+// after, which every refusal of another name spells out.
+var deploymentTiers = []string{productionTier, "staging", "testing", "development", "other"}
+
+// TestGroupProtectedEnvironments_Lifecycle_RefusesANameOutsideTheTiers
+// asks every surface to protect a name that is no deployment tier, which is
+// refused with the tiers spelled out, then protects the production tier in
+// a group of the surface's own, lists it, reads it, widens its deploy
+// access to Developer and unprotects it.
+//
+// The refusal of the name comes from two places, and the test holds each
+// surface to its own: the individual tool declares the tiers as an enum, so
+// the SDK refuses the argument before the handler runs, while the two
+// dispatchers hand the name to GitLab and wrap its refusal with the hint
+// that lists the tiers.
+//
+// Replaces: TestMeta_GroupProtectedEnvironmentsEE, TestEE_MetaGroupEnterpriseOperations
+func TestGroupProtectedEnvironments_Lifecycle_RefusesANameOutsideTheTiers(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("gpe"))
+		params := map[string]any{"group_id": group.IDParam()}
+		maintainers := []map[string]any{{"access_level": maintainerAccessLevel}}
+
+		outsideTheTiers := withParams(params, map[string]any{"name": e.Name("tier"), "deploy_access_levels": maintainers})
+		var refused string
+		if surface == harness.SurfaceIndividual {
+			refused = harness.Refused(s, actionGroupProtectedEnvProtect, outsideTheTiers, harness.FailureInvalidParams)
+		} else {
+			refused = harness.ExpectToolError(s, actionGroupProtectedEnvProtect, outsideTheTiers, "valid group protected environment tiers")
+		}
+		assertMentions(e, "the refusal of a name outside the tiers", refused, deploymentTiers...)
+
+		protected := harness.Do[groupprotectedenvs.Output](s, actionGroupProtectedEnvProtect, withParams(params, map[string]any{
+			"name": productionTier, "deploy_access_levels": maintainers,
+		}))
+		if protected.Name != productionTier || len(protected.DeployAccessLevels) == 0 || protected.DeployAccessLevels[0].ID == 0 {
+			e.T.Fatalf("protected_env_protect answered %+v, want the %s tier with a deploy access level carrying an ID", protected, productionTier)
+		}
+		tier := withParams(params, map[string]any{"environment": productionTier})
+
+		listed := harness.Do[groupprotectedenvs.ListOutput](s, actionGroupProtectedEnvList, params)
+		if !containsEnvName(listed.Environments, productionTier) {
+			e.T.Errorf("the group's protected environments do not hold %s: %v", productionTier, protectedEnvNames(listed.Environments))
+		}
+		got := harness.Do[groupprotectedenvs.Output](s, actionGroupProtectedEnvGet, tier)
+		if got.Name != productionTier {
+			e.T.Errorf("protected_env_get answered %q, want %s", got.Name, productionTier)
+		}
+
+		updated := harness.Do[groupprotectedenvs.Output](s, actionGroupProtectedEnvUpdate, withParams(tier, map[string]any{
+			"deploy_access_levels": []map[string]any{{"id": protected.DeployAccessLevels[0].ID, "access_level": developerAccessLevel}},
+		}))
+		if updated.Name != productionTier || !hasDeployAccessLevel(updated, developerAccessLevel) {
+			e.T.Errorf("protected_env_update answered %+v, want %s with a deploy access level of %d", updated, productionTier, developerAccessLevel)
+		}
+
+		harness.DoVoid(s, actionGroupProtectedEnvUnprotect, tier)
+		after := harness.Do[groupprotectedenvs.ListOutput](s, actionGroupProtectedEnvList, params)
+		if containsEnvName(after.Environments, productionTier) {
+			e.T.Errorf("the group's protected environments still hold %s after its unprotect", productionTier)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/grouppushrules_test.go
+++ b/test/e2e/gitlab/ee/grouppushrules_test.go
@@ -1,0 +1,62 @@
+//go:build e2e
+
+// grouppushrules_test.go covers a group's push rules, which are one record
+// per group: add it, read it back, edit it and check the edit persisted,
+// delete it and check the read is then refused.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groups"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The two file size limits the rule is written with, so the edit is told
+// apart from the add by what a read answers.
+const (
+	pushRuleInitialMaxFileSize = int64(25)
+	pushRuleEditedMaxFileSize  = int64(75)
+)
+
+// TestGroupPushRules_Lifecycle_AddGetEditDelete walks the push rules of a
+// group of the surface's own through their whole life, since a group holds
+// one rule record and three surfaces cannot share it.
+//
+// Replaces: TestMeta_GroupPushRules
+func TestGroupPushRules_Lifecycle_AddGetEditDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("pushrule"))
+		params := map[string]any{"group_id": group.IDParam()}
+
+		added := harness.Do[groups.PushRuleOutput](s, actionGroupPushRuleAdd, withParams(params, map[string]any{
+			"commit_message_regex": "^[A-Z].*", "max_file_size": pushRuleInitialMaxFileSize,
+		}))
+		if added.ID == 0 || added.MaxFileSize != pushRuleInitialMaxFileSize {
+			e.T.Fatalf("push_rule_add answered %+v, want a rule with an ID limiting files to %d MB", added, pushRuleInitialMaxFileSize)
+		}
+
+		got := harness.Do[groups.PushRuleOutput](s, actionGroupPushRuleGet, params)
+		if got.ID != added.ID || got.MaxFileSize != pushRuleInitialMaxFileSize || got.CommitMessageRegex != "^[A-Z].*" {
+			e.T.Errorf("push_rule_get answered %+v, want rule %d as it was added", got, added.ID)
+		}
+
+		edited := harness.Do[groups.PushRuleOutput](s, actionGroupPushRuleEdit, withParams(params, map[string]any{"max_file_size": pushRuleEditedMaxFileSize}))
+		if edited.MaxFileSize != pushRuleEditedMaxFileSize {
+			e.T.Errorf("push_rule_edit answered a limit of %d MB, want %d", edited.MaxFileSize, pushRuleEditedMaxFileSize)
+		}
+		reread := harness.Do[groups.PushRuleOutput](s, actionGroupPushRuleGet, params)
+		if reread.MaxFileSize != pushRuleEditedMaxFileSize {
+			e.T.Errorf("the rule reads a limit of %d MB after the edit, want %d", reread.MaxFileSize, pushRuleEditedMaxFileSize)
+		}
+
+		harness.DoVoid(s, actionGroupPushRuleDelete, params)
+		refused := harness.Refused(s, actionGroupPushRuleGet, params, harness.FailureNotFound)
+		e.T.Logf("the read of the deleted rule was refused: %s", firstLine(refused))
+	})
+}

--- a/test/e2e/gitlab/ee/groups_test.go
+++ b/test/e2e/gitlab/ee/groups_test.go
@@ -2,21 +2,102 @@
 
 // groups_test.go covers two licensed reads and one licensed write of the
 // group tool that stand on nothing but a fresh group: the three analytics
-// counts, and the group's secret push protection switch. The group's other
+// counts, and the group's secret push protection switch; and the one
+// Ultimate scenario of the Free group create, update and read, the
+// download-limit fields only an Ultimate schema carries. The group's other
 // licensed families, its boards, wikis, links, certificates, credentials
 // and protected refs, each have a file of their own.
 
 package ee
 
 import (
+	"context"
+	"strconv"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupanalytics"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groups"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securitysettings"
 	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
 	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
 )
+
+// The download limit the Ultimate group is created with: ten unique
+// projects in five minutes, with the ban on exceeding it.
+const (
+	downloadLimit         = int64(10)
+	downloadLimitInterval = int64(300)
+)
+
+// downloadLimitFields is the download limit as the group actions take it:
+// the limit, its interval, the two empty lists and the ban.
+var downloadLimitFields = map[string]any{
+	"unique_project_download_limit":                     downloadLimit,
+	"unique_project_download_limit_interval_in_seconds": downloadLimitInterval,
+	"unique_project_download_limit_allowlist":           []string{},
+	"unique_project_download_limit_alertlist":           []int64{},
+	"auto_ban_user_on_excessive_projects_download":      true,
+}
+
+// assertDownloadLimit checks the three settings an answer carries about the
+// download limit, which GitLab exposes to the group's owner on Ultimate.
+func assertDownloadLimit(e *harness.Env, what string, group groups.DetailOutput) {
+	e.T.Helper()
+	if group.UniqueProjectDownloadLimit == nil || *group.UniqueProjectDownloadLimit != downloadLimit {
+		e.T.Errorf("%s answers the download limit %s, want %d", what, int64Word(group.UniqueProjectDownloadLimit), downloadLimit)
+	}
+	if group.UniqueProjectDownloadLimitIntervalSecs == nil || *group.UniqueProjectDownloadLimitIntervalSecs != downloadLimitInterval {
+		e.T.Errorf("%s answers the limit interval %s, want %d", what, int64Word(group.UniqueProjectDownloadLimitIntervalSecs), downloadLimitInterval)
+	}
+	if group.AutoBanUserOnExcessiveProjectsDownload == nil || !*group.AutoBanUserOnExcessiveProjectsDownload {
+		e.T.Errorf("%s answers the auto-ban %v, want it on", what, group.AutoBanUserOnExcessiveProjectsDownload)
+	}
+}
+
+// int64Word spells an optional number for a message: the number, or absent.
+func int64Word(value *int64) string {
+	if value == nil {
+		return "absent"
+	}
+	return strconv.FormatInt(*value, 10)
+}
+
+// TestGroupUpdate_UltimateDownloadLimit_FieldsRoundTrip creates a group on
+// every surface with the download-limit fields, then sets them through the
+// update and reads them back off the update's answer and off a read.
+//
+// The create is sent the fields and is asserted only to be accepted: GitLab's
+// create route drops them, as the live API record says by declaring the five
+// on PUT /groups/:id and none of them on POST /groups, while the create
+// input still publishes them because client-go's CreateGroupOptions carries
+// them. The update route is where the settings land.
+//
+// Replaces: TestIndividual_GroupCreateUltimateFields
+func TestGroupUpdate_UltimateDownloadLimit_FieldsRoundTrip(t *testing.T) {
+	e := harness.New(t, harness.Needs(harness.Tier(edition.Ultimate)))
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		name := e.Name("ult")
+
+		created := harness.Do[groups.DetailOutput](s, actionGroupCreate, withParams(downloadLimitFields, map[string]any{
+			"name": name, "path": name, "visibility": "private",
+		}))
+		if created.ID == 0 || created.Path != name {
+			e.T.Fatalf("group create answered %+v, want a group at %q with an ID", created, name)
+		}
+		e.Defer("group "+created.FullPath, func(ctx context.Context) error {
+			return fixture.DeleteGroup(ctx, e.Client(), created.ID, created.FullPath)
+		})
+		params := map[string]any{"group_id": strconv.FormatInt(created.ID, 10)}
+
+		updated := harness.Do[groups.DetailOutput](s, actionGroupUpdate, withParams(downloadLimitFields, params))
+		assertDownloadLimit(e, "group update", updated)
+		reread := harness.Do[groups.DetailOutput](s, actionGroupGet, params)
+		assertDownloadLimit(e, "group get after the update", reread)
+	})
+}
 
 // TestGroupAnalytics_FreshGroup_CountsAnswerForThePath asks a fresh group
 // for its recently created issues, merge requests and members on every

--- a/test/e2e/gitlab/ee/groupsaml_test.go
+++ b/test/e2e/gitlab/ee/groupsaml_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+// groupsaml_test.go covers a group's SAML links and its SAML users on an
+// instance with no SSO provider, which is what the Docker stack is: the
+// four link actions are refused as unauthorized, and each refusal is held
+// to the hint that says what the group lacks, while the user listing
+// answers with nobody, since SAML provisioned no one.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupsaml"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// samlLinkAccessLevel is the access a link would grant: Developer.
+const samlLinkAccessLevel = int64(30)
+
+// TestGroupSAMLLinks_NoSSO_EveryActionIsRefusedWithTheSSOHint drives the
+// list, add, get and delete of a SAML link on a fresh group on every
+// surface and checks each is refused, naming SSO, the tier and the access.
+//
+// Replaces: TestMeta_GroupSAML, TestEE_MetaGroupEnterpriseOperations
+func TestGroupSAMLLinks_NoSSO_EveryActionIsRefusedWithTheSSOHint(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("saml"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		params := map[string]any{"group_id": group.IDParam()}
+		named := withParams(params, map[string]any{"saml_group_name": e.Name("saml")})
+		hint := []string{"group SAML SSO", "Premium/Ultimate", "Owner access", "401 or 404"}
+
+		refused := harness.Refused(s, actionGroupSAMLLinkList, params, harness.FailureForbidden)
+		assertMentions(e, "the SAML link listing", refused, hint...)
+		refused = harness.Refused(s, actionGroupSAMLLinkAdd, withParams(named, map[string]any{"access_level": samlLinkAccessLevel}), harness.FailureForbidden)
+		assertMentions(e, "the SAML link add", refused, hint...)
+		refused = harness.Refused(s, actionGroupSAMLLinkGet, named, harness.FailureForbidden)
+		assertMentions(e, "the SAML link read", refused, hint...)
+		refused = harness.Refused(s, actionGroupSAMLLinkDelete, named, harness.FailureForbidden)
+		assertMentions(e, "the SAML link delete", refused, hint...)
+	})
+}
+
+// TestGroupSAMLUsers_NoSSO_ListsNobody lists the SAML users of a fresh
+// group on every surface with every filter the action offers, and checks
+// the answer names nobody.
+//
+// Replaces: TestMeta_GroupSAMLUsers
+func TestGroupSAMLUsers_NoSSO_ListsNobody(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("samlusers"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		listed := harness.Do[groupsaml.SAMLUsersListOutput](s, actionGroupSAMLUsersList, map[string]any{
+			"group_id": group.IDParam(), "search": "nobody", "active": true,
+			"created_after": "2026-01-01T00:00:00Z", "created_before": "2026-12-31T23:59:59Z",
+		})
+		if len(listed.Users) != 0 {
+			e.T.Errorf("a group with no SSO lists %d SAML user(s): %+v", len(listed.Users), listed.Users)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupsshcerts_test.go
+++ b/test/e2e/gitlab/ee/groupsshcerts_test.go
@@ -1,0 +1,65 @@
+//go:build e2e
+
+// groupsshcerts_test.go covers a group's SSH certificates: a fresh group
+// has none, a certificate minted from a fresh key is listed once it is
+// created, and deleted it is listed no more.
+
+package ee
+
+import (
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupsshcerts"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// sshCertIDs lists the ids of a certificate listing.
+func sshCertIDs(certificates []groupsshcerts.Output) []int64 {
+	ids := make([]int64, 0, len(certificates))
+	for _, certificate := range certificates {
+		ids = append(ids, certificate.ID)
+	}
+	return ids
+}
+
+// TestGroupSSHCerts_Lifecycle_CreateListDelete creates one certificate per
+// surface in a group of the surface's own, so the empty listing before and
+// the one-entry listing after are exact, and deletes it.
+//
+// Replaces: TestMeta_GroupSSHCerts, TestEE_MetaGroupEnterpriseOperations
+func TestGroupSSHCerts_Lifecycle_CreateListDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.EachSurface(e, func(e *harness.Env, surface harness.Surface) {
+		s := e.On(surface)
+		group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("sshcert"))
+		params := map[string]any{"group_id": group.IDParam()}
+
+		empty := harness.Do[groupsshcerts.ListOutput](s, actionGroupSSHCertList, params)
+		if len(empty.Certificates) != 0 {
+			e.T.Errorf("a fresh group lists %d SSH certificate(s): %v", len(empty.Certificates), sshCertIDs(empty.Certificates))
+		}
+
+		key, err := fixture.SSHPublicKey()
+		if err != nil {
+			e.T.Fatal(err)
+		}
+		title := e.Name("cert")
+		created := harness.Do[groupsshcerts.Output](s, actionGroupSSHCertCreate, withParams(params, map[string]any{"key": key, "title": title}))
+		if created.ID == 0 || created.Title != title {
+			e.T.Fatalf("ssh_cert_create answered %+v, want a certificate titled %q with an ID", created, title)
+		}
+
+		listed := harness.Do[groupsshcerts.ListOutput](s, actionGroupSSHCertList, params)
+		if ids := sshCertIDs(listed.Certificates); len(ids) != 1 || ids[0] != created.ID {
+			e.T.Errorf("the group lists the certificates %v, want exactly the created %d", ids, created.ID)
+		}
+
+		harness.DoVoid(s, actionGroupSSHCertDelete, withParams(params, map[string]any{"certificate_id": created.ID}))
+		after := harness.Do[groupsshcerts.ListOutput](s, actionGroupSSHCertList, params)
+		if containsID(sshCertIDs(after.Certificates), created.ID) {
+			e.T.Errorf("the group still lists certificate %d after its delete", created.ID)
+		}
+	})
+}

--- a/test/e2e/gitlab/ee/groupwikis_test.go
+++ b/test/e2e/gitlab/ee/groupwikis_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+// groupwikis_test.go covers a group's wiki pages: create one, find it in
+// the listing, read it, edit it and check the edit landed, delete it and
+// check the listing lets it go.
+
+package ee
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/groupwikis"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/fixture"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// The two bodies a wiki page is written with, so the edit is told apart from
+// the create by what a read answers.
+const (
+	wikiInitialContent = "# E2E group wiki\n\nInitial content."
+	wikiUpdatedContent = "# E2E group wiki\n\nUpdated content."
+)
+
+// wikiSlugs lists the slugs of a wiki listing.
+func wikiSlugs(pages []groupwikis.Output) []string {
+	slugs := make([]string, 0, len(pages))
+	for _, page := range pages {
+		slugs = append(slugs, page.Slug)
+	}
+	return slugs
+}
+
+// TestGroupWikis_Lifecycle_CreateListGetEditDelete walks one wiki page per
+// surface through its whole life in a shared group.
+//
+// Replaces: TestMeta_GroupWikis, TestEE_MetaGroupEnterpriseOperations
+func TestGroupWikis_Lifecycle_CreateListGetEditDelete(t *testing.T) {
+	e := harness.New(t)
+
+	harness.SurfacesWith(e, func(e *harness.Env) fixture.Group {
+		return fixture.NewGroup(e, fixture.WithGroupNamePrefix("wikis"))
+	}, func(e *harness.Env, surface harness.Surface, group fixture.Group) {
+		s := e.On(surface)
+		params := map[string]any{"group_id": group.IDParam()}
+
+		created := harness.Do[groupwikis.Output](s, actionGroupWikiCreate, withParams(params, map[string]any{
+			"title": e.Name("page"), "content": wikiInitialContent, "format": "markdown",
+		}))
+		if created.Slug == "" {
+			e.T.Fatalf("wiki_create answered %+v, want a page with a slug", created)
+		}
+		page := withParams(params, map[string]any{"slug": created.Slug})
+
+		listed := harness.Do[groupwikis.ListOutput](s, actionGroupWikiList, withParams(params, map[string]any{"with_content": true}))
+		if !slices.Contains(wikiSlugs(listed.WikiPages), created.Slug) {
+			e.T.Errorf("the group's wiki pages do not hold %q: %v", created.Slug, wikiSlugs(listed.WikiPages))
+		}
+		got := harness.Do[groupwikis.Output](s, actionGroupWikiGet, page)
+		if got.Slug != created.Slug || got.Content != wikiInitialContent {
+			e.T.Errorf("wiki_get answered %q with %q, want %q with the initial content", got.Slug, got.Content, created.Slug)
+		}
+
+		edited := harness.Do[groupwikis.Output](s, actionGroupWikiEdit, withParams(page, map[string]any{"content": wikiUpdatedContent}))
+		if edited.Slug != created.Slug || edited.Content != wikiUpdatedContent {
+			e.T.Errorf("wiki_edit answered %q with %q, want %q with the updated content", edited.Slug, edited.Content, created.Slug)
+		}
+		// The edit is checked through a read as well as through its own
+		// answer: an edit endpoint that echoed the request and wrote
+		// nothing would pass the first and fail this.
+		reread := harness.Do[groupwikis.Output](s, actionGroupWikiGet, page)
+		if reread.Content != wikiUpdatedContent {
+			e.T.Errorf("the page reads %q after the edit, want the updated content", reread.Content)
+		}
+
+		harness.DoVoid(s, actionGroupWikiDelete, page)
+		after := harness.Do[groupwikis.ListOutput](s, actionGroupWikiList, params)
+		if slices.Contains(wikiSlugs(after.WikiPages), created.Slug) {
+			e.T.Errorf("the group's wiki pages still hold %q after its delete", created.Slug)
+		}
+	})
+}

--- a/test/e2e/internal/fixture/board.go
+++ b/test/e2e/internal/fixture/board.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+// board.go builds a group issue board over GraphQL, because the REST create
+// route is the Premium one: it refuses a first board on an unlicensed
+// instance, while the mutation runs the same service the boards page runs
+// and lets every group have one board on every edition. The board goes with
+// the group, so nothing is registered.
+
+package fixture
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// GroupBoard is a group issue board a builder created.
+type GroupBoard struct {
+	// ID is the numeric identifier every board action takes.
+	ID int64
+	// GID is the GraphQL global ID it was created as.
+	GID string
+	// Name is what it was created with.
+	Name string
+}
+
+// boardMutation creates one group issue board.
+const boardMutation = `mutation($groupPath: ID!, $name: String!) {
+  createBoard(input: { groupPath: $groupPath, name: $name }) {
+    board { id }
+    errors
+  }
+}`
+
+// boardGIDPrefix is what GitLab puts in front of a board's number in its
+// global ID.
+const boardGIDPrefix = "gid://gitlab/Board/"
+
+// NewGroupBoard creates an issue board in the group, named with the run's
+// own scoping.
+func NewGroupBoard(e *harness.Env, group Group, prefix string) GroupBoard {
+	e.T.Helper()
+
+	name := e.Name(prefix)
+	var created struct {
+		CreateBoard struct {
+			Board *struct {
+				ID string `json:"id"`
+			} `json:"board"`
+			Errors []string `json:"errors"`
+		} `json:"createBoard"`
+	}
+	err := mutate(e, boardMutation, map[string]any{"groupPath": group.Path, "name": name}, &created)
+	if err != nil {
+		e.T.Fatalf("creating a board in group %s: %v", group.Path, err)
+	}
+	if errs := created.CreateBoard.Errors; len(errs) > 0 {
+		e.T.Fatalf("GitLab refused a board in group %s: %s", group.Path, strings.Join(errs, "; "))
+	}
+	if created.CreateBoard.Board == nil || created.CreateBoard.Board.ID == "" {
+		e.T.Fatalf("the board in group %s was created with no ID", group.Path)
+	}
+	id, err := boardIDFromGID(created.CreateBoard.Board.ID)
+	if err != nil {
+		e.T.Fatal(err)
+	}
+	return GroupBoard{ID: id, GID: created.CreateBoard.Board.ID, Name: name}
+}
+
+// boardIDFromGID reads the number out of a board's global ID, which is what
+// the REST actions name a board by.
+func boardIDFromGID(gid string) (int64, error) {
+	number, found := strings.CutPrefix(gid, boardGIDPrefix)
+	if !found {
+		return 0, fmt.Errorf("the board's global ID %q does not start with %s", gid, boardGIDPrefix)
+	}
+	id, err := strconv.ParseInt(number, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("the board's global ID %q carries no positive number", gid)
+	}
+	return id, nil
+}

--- a/test/e2e/internal/fixture/board_test.go
+++ b/test/e2e/internal/fixture/board_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+// board_test.go pins the one piece of the board builder that is not a call
+// to GitLab: reading the number a REST action needs out of the global ID
+// the mutation answers with.
+
+package fixture
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBoardIDFromGID_Answers_ReadsTheNumberOrRefuses checks the global ID
+// parser on the shape GitLab answers and on the shapes it must refuse: a
+// foreign prefix, a missing number, a zero, since a zero board id would be
+// sent on and refused by GitLab with a message about the wrong thing.
+func TestBoardIDFromGID_Answers_ReadsTheNumberOrRefuses(t *testing.T) {
+	cases := []struct {
+		name    string
+		gid     string
+		want    int64
+		refused string
+	}{
+		{name: "a board", gid: "gid://gitlab/Board/42", want: 42},
+		{name: "another object", gid: "gid://gitlab/Issue/42", refused: "does not start with"},
+		{name: "no number", gid: "gid://gitlab/Board/", refused: "no positive number"},
+		{name: "not a number", gid: "gid://gitlab/Board/x", refused: "no positive number"},
+		{name: "zero", gid: "gid://gitlab/Board/0", refused: "no positive number"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := boardIDFromGID(testCase.gid)
+			if testCase.refused != "" {
+				if err == nil || !strings.Contains(err.Error(), testCase.refused) {
+					t.Fatalf("boardIDFromGID(%q) = %d, %v; want an error mentioning %q", testCase.gid, got, err, testCase.refused)
+				}
+				return
+			}
+			if err != nil || got != testCase.want {
+				t.Errorf("boardIDFromGID(%q) = %d, %v; want %d", testCase.gid, got, err, testCase.want)
+			}
+		})
+	}
+}
+
+// TestRunGraphQL_BoardMutation_DecodesTheBoard checks the board mutation's
+// answer decodes into the shape the builder reads, through the same sender
+// the iteration builder uses, so a renamed payload field fails here rather
+// than as a board with no ID against a live GitLab.
+func TestRunGraphQL_BoardMutation_DecodesTheBoard(t *testing.T) {
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.graphqlAnswers = []string{`{"data":{"createBoard":{"board":{"id":"gid://gitlab/Board/7"},"errors":[]}}}`}
+	})
+
+	var got struct {
+		CreateBoard struct {
+			Board *struct {
+				ID string `json:"id"`
+			} `json:"board"`
+			Errors []string `json:"errors"`
+		} `json:"createBoard"`
+	}
+	err := runGraphQL(t.Context(), client, boardMutation, map[string]any{"groupPath": "g", "name": "b"}, &got)
+	if err != nil {
+		t.Fatalf("runGraphQL() error = %v, want nil", err)
+	}
+	if got.CreateBoard.Board == nil || got.CreateBoard.Board.ID != "gid://gitlab/Board/7" {
+		t.Errorf("decoded %+v, want the board the stub answered", got.CreateBoard)
+	}
+	if sent := len(stub.graphqlDocuments); sent != 1 || !strings.Contains(stub.graphqlDocuments[0], "createBoard") {
+		t.Errorf("the stub was sent %d document(s), want exactly the board mutation", sent)
+	}
+}

--- a/test/e2e/internal/fixture/epic.go
+++ b/test/e2e/internal/fixture/epic.go
@@ -1,0 +1,47 @@
+//go:build e2e
+
+// epic.go builds an epic, which GitLab 19 offers only as a work item: the
+// REST epics API is gone there, so the builder goes through client-go's work
+// item service, the same route the epic tools take. An epic goes with its
+// group, so nothing is registered.
+
+package fixture
+
+import (
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// Epic is an epic a builder created in a group.
+type Epic struct {
+	// IID is the group-scoped number every epic action takes.
+	IID int64
+	// ID is the instance-wide identifier.
+	ID int64
+	// Title is what it was created with.
+	Title string
+	// GroupPath is the full path of the group it belongs to, which is what
+	// the epic actions name the group by.
+	GroupPath string
+}
+
+// NewEpic creates an epic in the group. Epics are a licensed feature, and a
+// package that runs on an unlicensed instance never reaches this builder:
+// the harness refuses a Premium action before it is sent.
+func NewEpic(e *harness.Env, group Group, title string) Epic {
+	e.T.Helper()
+
+	epic, err := retryTransient(e, "create epic "+title, createRetries, func() (Epic, error) {
+		created, _, err := e.Client().GL().WorkItems.CreateWorkItem(group.Path, gl.WorkItemTypeEpic,
+			&gl.CreateWorkItemOptions{Title: title}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return Epic{}, err
+		}
+		return Epic{IID: created.IID, ID: created.ID, Title: created.Title, GroupPath: group.Path}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating epic %q in group %s: %v", title, group.Path, err)
+	}
+	return epic
+}

--- a/test/e2e/internal/fixture/facts.go
+++ b/test/e2e/internal/fixture/facts.go
@@ -11,7 +11,13 @@
 
 package fixture
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
 
 // NonSQLMetricsUnserved reports whether err is the answer GitLab 19 CE gives
 // on the usage-data non-SQL metrics endpoint: a 404, even with its feature
@@ -20,4 +26,29 @@ import "net/http"
 // that serves the endpoint, since it then gets no error to classify.
 func NonSQLMetricsUnserved(err error) bool {
 	return IsStatus(err, http.StatusNotFound)
+}
+
+// legacyEpicRESTRemovedMajor is the GitLab release that removed the epic
+// REST endpoints: epics became work items, and the routes the resource
+// event actions of an epic reach answer 404 there whatever the tier.
+const legacyEpicRESTRemovedMajor = 19
+
+// LegacyEpicRESTRemoved reports whether the instance this run targets has
+// no epic REST endpoints any more. A test of an epic's resource events
+// asserts the documented refusal on such a release and the events
+// themselves on an earlier one, and says which it did.
+func LegacyEpicRESTRemoved(e *harness.Env) bool {
+	return MajorVersion(e.Runtime().Version) >= legacyEpicRESTRemovedMajor
+}
+
+// MajorVersion reads the major number off a GitLab version string such as
+// "19.3.1-ee" or "18.11.0". A string with no leading number reads as zero,
+// which is below every release and so claims nothing about it.
+func MajorVersion(version string) int {
+	major, _, _ := strings.Cut(strings.TrimSpace(version), ".")
+	number, err := strconv.Atoi(major)
+	if err != nil || number < 0 {
+		return 0
+	}
+	return number
 }

--- a/test/e2e/internal/fixture/facts_test.go
+++ b/test/e2e/internal/fixture/facts_test.go
@@ -10,6 +10,33 @@ import (
 	"testing"
 )
 
+// TestMajorVersion_Strings_ReadsTheLeadingNumber checks the version reader
+// on what GET /api/v4/version answers, on the edition suffix, and on the
+// strings it must read as nothing: a version that claims nothing is below
+// every release, so a fact gated on a major never fires on it by accident.
+func TestMajorVersion_Strings_ReadsTheLeadingNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		want    int
+	}{
+		{name: "enterprise", version: "19.3.1-ee", want: 19},
+		{name: "community", version: "18.11.0", want: 18},
+		{name: "padded", version: " 17.0.0 ", want: 17},
+		{name: "major only", version: "20", want: 20},
+		{name: "empty", version: "", want: 0},
+		{name: "not a number", version: "unknown", want: 0},
+		{name: "negative", version: "-1.0", want: 0},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := MajorVersion(testCase.version); got != testCase.want {
+				t.Errorf("MajorVersion(%q) = %d, want %d", testCase.version, got, testCase.want)
+			}
+		})
+	}
+}
+
 // TestNonSQLMetricsUnserved_Answers_MatchesOnlyTheDocumented404 checks the
 // predicate a test of the non-SQL metrics action asserts its error path
 // with.

--- a/test/e2e/internal/fixture/group.go
+++ b/test/e2e/internal/fixture/group.go
@@ -124,6 +124,23 @@ func groupOf(g *gl.Group) Group {
 	return Group{ID: g.ID, Path: g.FullPath, Name: g.Name, ParentID: g.ParentID}
 }
 
+// AddGroupMember makes user a member of the group at the given access
+// level. The membership goes with the group, so nothing is registered.
+func AddGroupMember(e *harness.Env, group Group, user User, accessLevel gl.AccessLevelValue) {
+	e.T.Helper()
+
+	_, err := retryTransient(e, "add group member "+user.Username, createRetries, func() (struct{}, error) {
+		_, _, err := e.Client().GL().GroupMembers.AddGroupMember(group.ID, &gl.AddGroupMemberOptions{
+			UserID:      new(user.ID),
+			AccessLevel: new(accessLevel),
+		}, gl.WithContext(e.Ctx))
+		return struct{}{}, err
+	})
+	if err != nil {
+		e.T.Fatalf("adding user %s to group %d: %v", user.Username, group.ID, err)
+	}
+}
+
 // DeleteGroup removes a group permanently, with everything under it.
 //
 // It follows the project's two steps for the same reason: an instance with

--- a/test/e2e/internal/fixture/group_tracker.go
+++ b/test/e2e/internal/fixture/group_tracker.go
@@ -1,0 +1,87 @@
+//go:build e2e
+
+// group_tracker.go builds the objects that hang off a group's issue tracker
+// rather than a project's: a group label and a group milestone. Both go
+// with the group, so neither registers a deletion of its own.
+
+package fixture
+
+import (
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// GroupLabel is a group label a builder created.
+type GroupLabel struct {
+	// ID is what a label-backed board list and an epic's label ids take.
+	ID int64
+	// Name is what a label filter takes.
+	Name string
+	// Color is the hex color it was created with.
+	Color string
+}
+
+// GroupMilestone is a group milestone a builder created.
+type GroupMilestone struct {
+	// ID is the instance-wide identifier.
+	ID int64
+	// IID is the group-scoped identifier every group milestone action takes.
+	IID int64
+	// Title is what it was created with.
+	Title string
+}
+
+// groupMilestoneLength is how long a fixture group milestone runs. It starts
+// today, so a burndown chart has a window to report on.
+const groupMilestoneLength = 14 * 24 * time.Hour
+
+// NewGroupLabel creates a group label named with the run's own scoping.
+func NewGroupLabel(e *harness.Env, group Group, prefix string) GroupLabel {
+	e.T.Helper()
+
+	name := e.Name(prefix)
+	label, err := retryTransient(e, "create group label "+name, createRetries, func() (GroupLabel, error) {
+		created, _, err := e.Client().GL().GroupLabels.CreateGroupLabel(group.ID, &gl.CreateGroupLabelOptions{
+			Name:        new(name),
+			Color:       new(labelColor),
+			Description: new("e2e: " + e.T.Name()),
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return GroupLabel{}, err
+		}
+		return GroupLabel{ID: created.ID, Name: created.Name, Color: created.Color}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating group label %q in group %d: %v", name, group.ID, err)
+	}
+	return label
+}
+
+// NewGroupMilestone creates a group milestone titled with the run's own
+// scoping, running from today for two weeks.
+func NewGroupMilestone(e *harness.Env, group Group, prefix string) GroupMilestone {
+	e.T.Helper()
+
+	title := e.Name(prefix)
+	start := gl.ISOTime(time.Now().UTC())
+	due := gl.ISOTime(time.Now().UTC().Add(groupMilestoneLength))
+	milestone, err := retryTransient(e, "create group milestone "+title, createRetries, func() (GroupMilestone, error) {
+		created, _, err := e.Client().GL().GroupMilestones.CreateGroupMilestone(group.ID, &gl.CreateGroupMilestoneOptions{
+			Title:       new(title),
+			Description: new("e2e: " + e.T.Name()),
+			StartDate:   &start,
+			DueDate:     &due,
+		}, gl.WithContext(e.Ctx))
+		if err != nil {
+			return GroupMilestone{}, err
+		}
+		return GroupMilestone{ID: created.ID, IID: created.IID, Title: created.Title}, nil
+	})
+	if err != nil {
+		e.T.Fatalf("creating group milestone %q in group %d: %v", title, group.ID, err)
+	}
+	return milestone
+}

--- a/test/e2e/internal/fixture/hook.go
+++ b/test/e2e/internal/fixture/hook.go
@@ -1,0 +1,85 @@
+//go:build e2e
+
+// hook.go reads what GitLab recorded about a webhook's deliveries, which
+// client-go offers no method for: the events endpoint is reached through the
+// SDK's own request plumbing, the way the server reaches an endpoint the SDK
+// has no wrapper for.
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// hookEventWait bounds the wait for a delivery to be recorded: GitLab
+// delivers a test event through Sidekiq, and the fixture service answers
+// it at once.
+const hookEventWait = 60 * time.Second
+
+// hookEventPollInterval is how often the recorded deliveries are read; a
+// variable so the package's own tests can ask faster than Sidekiq delivers.
+var hookEventPollInterval = 2 * time.Second
+
+// hookEvent is the one field of a recorded delivery a test needs.
+type hookEvent struct {
+	ID int64 `json:"id"`
+}
+
+// WaitForGroupHookEvent waits until GitLab has recorded a delivery of the
+// group hook and returns the first one's ID, failing the test when none is
+// recorded within the budget. A hook whose test trigger has just been fired
+// has a delivery a moment later, once Sidekiq has run it.
+func WaitForGroupHookEvent(e *harness.Env, group Group, hookID int64) int64 {
+	e.T.Helper()
+
+	id, err := firstGroupHookEvent(e.Ctx, e.Client(), group.ID, hookID)
+	if err != nil {
+		e.T.Fatalf("waiting for a delivery of hook %d of group %d: %v", hookID, group.ID, err)
+	}
+	return id
+}
+
+// firstGroupHookEvent is WaitForGroupHookEvent without the test, so the
+// package's own tests can drive it against a stub.
+func firstGroupHookEvent(ctx context.Context, client *gitlabclient.Client, groupID, hookID int64) (int64, error) {
+	var first int64
+	err := harness.Poll(ctx, hookEventPollInterval, hookEventWait, func() (bool, string, error) {
+		events, err := listGroupHookEvents(ctx, client, groupID, hookID)
+		if err != nil {
+			// The endpoint answers a 404 until the first delivery exists on
+			// some releases, so an error is a state to wait through.
+			return false, fmt.Sprintf("the hook events endpoint answered: %v", err), nil
+		}
+		if len(events) == 0 {
+			return false, "no delivery recorded yet", nil
+		}
+		first = events[0].ID
+		return true, "", nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return first, nil
+}
+
+// listGroupHookEvents reads the recorded deliveries of one group hook.
+func listGroupHookEvents(ctx context.Context, client *gitlabclient.Client, groupID, hookID int64) ([]hookEvent, error) {
+	request, err := client.GL().NewRequest(http.MethodGet, fmt.Sprintf("groups/%d/hooks/%d/events", groupID, hookID),
+		nil, []gl.RequestOptionFunc{gl.WithContext(ctx)})
+	if err != nil {
+		return nil, fmt.Errorf("building the hook events request: %w", err)
+	}
+	var events []hookEvent
+	if _, err = client.GL().Do(request, &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}

--- a/test/e2e/internal/fixture/hook_test.go
+++ b/test/e2e/internal/fixture/hook_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+
+// hook_test.go drives the hook events reader against the stub: a listing
+// that is empty at first and holds a delivery later, the 404 GitLab answers
+// before any delivery exists, and a budget that runs out.
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/test/e2e/internal/harness"
+)
+
+// fastHookPolls makes the reader ask the stub as fast as a unit test can
+// afford, restoring the real cadence afterwards.
+func fastHookPolls(t *testing.T) {
+	t.Helper()
+	saved := hookEventPollInterval
+	hookEventPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { hookEventPollInterval = saved })
+}
+
+// TestFirstGroupHookEvent_DeliveryRecordedLater_ReturnsItsID checks that
+// the reader waits through an empty listing and through a 404 and answers
+// the first delivery once GitLab records one.
+func TestFirstGroupHookEvent_DeliveryRecordedLater_ReturnsItsID(t *testing.T) {
+	fastHookPolls(t)
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.hookEventAnswers = []string{"not yet", `[]`, `[{"id":31},{"id":32}]`}
+	})
+
+	got, err := firstGroupHookEvent(t.Context(), client, 4, 9)
+	if err != nil {
+		t.Fatalf("firstGroupHookEvent() error = %v, want nil", err)
+	}
+	if got != 31 {
+		t.Errorf("firstGroupHookEvent() = %d, want the first delivery, 31", got)
+	}
+}
+
+// TestFirstGroupHookEvent_NothingRecorded_TimesOutNamingTheState checks
+// that a hook nothing was ever delivered for ends with the poll's timeout
+// and the last state seen, rather than with a zero the caller would send
+// on as an event id.
+func TestFirstGroupHookEvent_NothingRecorded_TimesOutNamingTheState(t *testing.T) {
+	fastHookPolls(t)
+	stub, client := newStubGitLab(t)
+	stub.configure(func() {
+		stub.hookEventAnswers = []string{`[]`}
+	})
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	got, err := firstGroupHookEvent(ctx, client, 4, 9)
+	if got != 0 {
+		t.Errorf("firstGroupHookEvent() = %d, want 0 when nothing was recorded", got)
+	}
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, harness.ErrPollTimeout) {
+		t.Errorf("firstGroupHookEvent() error = %v, want the wait to run out", err)
+	}
+}

--- a/test/e2e/internal/fixture/stub_test.go
+++ b/test/e2e/internal/fixture/stub_test.go
@@ -79,6 +79,11 @@ type stubGitLab struct {
 	graphqlAnswers []string
 	// graphqlDocuments records every document the stub was sent.
 	graphqlDocuments []string
+	// hookEventAnswers are the raw bodies of the hook events listing,
+	// answered one per read, the last repeating; a body that is not JSON is
+	// answered as a 404, which is how a real GitLab answers before the
+	// first delivery on some releases.
+	hookEventAnswers []string
 
 	server *httptest.Server
 }
@@ -109,6 +114,7 @@ func newStubGitLab(t *testing.T) (*stubGitLab, *gitlabclient.Client) {
 	mux.HandleFunc("/api/v4/projects/{id}/issues/{iid}", stub.stateAnswer)
 	mux.HandleFunc("/api/v4/projects/{id}/labels/{label}", stub.stateAnswer)
 	mux.HandleFunc("/api/v4/projects/{id}/milestones/{milestone}", stub.stateAnswer)
+	mux.HandleFunc("/api/v4/groups/{id}/hooks/{hook}/events", stub.hookEvents)
 	mux.HandleFunc("/api/graphql", stub.graphql)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("stub GitLab: unexpected %s %s", r.Method, r.URL.Path)
@@ -444,6 +450,21 @@ func (s *stubGitLab) graphql(w http.ResponseWriter, r *http.Request) {
 	}
 	s.graphqlDocuments = append(s.graphqlDocuments, document.Query)
 	body := nextStatus(&s.graphqlAnswers)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(body))
+}
+
+// hookEvents answers the next scripted hook events body, or a 404 for a
+// body that is not JSON.
+func (s *stubGitLab) hookEvents(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	body := nextStatus(&s.hookEventAnswers)
+	if !json.Valid([]byte(body)) {
+		writeError(w, http.StatusNotFound, "404 Not Found")
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(body))

--- a/test/e2e/internal/harness/call.go
+++ b/test/e2e/internal/harness/call.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -616,6 +617,12 @@ func safeModePreview(result *mcp.CallToolResult, text string) (string, bool) {
 	return "", false
 }
 
+// answeredStatus matches the status client-go writes after the request it
+// made, "METHOD URL: 404 body", which is the one GitLab actually answered. It
+// asks for the colon and the space around the number so that a group or a
+// project whose id happens to be 404 is not read as a refusal.
+var answeredStatus = regexp.MustCompile(`: (40[134])\b`)
+
 // classifyToolError names the class an error result falls into, from the text
 // the server put in it.
 //
@@ -624,6 +631,12 @@ func safeModePreview(result *mcp.CallToolResult, text string) (string, bool) {
 // than in the result, so the only thing a client holds at the moment it has to
 // classify is the message, and a test that named no class at all could not
 // tell a refused confirmation from a 404.
+//
+// GitLab's own status is read off the last one the text answers with, and
+// only then off the words: the hints this server writes name the statuses an
+// endpoint can answer ("can return 401 or 404"), and a 401 refusal whose hint
+// mentioned 404 used to be classified as not found on the strength of the
+// hint alone.
 func classifyToolError(text string) Failure {
 	lowered := strings.ToLower(text)
 	switch {
@@ -644,10 +657,17 @@ func classifyToolError(text string) Failure {
 		// dispatcher, and reads as the same class as a dispatcher refusing it.
 		strings.Contains(lowered, `validating "arguments"`):
 		return FailureInvalidParams
-	case strings.Contains(lowered, "404"), strings.Contains(lowered, "not found"):
+	}
+	if answered := answeredStatus.FindAllStringSubmatch(lowered, -1); len(answered) > 0 {
+		if answered[len(answered)-1][1] == "404" {
+			return FailureNotFound
+		}
+		return FailureForbidden
+	}
+	switch {
+	case strings.Contains(lowered, "not found"):
 		return FailureNotFound
-	case strings.Contains(lowered, "403"), strings.Contains(lowered, "401"),
-		strings.Contains(lowered, "forbidden"), strings.Contains(lowered, "unauthorized"):
+	case strings.Contains(lowered, "forbidden"), strings.Contains(lowered, "unauthorized"):
 		return FailureForbidden
 	default:
 		return FailureToolError

--- a/test/e2e/internal/harness/call_test.go
+++ b/test/e2e/internal/harness/call_test.go
@@ -104,6 +104,28 @@ func TestClassify_EveryRefusal_LandsInItsOwnClass(t *testing.T) {
 			wantOutcome: e2ecalls.RefusedOutcome(string(FailureForbidden)),
 		},
 		{
+			// The status GitLab answered decides, not the ones the hint
+			// names: this hint mentions 404 and the answer was 401.
+			name:        "the hint names other statuses",
+			text:        "list group SAML links: authentication failed. Suggestion: self-managed instances without SAML SSO can return 401 or 404: GET http://gitlab.example/api/v4/groups/117/saml_group_links: 401 {message: 401 Unauthorized}",
+			wantFailure: FailureForbidden,
+			wantOutcome: e2ecalls.RefusedOutcome(string(FailureForbidden)),
+		},
+		{
+			// A number in the request's path is not a status.
+			name:        "the path carries a status-like number",
+			text:        "set hook variable: GitLab rejected the request: PUT http://gitlab.example/api/v4/groups/404/hooks/403/url_variables/x: 422 {error: Illegal key or value}",
+			wantFailure: FailureToolError,
+			wantOutcome: e2ecalls.OutcomeToolError,
+		},
+		{
+			// The individual surface's not-found card names no status.
+			name:        "not found card",
+			text:        "## Snippet Not Found\n\nThe snippet **12** does not exist or is not accessible with your current permissions.",
+			wantFailure: FailureNotFound,
+			wantOutcome: e2ecalls.RefusedOutcome(string(FailureNotFound)),
+		},
+		{
 			name:        "anything else",
 			text:        "create branch: branch already exists",
 			wantFailure: FailureToolError,


### PR DESCRIPTION
Step S14 of the e2e rebuild (issue 704), second half: the group and epic families of the old EE suite, the stranded group code, and the whole-step verification.

The scenarios of the 15 old group and epic `_ee_test.go` files (25 Test functions: epics, epic notes, discussions, issues, links and boards, group boards and label events, wikis, LDAP, SAML, SSH certificates, protected branches and environments, push rules, billable and provisioned members, hook extras, service accounts, iterations, work items, the Ultimate group create fields) are rewritten against the harness, together with the subtrees of `TestEE_MetaGroupEnterpriseOperations` and the group milestone burndown that sat behind an enterprise guard in a CE file. Premium and Ultimate actions live in `test/e2e/gitlab/ee`; the Free ones the old tests reached, including the state they built (group and project lifecycles, members, branches, commits, merge requests, environments, issues, pipelines, snippets), are scenarios of their own in `common`, because the baseline superset check credits what the old suite reached and a fixture builder leaves no credit.

This closes the EE port: `-port-map` resolves all 74 old EE Test functions (86 replaced, 9 dropped, every drop a unit test of the old suite's own baseline recorder, superseded by the harness recorder), and the licensed run reaches every credit the S09 baseline reached, 312 of 312 with nothing lost; L1 263 asserted on `ee`, all 20 stranded actions asserted on the three surfaces.

Three defects found. `group.group_board_delete` was tagged Free and is Premium (the docs and `boards_responses.rb` guard the delete as they guard the create), so the Free catalog is 869 dynamic actions and 865 individual tools; the harness classified a refusal by any status a hint mentioned, and now reads the status GitLab answered with, since the SAML refusals came back 401 with a hint naming 404; and client-go v3.0.0's work item get, create and update documents select five licensed widgets a Community image's schema lacks, with no caller option that changes the document, which is entry 45 of the upstream register and why the work item lifecycle skips on Community naming it.

Fixture additions: `NewEpic` over the work items API, `NewGroupBoard` over the `createBoard` mutation (the REST create is the Premium route), `NewGroupLabel`, `NewGroupMilestone`, `AddGroupMember`, `WaitForGroupHookEvent`, `LegacyEpicRESTRemoved` and `MajorVersion`. Verified on truenas: `make test-e2e-ee` 379 tests and no failure, twice; `make test-e2e-ce` 120 tests, one skip with the register's reason; `-baseline dist/e2e-calls/baseline-ee -check` passed; `-static` clean.
