### PR TITLE
build(e2e): remove the enterprise analysis pass and every mention of the tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,15 +397,12 @@ jobs:
           go-version-file: go.mod
       - run: go mod download
       - run: go build -o /dev/null ./cmd/server
+      # One compile sees the whole of the old suite now that every file in it
+      # carries `e2e` alone. It used to take two, because its Enterprise half
+      # sat behind a second tag that excluded the other half; that half was
+      # ported to test/e2e/gitlab/ee and deleted, and the second compile with it.
       - name: Verify E2E tests compile
         run: go test -tags e2e -c -o /dev/null ./test/e2e/suite/
-      # A second compile rather than a second tag on the line above: the
-      # suite's *_ce_test.go and *_ee_test.go files exclude each other, so one
-      # compile sees one half and never the other. Between the day the first
-      # _ee_test.go was written and issue 570, nothing compiled the 41 EE files
-      # except a person running make test-e2e-docker-enterprise by hand.
-      - name: Verify the Enterprise E2E tests compile
-        run: go test -tags "e2e enterprise" -c -o /dev/null ./test/e2e/suite/
       # The harness is the library every rebuilt e2e test goes through, and its
       # own tests need no GitLab: the ledger, the waits, the names, the runtime
       # guard's message, the environment a child is given, and one run of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,8 +180,7 @@ gitlab-mcp-server/
 │   ├── scripts/                 # E2E provisioning scripts (setup, runner, wait, Bitbucket, EE activation)
 │   └── suite/                   # Go test package (172 test files)
 │       ├── setup_test.go        # MCP server/client setup, test helpers, shared state
-│       └── fixture_ce_test.go   # Self-contained GitLab resource builders (CE runtime)
-│       └── fixture_ee_test.go   # Self-contained GitLab resource builders (EE runtime)
+│       └── fixture_ce_test.go   # Self-contained GitLab resource builders; the EE half was ported to test/e2e/gitlab/ee and deleted
 ├── plan/                        # Implementation plans for features
 ├── mcpb/                        # Claude Desktop extension (.mcpb) manifest + icon (packed by scripts/build-mcpb.sh)
 ├── .github/                     # AI assistance infrastructure
@@ -913,7 +912,7 @@ docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v
 The suite is one test file per domain (172 files), each self-contained against the shared fixture from `setup_test.go`, in three families named by the surface they drive:
 
 - **`TestIndividual_*`**: the individual surface (`gitlab_issue_list`-style tools) through each domain's lifecycle: user, project CRUD, commits, branches, tags, releases, issues, labels, milestones, members, upload, MR lifecycle, notes, discussions, search, groups, pipelines, packages, elicitation, cleanup
-- **`TestMeta_*`**: the same operations through the meta-tools, plus the domains only reachable there (admin, epics, group extras, wikis, CI variables, CI lint, environments, issue links, deploy keys, snippets, issue discussions, draft notes, pipeline schedules, badges, access tokens, award emoji); `TestEE_*` covers the Enterprise-only ones on an EE runtime
+- **`TestMeta_*`**: the same operations through the meta-tools, plus the domains only reachable there (admin, epics, group extras, wikis, CI variables, CI lint, environments, issue links, deploy keys, snippets, issue discussions, draft notes, pipeline schedules, badges, access tokens, award emoji). The Enterprise-only ones are no longer here: their `TestEE_*` half was ported to `test/e2e/gitlab/ee`, the rebuilt suite's licensed package, and deleted with the build tag that used to select it, so `make test-e2e-ee` (or its older name `make test-e2e-docker-enterprise`) is where they run
 - **`TestDynamicToolSurface_*`**: the default dynamic two-tool find/execute surface, including standalone project discovery, multi-intent discovery, and destructive-action confirmation guards. Run only this family in Docker mode after the Docker GitLab setup scripts complete:
 
 	```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@
 
 | Metric                    | Count                                                                                                        |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| MCP Tools (individual)    | By instance tier: ~866 Free/CE; ~1019 Premium; ~1085 Ultimate (self-managed) / ~1091 on GitLab.com Ultimate with Orbit |
+| MCP Tools (individual)    | By instance tier: ~865 Free/CE; ~1019 Premium; ~1085 Ultimate (self-managed) / ~1091 on GitLab.com Ultimate with Orbit |
 | Catalog groups            | By instance tier: 29 Free/CE; 35 Premium; 46 Ultimate                                                       |
 | Meta-mode tools           | 34 base (Free/CE) / 40 Premium / 51 self-managed Ultimate / 52 GitLab.com Ultimate (Orbit); `gitlab_server` is served on every one of them and is counted here |
 | Dynamic-mode tools        | 2 dynamic tools (`gitlab_find_action`, `gitlab_execute_action`) — see Dynamic toolset mode below |
@@ -737,7 +737,7 @@ ADRs document key decisions in `docs/development/adr`:
 
 | ADR      | Decision                                                       | Status                                       |
 | -------- | -------------------------------------------------------------- | -------------------------------------------- |
-| ADR-0004 | Modular sub-packages under `internal/tools/{domain}/`          | Accepted (179 `internal/tools` packages; tools by tier: ~866 Free/CE, ~1019 Premium, ~1085 Ultimate self-managed, ~1091 GitLab.com Ultimate) |
+| ADR-0004 | Modular sub-packages under `internal/tools/{domain}/`          | Accepted (179 `internal/tools` packages; tools by tier: ~865 Free/CE, ~1019 Premium, ~1085 Ultimate self-managed, ~1091 GitLab.com Ultimate) |
 | ADR-0005 | Meta-tool consolidation into a compact domain catalog          | Accepted (refines ADR-0004; its runtime mechanics are superseded by the catalog-first architecture of ADR-0014) |
 | ADR-0006 | Raw GraphQL.Do() for domains without client-go service wrappers | Accepted (7 GraphQL-only domains)             |
 | ADR-0007 | Rich error semantics for LLM-actionable diagnostics            | Accepted (WrapErrWithMessage, WrapErrWithHint) |

--- a/Makefile
+++ b/Makefile
@@ -42,24 +42,15 @@ GO_ANALYSIS_PKGS=./...
 # Every e2e build tag, and it must stay every one. A tagged file is invisible
 # to go vet and to golangci-lint unless its tag is listed here, so a suite
 # added behind a new tag is analysed by nothing until it is added. That has
-# happened four times: `httpe2e` was missing until the HTTP suite broke CI,
-# `stdioe2e` until the stdio suite did, `orbitlive` had never been listed
-# at all, so test/e2e/orbit had gone unlinted since it was written, and
-# `enterprise` (below) left the 41 Enterprise files of test/e2e/suite
-# unanalysed from the day the first was written until issue 570. The same
-# list lives in cmd/gen_testing_docs as e2eTags, for the same reason.
+# happened three times: `httpe2e` was missing until the HTTP suite broke CI,
+# `stdioe2e` until the stdio suite did, and `orbitlive` had never been listed
+# at all, so test/e2e/orbit had gone unlinted since it was written. The same
+# list lives in cmd/gen_testing_docs as e2eTags, for the same reason. Every
+# file under test/e2e/suite, test/e2e/gitlab and test/e2e/internal carries
+# `e2e` and nothing else, so this one list is the whole of what the analysis
+# has to know: no package under test/e2e selects between two file sets any
+# more, and one run sees all of them.
 GO_ANALYSIS_TAGS=e2e,collectore2e,httpe2e,orbitlive,stdioe2e
-# `enterprise` is not one more entry in that list, because it is not one more
-# suite: it selects between two runtimes of the same package. Every
-# *_ce_test.go in test/e2e/suite carries `e2e && !enterprise` and every
-# *_ee_test.go carries `e2e && enterprise`, so one analysis run sees one half
-# and never the other, and adding the tag above would trade the 128 CE files
-# for the 41 EE ones. The EE half therefore gets a run of its own, scoped to
-# the one package the tag reaches. That run is what found nineteen helpers
-# and four constants only CE tests use sitting in files both halves compile,
-# unused under the EE tag: nothing had ever compiled that combination.
-GO_ANALYSIS_ENTERPRISE_TAGS=$(GO_ANALYSIS_TAGS),enterprise
-GO_ANALYSIS_ENTERPRISE_PKGS=./test/e2e/suite/
 PROJECT_GO_VERSION := $(shell awk '/^go / {print $$2; exit}' go.mod)
 GO_TOOLCHAIN ?= go$(PROJECT_GO_VERSION)
 export GOTOOLCHAIN := $(GO_TOOLCHAIN)
@@ -102,6 +93,10 @@ ORBIT_FIXTURES_INDEXER_TIMEOUT ?= 600
 # When set to "true", additionally mirror gitlab-org/cli for realistic
 # cross-entity CI/MR data. Adds ~5 min of mirror time on first run.
 ORBIT_FIXTURES_MIRROR ?= false
+# The -timeout handed to go test by the licensed Docker run, test-e2e-ee. go
+# test applies it to each test binary on its own, so with the run naming two
+# packages, common and ee, each package gets the whole budget rather than the
+# two sharing it. E2E_GITLAB_TIMEOUT below is the same flag for the CE run.
 E2E_DOCKER_ENTERPRISE_TIMEOUT ?= 3600s
 # Where the e2e Docker fixture is reached from the machine running the suite.
 # Docker itself follows DOCKER_HOST or the active context, so the fixture can
@@ -339,6 +334,8 @@ test-e2e-docker: ensure-gotestsum
 # The server binary is built once and handed to every package through
 # E2E_SERVER_BINARY, so the three test binaries do not each build cmd/server.
 E2E_SERVER_BINARY=dist/e2e/$(BINARY_NAME)$(BINARY_EXT)
+# Per package binary, like E2E_DOCKER_ENTERPRISE_TIMEOUT above: common and ce
+# each get the whole of it.
 E2E_GITLAB_TIMEOUT ?= 1800s
 
 ## e2e-server-binary: build the server the rebuilt e2e suite drives, once for every package.
@@ -363,10 +360,10 @@ test-e2e-ee: ensure-gotestsum e2e-server-binary
 	./test/e2e/scripts/run-docker-e2e.sh ee -- -timeout $(E2E_DOCKER_ENTERPRISE_TIMEOUT) ./test/e2e/gitlab/common/ ./test/e2e/gitlab/ee/
 
 ## test-e2e-docker-enterprise: the licensed Docker run under its older name; an alias of test-e2e-ee.
-# The files it used to run, the `enterprise`-tagged half of test/e2e/suite,
-# were deleted once every one of their tests had a successor under
-# test/e2e/gitlab/ee, so the licensed run is the rebuilt suite's and this
-# name keeps working for anything that still spells it.
+# The files it used to run, the Enterprise half of test/e2e/suite behind a
+# build tag of its own, were deleted once every one of their tests had a
+# successor under test/e2e/gitlab/ee, so the licensed run is the rebuilt
+# suite's and this name keeps working for anything that still spells it.
 test-e2e-docker-enterprise: test-e2e-ee
 
 ## test-e2e-gitlab: run the rebuilt suite against a self-hosted GitLab (reads GITLAB_URL, GITLAB_TOKEN from .env); a package the instance cannot serve skips.
@@ -591,8 +588,6 @@ golangci-lint:
 	golangci-lint fmt --diff
 	@echo === golangci-lint run ===
 	golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS)
-	@echo === golangci-lint run, Enterprise half of the e2e suite ===
-	golangci-lint run --build-tags $(GO_ANALYSIS_ENTERPRISE_TAGS) $(GO_ANALYSIS_ENTERPRISE_PKGS)
 
 ## govulncheck: scan Go dependencies for known CVEs using call-graph analysis.
 ## Only reports vulnerabilities where the vulnerable function is actually called.
@@ -680,24 +675,22 @@ analyze:
 	echo "Go toolchain: $$GOTOOLCHAIN (go.mod: $(PROJECT_GO_VERSION))"; \
 	echo "Go analysis packages: $(GO_ANALYSIS_PKGS)"; \
 	echo "Go analysis build tags: $(GO_ANALYSIS_TAGS)"; \
-	echo "Enterprise e2e analysis: $(GO_ANALYSIS_ENTERPRISE_PKGS) with $(GO_ANALYSIS_ENTERPRISE_TAGS)"; \
 	echo ""; \
-	run_check "[1/16] golangci-lint config verify" golangci-lint config verify; \
-	run_check "[2/16] golangci-lint fmt" golangci-lint fmt --diff; \
-	run_check "[3/16] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[4/16] golangci-lint run (Enterprise e2e half)" golangci-lint run --build-tags $(GO_ANALYSIS_ENTERPRISE_TAGS) $(GO_ANALYSIS_ENTERPRISE_PKGS); \
-	run_check "[5/16] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[6/16] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
-	run_check "[7/16] test-goroutine aborts" go run ./cmd/audit_test_goroutines --check; \
-	run_check "[8/16] case loops without subtests" go run ./cmd/audit_test_subtests --check; \
-	run_check "[9/16] supply-chain policy" go run ./cmd/audit_supply_chain; \
-	run_check "[10/16] Markdown escaping" go run ./cmd/audit_md_escaping --check -fail-unresolved-in internal/toolutil; \
-	run_check "[11/16] pinned GraphQL schema" go run ./cmd/gen_graphql_schema/ --check; \
-	run_check "[12/16] GraphQL documents" go run ./cmd/audit_graphql_documents/; \
-	run_check "[13/16] request paths (R-PATH)" go run ./cmd/audit_1to1/ -scope=paths -gaps-only; \
-	run_check "[14/16] meta descriptions" go run ./cmd/audit_meta_descriptions/ -check; \
-	run_check "[15/16] pinned live GitLab record" go run ./cmd/gen_api_live/ -check; \
-	run_check "[16/16] GraphQL response shapes" go run ./cmd/audit_graphql_shapes/; \
+	run_check "[1/15] golangci-lint config verify" golangci-lint config verify; \
+	run_check "[2/15] golangci-lint fmt" golangci-lint fmt --diff; \
+	run_check "[3/15] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[4/15] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[5/15] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
+	run_check "[6/15] test-goroutine aborts" go run ./cmd/audit_test_goroutines --check; \
+	run_check "[7/15] case loops without subtests" go run ./cmd/audit_test_subtests --check; \
+	run_check "[8/15] supply-chain policy" go run ./cmd/audit_supply_chain; \
+	run_check "[9/15] Markdown escaping" go run ./cmd/audit_md_escaping --check -fail-unresolved-in internal/toolutil; \
+	run_check "[10/15] pinned GraphQL schema" go run ./cmd/gen_graphql_schema/ --check; \
+	run_check "[11/15] GraphQL documents" go run ./cmd/audit_graphql_documents/; \
+	run_check "[12/15] request paths (R-PATH)" go run ./cmd/audit_1to1/ -scope=paths -gaps-only; \
+	run_check "[13/15] meta descriptions" go run ./cmd/audit_meta_descriptions/ -check; \
+	run_check "[14/15] pinned live GitLab record" go run ./cmd/gen_api_live/ -check; \
+	run_check "[15/15] GraphQL response shapes" go run ./cmd/audit_graphql_shapes/; \
 	echo "============================================================"; \
 	if [ "$$analysis_status" -ne 0 ]; then \
 		echo "Analysis failed. Review findings above."; \

--- a/README.md
+++ b/README.md
@@ -467,20 +467,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,277 |     282,589 |
-| Unit tests (`_test.go`)  |       779 |     466,475 |
-| End-to-end tests         |       369 |      84,572 |
-| **Total**                | **2,425** | **833,636** |
+| Source (`.go`, non-test) |     1,277 |     282,630 |
+| Unit tests (`_test.go`)  |       779 |     466,539 |
+| End-to-end tests         |       369 |      84,682 |
+| **Total**                | **2,425** | **833,851** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                | 10,438 |
+| Source functions                | 10,440 |
 | . Exported (public)             |  3,137 |
-| . Unexported (private)          |  7,301 |
-| Unit test functions (`TestXxx`) | 15,349 |
-| Subtests (`t.Run(...)`)         |  5,858 |
+| . Unexported (private)          |  7,303 |
+| Unit test functions (`TestXxx`) | 15,350 |
+| Subtests (`t.Run(...)`)         |  5,859 |
 | End-to-end test functions       |    935 |
 
 ### Ratios worth noting
@@ -490,7 +490,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.65× more tests than code |
 | Average source file length         |                 ~221 lines |
 | Average test file length           |                 ~599 lines |
-| Comment lines in source            |  56,211 (~19.9% of source) |
+| Comment lines in source            |  56,226 (~19.9% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -522,7 +522,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~5,137 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~5,138 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 15,414 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The server can present GitLab in three shapes, controlled by `GITLAB_MCP_TOOL_SU
 | ----------------------------- | ------------------------------------------------- | ---------------------------------------------------------------- |
 | **Dynamic** (default)         | 2 (`gitlab_find_action`, `gitlab_execute_action`) | Lowest token cost; reaches the full catalog via find/execute.    |
 | **Meta-tools** (`meta`)       | 34 base / 51 Ultimate / 52 GitLab.com Ultimate    | Domain-grouped dispatchers with an `action` parameter.           |
-| **Individual** (`individual`) | ~866 Free/CE · ~1019 Premium · 1085–1091 Ultimate | One MCP tool per GitLab operation; needs a large context window. |
+| **Individual** (`individual`) | ~865 Free/CE · ~1019 Premium · 1085–1091 Ultimate | One MCP tool per GitLab operation; needs a large context window. |
 
 Tool counts scale with your GitLab edition (`GITLAB_MCP_TIER`); higher tiers expose more actions. See [Dynamic Toolset](docs/concepts/dynamic-tools.md) and [Meta-Tools Reference](docs/concepts/meta-tools.md) for the ranking model, safety guards, and full catalogs. For dynamic runs where resources dominate context, set `GITLAB_MCP_CAPABILITY_SURFACE=minimal`.
 
@@ -275,8 +275,8 @@ Measured with `go run ./cmd/audit_tokens/ -footprint` against the current catalo
 
 | Configuration (`GITLAB_MCP_TOOL_SURFACE` / `GITLAB_MCP_CAPABILITY_SURFACE`) | Tier     | Visible tools | Reachable actions | `GITLAB_MCP_META_PARAM_SCHEMA` | Tool schema tokens | Shared tokens | Total tokens |
 | --------------------------------------------------------------------------- | -------- | ------------: | ----------------: | ------------------------------ | -----------------: | ------------: | -----------: |
-| `dynamic` / `full` (default)                                                | Free/CE  |             2 |               870 | n/a                            |              1,524 |         8,835 |       10,359 |
-| `dynamic` / `minimal`                                                       | Free/CE  |             2 |               870 | n/a                            |              1,524 |           170 |        1,694 |
+| `dynamic` / `full` (default)                                                | Free/CE  |             2 |               869 | n/a                            |              1,524 |         8,835 |       10,359 |
+| `dynamic` / `minimal`                                                       | Free/CE  |             2 |               869 | n/a                            |              1,524 |           170 |        1,694 |
 | `dynamic` / `full` (default)                                                | Premium  |             2 |             1,023 | n/a                            |              1,524 |         8,835 |       10,359 |
 | `dynamic` / `minimal`                                                       | Premium  |             2 |             1,023 | n/a                            |              1,524 |           170 |        1,694 |
 | `dynamic` / `full` (default)                                                | Ultimate |             2 |             1,089 | n/a                            |              1,524 |         8,835 |       10,359 |
@@ -467,21 +467,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,277 |     282,337 |
-| Unit tests (`_test.go`)  |       779 |     466,123 |
-| End-to-end tests         |       340 |      87,711 |
-| **Total**                | **2,396** | **836,171** |
+| Source (`.go`, non-test) |     1,277 |     282,589 |
+| Unit tests (`_test.go`)  |       779 |     466,475 |
+| End-to-end tests         |       369 |      84,572 |
+| **Total**                | **2,425** | **833,636** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                | 10,434 |
+| Source functions                | 10,438 |
 | . Exported (public)             |  3,137 |
-| . Unexported (private)          |  7,297 |
-| Unit test functions (`TestXxx`) | 15,339 |
-| Subtests (`t.Run(...)`)         |  6,177 |
-| End-to-end test functions       |    910 |
+| . Unexported (private)          |  7,301 |
+| Unit test functions (`TestXxx`) | 15,349 |
+| Subtests (`t.Run(...)`)         |  5,858 |
+| End-to-end test functions       |    935 |
 
 ### Ratios worth noting
 
@@ -489,18 +489,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.65× more tests than code |
 | Average source file length         |                 ~221 lines |
-| Average test file length           |                 ~598 lines |
-| Comment lines in source            |  56,120 (~19.9% of source) |
+| Average test file length           |                 ~599 lines |
+| Comment lines in source            |  56,211 (~19.9% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 8,554 |
-| `defer` statements                 | 1,483 |
+| `if err != nil` checks             | 8,559 |
+| `defer` statements                 | 1,408 |
 | `struct` types defined             | 3,322 |
-| `//nolint` suppressions            |   358 |
+| `//nolint` suppressions            |   350 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
@@ -522,8 +522,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~5,133 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 15,410 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~5,137 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 15,414 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_e2e_coverage/baseline.go
+++ b/cmd/audit_e2e_coverage/baseline.go
@@ -18,6 +18,12 @@ const baselineResultsSuffix = ".results.json"
 // directory has no results stream beside it.
 var errBaselineUnjudged = errors.New("the baseline carries no test verdicts and no results stream sits beside it")
 
+// errBaselineStreamMismatch is a results stream that sits beside the baseline
+// and judges none, or not all, of the tests its calls name: a stream from
+// another run, which would leave the calls unjudged and the comparison
+// vacuous.
+var errBaselineStreamMismatch = errors.New("the results stream beside the baseline does not judge the tests its calls name")
+
 // joinBaselineResults gives every baseline runtime its verdicts, so that the
 // comparison has something to compare against.
 //
@@ -29,7 +35,12 @@ var errBaselineUnjudged = errors.New("the baseline carries no test verdicts and 
 // which is exactly the silence it exists to refuse. A baseline whose calls
 // already carry verdicts, the way the harness writes them, needs no stream
 // and is left alone; one that carries none and has no stream is refused
-// rather than compared vacuously.
+// rather than compared vacuously. So is one whose stream judges none of the
+// tests the calls name, or leaves some of them without a verdict: that is a
+// stream from another run, and a stream that matches nothing would leave
+// the reached set empty and the superset check passing against nothing, the
+// same silence by another door. A call that names no test at all is a
+// cleanup the old suite could not attribute, and stays unjudged on purpose.
 func joinBaselineResults(runtimes []*runtimeRecords) error {
 	for _, rt := range runtimes {
 		if baselineJudged(rt) {
@@ -43,9 +54,36 @@ func joinBaselineResults(runtimes []*runtimeRecords) error {
 			}
 			return fmt.Errorf("%s: %w", rt.dir, err)
 		}
-		joinResults(rt, results)
+		join := joinResults(rt, results)
+		if unjudged := baselineUnjudgedCalls(rt); join.Filled == 0 || len(unjudged) > 0 {
+			return fmt.Errorf("%s: %w: %s judged %d call(s) and left %d naming a test without a verdict (first: %s)",
+				rt.dir, errBaselineStreamMismatch, path, join.Filled, len(unjudged), firstOrNone(unjudged))
+		}
 	}
 	return nil
+}
+
+// baselineUnjudgedCalls lists the tests named by calls that carry no verdict
+// after the join, each once.
+func baselineUnjudgedCalls(rt *runtimeRecords) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, call := range rt.calls {
+		if call.Test == "" || call.TestStatus != "" || seen[call.Test] {
+			continue
+		}
+		seen[call.Test] = true
+		names = append(names, call.Test)
+	}
+	return names
+}
+
+// firstOrNone renders the first of a list, or "none" for an empty one.
+func firstOrNone(names []string) string {
+	if len(names) == 0 {
+		return "none"
+	}
+	return names[0]
 }
 
 // baselineJudged reports whether any call of the runtime carries a verdict.

--- a/cmd/audit_e2e_coverage/baseline_test.go
+++ b/cmd/audit_e2e_coverage/baseline_test.go
@@ -110,6 +110,70 @@ func TestJoinBaselineResults_UnjudgedShards_TakeTheStreamBeside(t *testing.T) {
 	}
 }
 
+// TestJoinBaselineResults_StreamFromAnotherRun_Refused verifies that a stream
+// beside the baseline which judges tests the calls never name, or leaves a
+// named test without a verdict, is refused: joined silently it would leave
+// every call unjudged, the reached set empty and the superset check passing
+// against nothing. A call naming no test (an unattributed cleanup) is not
+// what trips it.
+func TestJoinBaselineResults_StreamFromAnotherRun_Refused(t *testing.T) {
+	cases := []struct {
+		name   string
+		stream []string
+		calls  []string
+		want   string
+	}{
+		{
+			name: "judges other tests only",
+			stream: []string{
+				`{"Time":"2026-09-01T10:00:00Z","Action":"run","Package":"example.com/old/test/e2e/suite","Test":"TestElsewhere"}`,
+				`{"Time":"2026-09-01T10:00:01Z","Action":"pass","Package":"example.com/old/test/e2e/suite","Test":"TestElsewhere","Elapsed":1}`,
+			},
+			calls: []string{"TestOld_Passed"},
+			want:  "judged 0 call(s) and left 1 naming a test without a verdict (first: TestOld_Passed)",
+		},
+		{
+			name: "judges some of the named tests",
+			stream: []string{
+				`{"Time":"2026-09-01T10:00:00Z","Action":"run","Package":"example.com/old/test/e2e/suite","Test":"TestOld_Passed"}`,
+				`{"Time":"2026-09-01T10:00:01Z","Action":"pass","Package":"example.com/old/test/e2e/suite","Test":"TestOld_Passed","Elapsed":1}`,
+			},
+			calls: []string{"TestOld_Passed", "TestOld_Missing"},
+			want:  "judged 1 call(s) and left 1 naming a test without a verdict (first: TestOld_Missing)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "baseline-ce")
+			if err := os.MkdirAll(dir, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			rt := &runtimeRecords{dir: dir, key: "community/free", packages: map[*e2ecalls.Call]string{}}
+			for _, name := range tc.calls {
+				call := fixtureCall(callSpec{test: name, action: "issue.list", dispatched: "issue.list", shape: dynamicDefault})
+				call.TestStatus = ""
+				rt.calls = append(rt.calls, call)
+				rt.packages[call] = "suite"
+			}
+			// The unattributed cleanup the old suite's recorder writes with no
+			// test name: unjudged after the join, and not a mismatch.
+			cleanup := fixtureCall(callSpec{test: "", action: "project.delete", dispatched: "project.delete", shape: dynamicDefault})
+			cleanup.TestStatus = ""
+			rt.calls = append(rt.calls, cleanup)
+			rt.packages[cleanup] = "suite"
+			writeFile(t, dir+baselineResultsSuffix, strings.Join(append(tc.stream, ""), "\n"))
+
+			err := joinBaselineResults([]*runtimeRecords{rt})
+			if !errors.Is(err, errBaselineStreamMismatch) {
+				t.Fatalf("joinBaselineResults() error = %v, want %v", err, errBaselineStreamMismatch)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("joinBaselineResults() error = %q, want it to say %q", err, tc.want)
+			}
+		})
+	}
+}
+
 // TestJoinBaselineResults_UnjudgedShardsWithoutAStream_Refused verifies that
 // a baseline that could only reach nothing is refused, naming the file it
 // looked for, instead of being compared against.

--- a/cmd/audit_e2e_coverage/doc.go
+++ b/cmd/audit_e2e_coverage/doc.go
@@ -42,12 +42,15 @@
 // -run filter (a partial run is not a coverage claim about the rest), and
 // when the asserted count falls below the floor exemptions.go records. -baseline compares two shard
 // directories and fails on any runtime x surface x mode x action x credit the
-// old suite reached in a passing test and the new one does not; a cleanup or
-// sweep credit is also met by the same cell asserted, since all three say the
-// action ran and answered. A baseline whose shards carry no verdicts, which is
-// how the old suite's recorder wrote them, is joined with the gotestsum stream
-// at <directory>.results.json beside it, and refused when there is none rather
-// than compared against nothing. -port-map
+// old suite reached in a passing test and the new one does not. The credits
+// order themselves: a cleanup credit is met by the same cell as cleanup, sweep
+// or asserted, and a sweep credit by sweep or asserted, since each of those
+// says the action ran and answered at least as firmly as the one it stands
+// in for. A baseline whose shards carry no verdicts, which is how the old
+// suite's recorder wrote them, is joined with the gotestsum stream at
+// <directory>.results.json beside it, and refused when there is none, or when
+// the stream judges none or not all of the tests the calls name, rather than
+// compared against nothing. -port-map
 // reads the "// Replaces:" lines of the new suite against every Test function
 // of the old one, with declared drops for the tests nothing replaces. An old
 // test whose file has already been deleted stays on the map through the

--- a/cmd/audit_e2e_coverage/portmap.go
+++ b/cmd/audit_e2e_coverage/portmap.go
@@ -88,8 +88,9 @@ var declaredDropCategories = map[string]bool{
 }
 
 // retiredTests lists the old Test functions whose files are gone: the 74 of
-// the old suite's EE half, deleted with the `enterprise` build constraint
-// once every one of them had a Replaces successor under test/e2e/gitlab/ee.
+// the old suite's EE half, deleted with the build constraint that used to
+// select it once every one of them had a Replaces successor under
+// test/e2e/gitlab/ee.
 //
 // The port map reads the old suite's Test functions from its files, and a
 // deleted file declares nothing, so without this list every Replaces line

--- a/cmd/gen_testing_docs/main.go
+++ b/cmd/gen_testing_docs/main.go
@@ -50,16 +50,11 @@ const (
 	// added to this list, exactly as it has to be added to GO_ANALYSIS_TAGS in
 	// the Makefile, or the tooling silently measures a smaller project than
 	// the one in the repository. None of these tags gates anything outside
-	// test/e2e, so cmd/ and internal/ resolve identically with them.
-	//
-	// `enterprise` is deliberately not here. It reveals no package: it selects
-	// between the CE and EE halves of test/e2e/suite, which exclude each
-	// other, so listing it would hide the 128 CE files from `go list` rather
-	// than reveal anything. The counts below come from reading each package
-	// directory, not from the file lists `go list` returns, so both halves
-	// are counted whichever tag is passed. The Makefile gives that tag an
-	// analysis pass of its own (GO_ANALYSIS_ENTERPRISE_TAGS) for the same
-	// reason.
+	// test/e2e, so cmd/ and internal/ resolve identically with them. Every
+	// file under test/e2e/suite, test/e2e/gitlab and test/e2e/internal is
+	// behind `e2e` alone, so this list reveals all of them at once; the
+	// counts below still come from reading each package directory rather
+	// than from the file lists `go list` returns.
 	e2eTags = "e2e,orbitlive,httpe2e,stdioe2e,collectore2e"
 
 	goFileSuffix     = ".go"

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -70,7 +70,7 @@ graph TD
         SPECS[domain ActionSpecs<br/>179 internal/tools packages<br/>(170 with action_specs.go)]
         CATALOG[action catalog<br/>canonical ActionRoute registry]
         STANDALONE[standalone surface specs<br/>project discovery + interactive flows]
-        IND[individual projection<br/>866 Free/CE / 1019 Premium / 1085 Ultimate / 1091 GitLab.com Ultimate tools]
+        IND[individual projection<br/>865 Free/CE / 1019 Premium / 1085 Ultimate / 1091 GitLab.com Ultimate tools]
         META[meta projection<br/>34 base / 40 Premium / 51 Ultimate / 52 GitLab.com Ultimate tools]
         DYN[dynamic projection<br/>2 visible find / execute tools]
         ELIC[elicitation support<br/>4 interactive actions]
@@ -167,7 +167,7 @@ Thin wrapper around the official `gitlab.com/gitlab-org/api/client-go/v3` librar
 
 ### Tools (`internal/tools`)
 
-The largest package family — contains 1085 self-managed Ultimate MCP tool implementations (866 on Free/CE, 1019 on Premium), plus 6 GitLab.com-only Orbit handlers for 1091 total in the GitLab.com Ultimate catalog, organized across 178 sub-packages under `internal/tools/`. Each sub-package owns its types, handlers, Markdown formatters, and ActionSpecs; root surface registration is catalog-backed. Tool-surface counts come from `go run ./cmd/audit_metrics/`; package counts can be verified with `go list ./internal/tools/...`, which lists 179 — the 178 sub-packages plus the `internal/tools` root package itself.
+The largest package family — contains 1085 self-managed Ultimate MCP tool implementations (865 on Free/CE, 1019 on Premium), plus 6 GitLab.com-only Orbit handlers for 1091 total in the GitLab.com Ultimate catalog, organized across 178 sub-packages under `internal/tools/`. Each sub-package owns its types, handlers, Markdown formatters, and ActionSpecs; root surface registration is catalog-backed. Tool-surface counts come from `go run ./cmd/audit_metrics/`; package counts can be verified with `go list ./internal/tools/...`, which lists 179 — the 178 sub-packages plus the `internal/tools` root package itself.
 
 For the detailed relationship between individual tools, meta-tools, dynamic mode, and the canonical action catalog, see [Tool Surfaces And Canonical Action Core](../development/tool-surfaces-and-action-core.md).
 

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -671,7 +671,7 @@ The report holds the findings deduplicated by package, schema type and field, wi
 
 #### Make targets
 
-- `make check-graphql-shapes`: the CI gate; also step [16/16] of `make analyze`.
+- `make check-graphql-shapes`: the CI gate; also step [15/15] of `make analyze`.
 - `make audit-graphql-shapes`: the same gate, listing everything it judged.
 - `make audit-graphql-sent`: the same run, writing `plan/graphql-sent.json`. The record is deliberately uncommitted and not freshness-gated: a schema re-pin would churn it every time.
 
@@ -961,7 +961,7 @@ Human report to stdout (per-site `file:line [category] boundary`), summary line,
 #### Make targets
 
 - `make audit-test-goroutines` — writes `plan/test-goroutines-backlog.json`.
-- `make check-test-goroutines` — CI gate; also step [7/16] of `make analyze`.
+- `make check-test-goroutines` — CI gate; also step [6/15] of `make analyze`.
 
 ### audit_test_names
 
@@ -1027,7 +1027,7 @@ Per-file tallies (`sites`, `fixable`), a summary line, and optionally the JSON w
 #### Make targets
 
 - `make audit-test-subtests` — writes `plan/test-subtests-backlog.json`.
-- `make check-test-subtests` — CI gate; also step [8/16] of `make analyze`.
+- `make check-test-subtests` — CI gate; also step [7/15] of `make analyze`.
 
 ### audit_md_escaping
 
@@ -1083,7 +1083,7 @@ Findings grouped by package, each naming the file, line, formatter, construct, v
 #### Make targets
 
 - `make audit-md-escaping` — report plus `plan/md-escaping-backlog.json`, with the two staged rules judged beside the gating contexts.
-- `make check-md-escaping` — CI gate over the six gating contexts, holding `internal/toolutil` to no unresolved value; also step [10/16] of `make analyze`.
+- `make check-md-escaping` — CI gate over the six gating contexts, holding `internal/toolutil` to no unresolved value; also step [9/15] of `make analyze`.
 
 ## Release & supply-chain audits
 
@@ -1116,7 +1116,7 @@ One line per violation under a `supply-chain audit FAILED (N problems):` header,
 
 #### Make targets
 
-- `make check-supply-chain` — CI gate; also step [9/16] of `make analyze`.
+- `make check-supply-chain` — CI gate; also step [8/15] of `make analyze`.
 
 ### audit_install_buttons
 
@@ -1282,7 +1282,7 @@ Writes `gitlab-api-live.json` into `-dir` and reports the entity, field, route a
 #### Make targets
 
 - `make gen-api-live`
-- `make check-api-live` — CI gate; also step [15/16] of `make analyze`.
+- `make check-api-live` — CI gate; also step [14/15] of `make analyze`.
 
 ### gen_lhm_manifest
 

--- a/docs/development/enterprise-schema-checks.md
+++ b/docs/development/enterprise-schema-checks.md
@@ -6,11 +6,14 @@ no license, and what the maintainer runs by hand before a release.
 > **Diátaxis type**: How-to & Explanation · **Audience**: 🛠️ Maintainers
 
 The Enterprise-only tools were the least-checked part of this server for a long time,
-and the reason was structural rather than accidental. `.github/workflows/e2e.yml` runs
-the suite with `-tags e2e` against a GitLab CE image, and the `enterprise` build tag
-appears in no workflow, so 41 files and 74 test functions covering the Premium and
-Ultimate surface were never compiled. Every package that turned out to hold a broken
-GraphQL document was a package only that tag covers.
+and the reason was structural rather than accidental. `.github/workflows/e2e.yml` ran
+the old suite against a GitLab CE image, and its Premium and Ultimate half sat behind
+a second build tag that appeared in no workflow, so 41 files and 74 test functions
+covering that surface were never compiled. Every package that turned out to hold a
+broken GraphQL document was a package only that half covered. The rebuilt suite under
+`test/e2e/gitlab` has no such half: every file carries `e2e` alone, so the licensed
+package `ee` is compiled and linted by the same run as everything else, and what still
+needs a license is running it.
 
 There are two checks, and they answer different questions.
 
@@ -99,15 +102,21 @@ of tests. Budget half an hour end to end, and expect the boot to dominate.
 
 ```bash
 export GITLAB_ACTIVATION_CODE=...   # the trial activation code
-make test-e2e-docker-enterprise
+make test-e2e-ee
 ```
 
-That target starts GitLab EE from `test/e2e/docker-compose.yml`, waits for it, applies
-the license, registers the runner, runs the suite with `-tags "e2e enterprise"` and
-tears the stack down, leaving its reports under `dist/e2e-reports/`.
+That target builds the server binary once, starts GitLab EE from
+`test/e2e/docker-compose.yml` through `test/e2e/scripts/run-docker-e2e.sh`, waits for
+it, applies the license, registers the runner, runs the `common` and `ee` packages of
+`test/e2e/gitlab` against that binary over stdio and tears the stack down, leaving its
+reports under `dist/e2e-reports/` and the calls it recorded under `dist/e2e-calls/ee`.
+`make test-e2e-docker-enterprise` is the same target under its older name.
 
-The `enterprise` tag is the load-bearing part. Without it the Premium and Ultimate
-files are not compiled, which is the gap this page exists to close.
+The package is the load-bearing part, not a tag. `ee` declares in its `TestMain` that
+it needs a Premium or Ultimate license and refuses before it writes anything when the
+instance it is pointed at has none, naming what it found; and the Free actions in
+`common` run here too, on the licensed catalog, where schema pruning differs from the
+CE one.
 
 ### Where its result belongs
 
@@ -117,19 +126,22 @@ tag cannot be cut without somebody having looked at the result.
 
 ## What every push checks without a license
 
-Two things about the Enterprise suite need no GitLab at all, and neither
-happened until issue 570. The suite is compiled with `-tags "e2e enterprise"`
-in the CI compile job, and it is linted with that tag added, in a pass of its
-own over `test/e2e/suite/` (`make golangci-lint` runs it, and the comment on
-`GO_ANALYSIS_ENTERPRISE_TAGS` in the Makefile says why it cannot share the
-ordinary pass: the CE and EE halves of the suite exclude each other, so one
-run sees one half and never the other). Between the day the first
-`_ee_test.go` was written and that change, nothing had compiled those 41 files
-except a person running `make test-e2e-docker-enterprise` by hand, which is
-how nineteen helpers and four constants used only by CE tests came to be
-unused under the Enterprise tag without anyone knowing.
+Two things about the licensed package need no GitLab at all. It is compiled in
+the CI compile job, by the same `go test -tags e2e -c` that compiles the rest
+of the rebuilt suite, and it is linted by the one `golangci-lint run` that
+`make golangci-lint` performs with every e2e tag. Neither needs a step of its
+own, because `test/e2e/gitlab/ee` is an ordinary package behind the ordinary
+tag. The old suite's Enterprise half needed both, in passes of their own,
+because it sat behind a second tag that excluded the CE half, so one run could
+only ever see one of them; and until issue 570 neither pass existed, so nothing
+had compiled those 41 files except a person running the licensed target by
+hand, which is how nineteen helpers and four constants used only by CE tests
+came to sit unused in files both halves shared without anyone knowing. The
+static gate, `go run ./cmd/audit_e2e_coverage/ -static`, holds the rebuilt
+layout to the shape that closed this: every file under `test/e2e/gitlab`
+carries exactly `e2e`, and a test that needs Ultimate declares the tier.
 
-The licensed run is still where the behaviour is checked, and that is
+The licensed run is still where the behavior is checked, and that is
 unchanged. What changed is that the code it compiles is known to compile, and
 to pass every linter, before anyone boots a GitLab for it.
 

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -20,7 +20,7 @@ The project uses three complementary analysis surfaces:
 
 Standalone Go tools that are already executed through `golangci-lint` are not run separately in Make or CI. This avoids duplicate work, divergent flags, and inconsistent findings. The consolidated Go gate covers `govet`, `modernize`, `gosec`, `staticcheck`, `goimports`, `gofumpt`, and `gci` through `.golangci.yml`.
 
-Go analysis targets pass every end-to-end build tag (`e2e,collectore2e,httpe2e,orbitlive,stdioe2e`, the Makefile's `GO_ANALYSIS_TAGS`) so every tagged suite under `test/e2e/` is analysed without being run; a suite added behind a new tag is invisible to `go vet` and `golangci-lint` until its tag is added to that list. The `enterprise` tag is the exception, because it is not a suite's tag but a switch between the two halves of `test/e2e/suite` (`*_ce_test.go` carry `e2e && !enterprise`, `*_ee_test.go` carry `e2e && enterprise`): one run can only see one half, so the Enterprise half gets a second `golangci-lint run` of its own, scoped to that package, with `GO_ANALYSIS_ENTERPRISE_TAGS`. Markdown linting remains repository-wide for Markdown files, excluding `plan/` drafts in Make targets.
+Go analysis targets pass every end-to-end build tag (`e2e,collectore2e,httpe2e,orbitlive,stdioe2e`, the Makefile's `GO_ANALYSIS_TAGS`) so every tagged suite under `test/e2e/` is analysed without being run; a suite added behind a new tag is invisible to `go vet` and `golangci-lint` until its tag is added to that list. Every file under `test/e2e/suite`, `test/e2e/gitlab` and `test/e2e/internal` carries `e2e` and nothing else, so that one list is the whole of what the analysis has to know and one run sees every file. The old suite's Enterprise half used to sit behind a second tag that excluded the other half, which cost it a `golangci-lint run` of its own; that half was ported to `test/e2e/gitlab/ee` and deleted, and the second run with it. Markdown linting remains repository-wide for Markdown files, excluding `plan/` drafts in Make targets.
 
 ## Quick Start
 
@@ -147,7 +147,6 @@ make golangci-lint
 golangci-lint config verify
 golangci-lint fmt --diff
 golangci-lint run --build-tags e2e,collectore2e,httpe2e,orbitlive,stdioe2e ./...
-golangci-lint run --build-tags e2e,collectore2e,httpe2e,orbitlive,stdioe2e,enterprise ./test/e2e/suite/
 ```
 
 The Make target performs these steps:
@@ -155,7 +154,6 @@ The Make target performs these steps:
 1. Validate `.golangci.yml`.
 2. Check configured Go formatters with `golangci-lint fmt --diff`.
 3. Run configured linters with every end-to-end build tag.
-4. Run them again over `test/e2e/suite/` with `enterprise` added, since that tag selects the Enterprise half of the suite rather than adding a module, and the run above never sees it.
 
 Configured formatters:
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 16,255 |
-| Unit test functions                                   | 15,339 |
+| Total test functions                                  | 16,256 |
+| Unit test functions                                   | 15,340 |
 | E2E test functions                                    |    916 |
-| cmd test functions                                    |  3,170 |
+| cmd test functions                                    |  3,171 |
 | Test files (internal/)                                |    555 |
 | Test files (cmd/)                                     |    221 |
 | Test files (test/e2e/)                                |    312 |
@@ -37,7 +37,7 @@
 | -------------------------------------- | -----: | ----: |
 | `TestFunc_Scenario` (2-part)           | 12,397 | 76.3% |
 | `TestFunc` (no underscore)             |    943 |  5.8% |
-| `TestFunc_Scenario_Expected` (3+ part) |  2,915 | 17.9% |
+| `TestFunc_Scenario_Expected` (3+ part) |  2,916 | 17.9% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            366 |         16 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (178) |          9,096 |        379 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            916 |        312 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          3,170 |        221 | server entry point and developer command utilities                                              |
-| **Total**               |     **16,255** |  **1,088** |                                                                                                 |
+| cmd packages            |          3,171 |        221 | server entry point and developer command utilities                                              |
+| **Total**               |     **16,256** |  **1,088** |                                                                                                 |
 
 ### Core Packages
 
@@ -311,7 +311,7 @@
 | cmd/audit_1to1/internal/enums                  |    99.7% |
 | cmd/audit_1to1/internal/merge                  |   100.0% |
 | cmd/audit_1to1/internal/metadata               |   100.0% |
-| cmd/audit_1to1/internal/paths                  |    98.0% |
+| cmd/audit_1to1/internal/paths                  |    99.5% |
 | cmd/audit_1to1/internal/sdk                    |   100.0% |
 | cmd/audit_1to1/internal/shared                 |   100.0% |
 | cmd/audit_1to1/internal/structs                |   100.0% |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -681,12 +681,12 @@ make test-e2e-docker
 For Enterprise/Premium E2E coverage, set `ENTERPRISE_LICENSE` in `.env` or the shell and use:
 
 ```bash
-make test-e2e-docker-enterprise
+make test-e2e-ee                  # or its older name, make test-e2e-docker-enterprise
 ```
 
-The Enterprise target runs with the `e2e enterprise` build tags, so common harness files plus `test/e2e/suite/*_ee_test.go` Enterprise/Premium tests are compiled and executed. CE-only tests live in `test/e2e/suite/*_ce_test.go` and remain in `make test-e2e-docker`, while Enterprise-specific fixture behavior can be tuned independently.
+The licensed target runs the `common` and `ee` packages of the rebuilt suite under `test/e2e/gitlab` against the real binary. There is no Enterprise build tag: every file carries `e2e` alone, and the package decides the runtime, so one compile and one analysis run see the licensed tests with everything else. The old suite under `test/e2e/suite` stays with `make test-e2e-docker` until its CE half is ported; the Premium scenarios its CE files still hold run when the instance is licensed and skip when it reports Free.
 
-The E2E harness also re-validates the GitLab tier at runtime by calling the License API (`GET /api/v4/license`). When an enterprise tier is requested (via `GITLAB_MCP_TIER=premium`/`ultimate`, or the legacy `GITLAB_ENTERPRISE=true` harness toggle) but the fixture reports a Free license, the session downgrades to CE and `*_ee_test.go` tests skip cleanly with a logged reason instead of failing outright. This keeps the suite safe against accidental CE/EE mismatches.
+The rebuilt suite re-validates the GitLab tier before it writes anything, by calling the License API (`GET /api/v4/license`). A package pointed at the wrong runtime refuses, naming what it found and the target to run instead, and `E2E_RUNTIME_MISMATCH=skip` turns that refusal into skips. The old suite keeps its own check: when an enterprise tier is requested (via `GITLAB_MCP_TIER=premium`/`ultimate`, or the legacy `GITLAB_ENTERPRISE=true` harness toggle) but the fixture reports a Free license, its session downgrades to CE and the Premium scenarios skip with a logged reason instead of failing outright.
 
 Docker mode enables pipeline and job tests that require a CI runner. It also starts an internal `e2e-fixture` HTTP service and configures GitLab to allow local outbound requests, so project webhook, push mirror, and custom emoji tests use deterministic in-network endpoints instead of public Internet access.
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,13 +18,13 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 16,221 |
-| Unit test functions                                   | 15,330 |
-| E2E test functions                                    |    891 |
-| cmd test functions                                    |  3,163 |
+| Total test functions                                  | 16,255 |
+| Unit test functions                                   | 15,339 |
+| E2E test functions                                    |    916 |
+| cmd test functions                                    |  3,170 |
 | Test files (internal/)                                |    555 |
 | Test files (cmd/)                                     |    221 |
-| Test files (test/e2e/)                                |    290 |
+| Test files (test/e2e/)                                |    312 |
 | Tool sub-packages tested                              |    178 |
 | Core packages tested                                  |     23 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  98.3% |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 12,466 | 76.9% |
-| `TestFunc` (no underscore)             |    944 |  5.8% |
-| `TestFunc_Scenario_Expected` (3+ part) |  2,811 | 17.3% |
+| `TestFunc_Scenario` (2-part)           | 12,397 | 76.3% |
+| `TestFunc` (no underscore)             |    943 |  5.8% |
+| `TestFunc_Scenario_Expected` (3+ part) |  2,915 | 17.9% |
 
 ## Test Distribution
 
@@ -47,10 +47,10 @@
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          2,707 |        160 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            366 |         16 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (178) |          9,094 |        379 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            891 |        290 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          3,163 |        221 | server entry point and developer command utilities                                              |
-| **Total**               |     **16,221** |  **1,066** |                                                                                                 |
+| Tool sub-packages (178) |          9,096 |        379 | domain-specific GitLab tool handlers                                                            |
+| E2E integration         |            916 |        312 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          3,170 |        221 | server entry point and developer command utilities                                              |
+| **Total**               |     **16,255** |  **1,088** |                                                                                                 |
 
 ### Core Packages
 
@@ -107,7 +107,7 @@
 | groupmembers      |    94 |   100.0% |    10 |
 | pipelineschedules |    94 |    99.0% |    11 |
 | groupmilestones   |    90 |    99.7% |     8 |
-| mrapprovals       |    85 |    99.4% |     7 |
+| mrapprovals       |    86 |    99.4% |     7 |
 | files             |    84 |   100.0% |     8 |
 | integrations      |    79 |    99.5% |    12 |
 
@@ -180,7 +180,7 @@
 | geo                     |        75 |          3 |    98.3% |         8 |
 | gitignoretemplates      |        15 |          1 |   100.0% |         2 |
 | groupanalytics          |         8 |          2 |   100.0% |         3 |
-| groupboards             |        65 |          2 |    99.4% |        10 |
+| groupboards             |        66 |          2 |    99.4% |        10 |
 | groupcredentials        |        43 |          3 |   100.0% |         4 |
 | groupepicboards         |        15 |          3 |    98.4% |         2 |
 | groupimportexport       |        23 |          2 |   100.0% |         3 |
@@ -229,7 +229,7 @@
 | metadata                |         8 |          1 |   100.0% |         1 |
 | milestones              |        71 |          1 |    99.7% |         7 |
 | modelregistry           |         7 |          3 |   100.0% |         1 |
-| mrapprovals             |        85 |          3 |    99.4% |         7 |
+| mrapprovals             |        86 |          3 |    99.4% |         7 |
 | mrapprovalsettings      |         9 |          2 |   100.0% |         4 |
 | mrchanges               |        38 |          1 |    98.4% |         4 |
 | mrcontextcommits        |        23 |          1 |   100.0% |         3 |
@@ -296,7 +296,7 @@
 | wikis                   |        63 |          2 |    99.5% |         6 |
 | workitems               |       116 |          3 |    99.5% |         6 |
 | workitemsavedviews      |        55 |          4 |   100.0% |         7 |
-| **Total**               | **9,094** |    **379** |          | **1,187** |
+| **Total**               | **9,096** |    **379** |          | **1,187** |
 
 </details>
 
@@ -311,7 +311,7 @@
 | cmd/audit_1to1/internal/enums                  |    99.7% |
 | cmd/audit_1to1/internal/merge                  |   100.0% |
 | cmd/audit_1to1/internal/metadata               |   100.0% |
-| cmd/audit_1to1/internal/paths                  |    99.5% |
+| cmd/audit_1to1/internal/paths                  |    98.0% |
 | cmd/audit_1to1/internal/sdk                    |   100.0% |
 | cmd/audit_1to1/internal/shared                 |   100.0% |
 | cmd/audit_1to1/internal/structs                |   100.0% |
@@ -320,7 +320,7 @@
 | cmd/audit_doc_coverage                         |    91.6% |
 | cmd/audit_doc_tool_names                       |    94.2% |
 | cmd/audit_dynamic_aliases                      |    77.4% |
-| cmd/audit_e2e_coverage                         |    95.7% |
+| cmd/audit_e2e_coverage                         |    95.9% |
 | cmd/audit_e2e_gaps                             |    92.9% |
 | cmd/audit_edition_tier                         |    86.9% |
 | cmd/audit_gateway_chars                        |    87.5% |
@@ -366,7 +366,7 @@
 | cmd/internal/provenance                        |   100.0% |
 | cmd/internal/requestinventory                  |   100.0% |
 | cmd/internal/testsource                        |   100.0% |
-| cmd/server                                     |    99.8% |
+| cmd/server                                     |    99.9% |
 
 ### Core Packages
 

--- a/docs/development/token-footprint.md
+++ b/docs/development/token-footprint.md
@@ -29,15 +29,15 @@ All measurements are against the current source tree. The catalog is built in-me
 
 | Configuration                | Tier     | Visible tools | Reachable actions | `GITLAB_MCP_META_PARAM_SCHEMA` | Tool schema tokens | Shared tokens | Total tokens |
 | ---------------------------- | -------- | ------------: | ----------------: | ------------------------------ | -----------------: | ------------: | -----------: |
-| `dynamic` / `full` (default) | Free/CE  |             2 |               870 | n/a                            |              1,524 |         8,835 |       10,359 |
-| `dynamic` / `minimal`        | Free/CE  |             2 |               870 | n/a                            |              1,524 |           170 |        1,694 |
-| `meta` / `full` (opaque)     | Free/CE  |            34 |               870 | `opaque`                       |            130,059 |         8,835 |      138,894 |
-| `meta` / `minimal` (opaque)  | Free/CE  |            34 |               870 | `opaque`                       |            130,059 |           170 |      130,229 |
-| `meta` / `full` (compact)    | Free/CE  |            34 |               870 | `compact`                      |            205,193 |         8,835 |      214,028 |
-| `meta` / `minimal` (compact) | Free/CE  |            34 |               870 | `compact`                      |            205,193 |           170 |      205,363 |
-| `meta` / `full` (full)       | Free/CE  |            34 |               870 | `full`                         |            298,003 |         8,835 |      306,838 |
-| `meta` / `minimal` (full)    | Free/CE  |            34 |               870 | `full`                         |            298,003 |           170 |      298,173 |
-| `individual` / `full`        | Free/CE  |           866 |               866 | n/a                            |            537,551 |         8,835 |      546,386 |
+| `dynamic` / `full` (default) | Free/CE  |             2 |               869 | n/a                            |              1,524 |         8,835 |       10,359 |
+| `dynamic` / `minimal`        | Free/CE  |             2 |               869 | n/a                            |              1,524 |           170 |        1,694 |
+| `meta` / `full` (opaque)     | Free/CE  |            34 |               869 | `opaque`                       |            129,996 |         8,835 |      138,831 |
+| `meta` / `minimal` (opaque)  | Free/CE  |            34 |               869 | `opaque`                       |            129,996 |           170 |      130,166 |
+| `meta` / `full` (compact)    | Free/CE  |            34 |               869 | `compact`                      |            205,079 |         8,835 |      213,914 |
+| `meta` / `minimal` (compact) | Free/CE  |            34 |               869 | `compact`                      |            205,079 |           170 |      205,249 |
+| `meta` / `full` (full)       | Free/CE  |            34 |               869 | `full`                         |            297,869 |         8,835 |      306,704 |
+| `meta` / `minimal` (full)    | Free/CE  |            34 |               869 | `full`                         |            297,869 |           170 |      298,039 |
+| `individual` / `full`        | Free/CE  |           865 |               865 | n/a                            |            537,351 |         8,835 |      546,186 |
 | `dynamic` / `full` (default) | Premium  |             2 |             1,023 | n/a                            |              1,524 |         8,835 |       10,359 |
 | `dynamic` / `minimal`        | Premium  |             2 |             1,023 | n/a                            |              1,524 |           170 |        1,694 |
 | `meta` / `full` (opaque)     | Premium  |            40 |             1,023 | `opaque`                       |            149,686 |         8,835 |      158,521 |
@@ -46,7 +46,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Premium  |            40 |             1,023 | `compact`                      |            237,954 |           170 |      238,124 |
 | `meta` / `full` (full)       | Premium  |            40 |             1,023 | `full`                         |            345,695 |         8,835 |      354,530 |
 | `meta` / `minimal` (full)    | Premium  |            40 |             1,023 | `full`                         |            345,695 |           170 |      345,865 |
-| `individual` / `full`        | Premium  |         1,019 |             1,019 | n/a                            |            646,650 |         8,835 |      655,485 |
+| `individual` / `full`        | Premium  |         1,019 |             1,019 | n/a                            |            646,632 |         8,835 |      655,467 |
 | `dynamic` / `full` (default) | Ultimate |             2 |             1,089 | n/a                            |              1,524 |         8,835 |       10,359 |
 | `dynamic` / `minimal`        | Ultimate |             2 |             1,089 | n/a                            |              1,524 |           170 |        1,694 |
 | `meta` / `full` (opaque)     | Ultimate |            51 |             1,089 | `opaque`                       |            161,859 |         8,835 |      170,694 |
@@ -55,7 +55,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Ultimate |            51 |             1,089 | `compact`                      |            255,233 |           170 |      255,403 |
 | `meta` / `full` (full)       | Ultimate |            51 |             1,089 | `full`                         |            368,059 |         8,835 |      376,894 |
 | `meta` / `minimal` (full)    | Ultimate |            51 |             1,089 | `full`                         |            368,059 |           170 |      368,229 |
-| `individual` / `full`        | Ultimate |         1,085 |             1,085 | n/a                            |            680,607 |         8,835 |      689,442 |
+| `individual` / `full`        | Ultimate |         1,085 |             1,085 | n/a                            |            680,589 |         8,835 |      689,424 |
 
 ## Interpretation guide
 

--- a/internal/tools/testdata/tools_individual.json
+++ b/internal/tools/testdata/tools_individual.json
@@ -52359,7 +52359,7 @@
   },
   {
     "name": "gitlab_group_board_delete",
-    "description": "Delete a group issue board permanently. Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.",
+    "description": "Delete a group issue board permanently (Premium/Ultimate). Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
@@ -125792,10 +125792,7 @@
         "project_id",
         "merge_request_iid",
         "name",
-        "approvals_required",
-        "approval_project_rule_id",
-        "user_ids",
-        "group_ids"
+        "approvals_required"
       ],
       "type": "object"
     },
@@ -126305,11 +126302,7 @@
       "required": [
         "project_id",
         "merge_request_iid",
-        "approval_rule_id",
-        "name",
-        "approvals_required",
-        "user_ids",
-        "group_ids"
+        "approval_rule_id"
       ],
       "type": "object"
     },

--- a/llms-full-individual-tools.txt
+++ b/llms-full-individual-tools.txt
@@ -4603,7 +4603,7 @@ Annotations: readOnly=false, destructive=false, idempotent=false, openWorld=true
 
 #### gitlab_group_board_delete
 
-Delete a group issue board permanently. Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.
+Delete a group issue board permanently (Premium/Ultimate). Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.
 
 **Parameters:**
 
@@ -9150,13 +9150,13 @@ Create an approval rule on a merge request. Returns: the created rule with its t
 
 **Parameters:**
 
-- `approval_project_rule_id` (integer) (required): Project-level approval rule ID to inherit from
+- `approval_project_rule_id` (integer): Project-level approval rule ID to inherit from
 - `approvals_required` (integer) (required): Number of approvals required
-- `group_ids` (array of integers) (required): Group IDs eligible to approve
+- `group_ids` (array of integers): Group IDs eligible to approve
 - `merge_request_iid` (integer) (required): Merge request internal ID
 - `name` (string) (required): Rule name
 - `project_id` (string) (required): Project ID or URL-encoded path
-- `user_ids` (array of integers) (required): User IDs eligible to approve
+- `user_ids` (array of integers): User IDs eligible to approve
 
 Annotations: readOnly=false, destructive=false, idempotent=false, openWorld=true
 
@@ -9180,12 +9180,12 @@ Update an approval rule on a merge request. Returns: the updated rule with its t
 **Parameters:**
 
 - `approval_rule_id` (integer) (required): Approval rule ID
-- `approvals_required` (integer) (required): Number of approvals required
-- `group_ids` (array of integers) (required): Group IDs eligible to approve
+- `approvals_required` (integer): Number of approvals required
+- `group_ids` (array of integers): Group IDs eligible to approve
 - `merge_request_iid` (integer) (required): Merge request internal ID
-- `name` (string) (required): Rule name
+- `name` (string): Rule name
 - `project_id` (string) (required): Project ID or URL-encoded path
-- `user_ids` (array of integers) (required): User IDs eligible to approve
+- `user_ids` (array of integers): User IDs eligible to approve
 
 Annotations: readOnly=false, destructive=false, idempotent=true, openWorld=true
 

--- a/llms-full-meta-tools.txt
+++ b/llms-full-meta-tools.txt
@@ -2722,7 +2722,6 @@ Action guidance:
 - delete: Delete a group (marks it for deletion, or permanently removes it with permanently_remove=true). Destructive: this removes the group and all its projects. Confirm before calling.
 - get: Get one exact group by group_id (numeric ID or full path). Use this when the prompt already targets a specific group and needs metadata such as visibility, parent, web URL, or statistics.
 - group_board_create_list: Add a new column backed by a group label to a group issue board's workflow.
-- group_board_delete: Permanently remove an issue board from a group when the team no longer needs it.
 - group_board_delete_list: Remove a column from a group issue board when that workflow stage is no longer used.
 - group_board_get: Inspect one group issue board's milestone, scope labels, and columns by its board ID.
 - group_board_get_list: Inspect one column of a group issue board, including its label, assignee, and iteration scope.
@@ -2800,7 +2799,6 @@ Parameter guidance:
 - delete.group_id: scope_group. Source: Group numeric ID or full path to delete. Avoid: permanently_remove=true requires full_path and bypasses the retention window.
 - get.group_id: scope_group. Source: Group numeric ID or full path from the prompt or prior discovery step. Avoid: Use group_id for path or ID. Do not send project_id for group lookups.
 - group_board_create_list.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
-- group_board_delete.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
 - group_board_delete_list.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
 - group_board_get.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
 - group_board_get_list.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2722,7 +2722,6 @@ Action guidance:
 - delete: Delete a group (marks it for deletion, or permanently removes it with permanently_remove=true). Destructive: this removes the group and all its projects. Confirm before calling.
 - get: Get one exact group by group_id (numeric ID or full path). Use this when the prompt already targets a specific group and needs metadata such as visibility, parent, web URL, or statistics.
 - group_board_create_list: Add a new column backed by a group label to a group issue board's workflow.
-- group_board_delete: Permanently remove an issue board from a group when the team no longer needs it.
 - group_board_delete_list: Remove a column from a group issue board when that workflow stage is no longer used.
 - group_board_get: Inspect one group issue board's milestone, scope labels, and columns by its board ID.
 - group_board_get_list: Inspect one column of a group issue board, including its label, assignee, and iteration scope.
@@ -2800,7 +2799,6 @@ Parameter guidance:
 - delete.group_id: scope_group. Source: Group numeric ID or full path to delete. Avoid: permanently_remove=true requires full_path and bypasses the retention window.
 - get.group_id: scope_group. Source: Group numeric ID or full path from the prompt or prior discovery step. Avoid: Use group_id for path or ID. Do not send project_id for group lookups.
 - group_board_create_list.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
-- group_board_delete.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
 - group_board_delete_list.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
 - group_board_get.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
 - group_board_get_list.group_id: scope_group. Source: Group ID or URL-encoded path (e.g. "my-group" or "my-group/sub").
@@ -17963,7 +17961,7 @@ Annotations: readOnly=false, destructive=false, idempotent=false, openWorld=true
 
 #### gitlab_group_board_delete
 
-Delete a group issue board permanently. Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.
+Delete a group issue board permanently (Premium/Ultimate). Returns: a success confirmation. See also: gitlab_group_board_get, gitlab_group_board_list.
 
 **Parameters:**
 
@@ -22510,13 +22508,13 @@ Create an approval rule on a merge request. Returns: the created rule with its t
 
 **Parameters:**
 
-- `approval_project_rule_id` (integer) (required): Project-level approval rule ID to inherit from
+- `approval_project_rule_id` (integer): Project-level approval rule ID to inherit from
 - `approvals_required` (integer) (required): Number of approvals required
-- `group_ids` (array of integers) (required): Group IDs eligible to approve
+- `group_ids` (array of integers): Group IDs eligible to approve
 - `merge_request_iid` (integer) (required): Merge request internal ID
 - `name` (string) (required): Rule name
 - `project_id` (string) (required): Project ID or URL-encoded path
-- `user_ids` (array of integers) (required): User IDs eligible to approve
+- `user_ids` (array of integers): User IDs eligible to approve
 
 Annotations: readOnly=false, destructive=false, idempotent=false, openWorld=true
 
@@ -22540,12 +22538,12 @@ Update an approval rule on a merge request. Returns: the updated rule with its t
 **Parameters:**
 
 - `approval_rule_id` (integer) (required): Approval rule ID
-- `approvals_required` (integer) (required): Number of approvals required
-- `group_ids` (array of integers) (required): Group IDs eligible to approve
+- `approvals_required` (integer): Number of approvals required
+- `group_ids` (array of integers): Group IDs eligible to approve
 - `merge_request_iid` (integer) (required): Merge request internal ID
-- `name` (string) (required): Rule name
+- `name` (string): Rule name
 - `project_id` (string) (required): Project ID or URL-encoded path
-- `user_ids` (array of integers) (required): User IDs eligible to approve
+- `user_ids` (array of integers): User IDs eligible to approve
 
 Annotations: readOnly=false, destructive=false, idempotent=true, openWorld=true
 

--- a/llms-medium.txt
+++ b/llms-medium.txt
@@ -797,7 +797,7 @@ Enabled with `GITLAB_MCP_TOOL_SURFACE=individual`: 1091 tools, one per operation
 - gitlab_group_add_push_rule: Add push rules to a GitLab group.
 - gitlab_group_archive: Archive a GitLab group, making it and its projects read-only in GitLab.
 - gitlab_group_board_create: Create a new group issue board (Premium/Ultimate).
-- gitlab_group_board_delete: Delete a group issue board permanently.
+- gitlab_group_board_delete: Delete a group issue board permanently (Premium/Ultimate).
 - gitlab_group_board_get: Get a single group issue board by ID.
 - gitlab_group_board_list: List all issue boards in a group with pagination.
 - gitlab_group_board_list_create: Create a new list (column) on a group issue board from a group label.

--- a/site/src/content/docs/es/operations/docker-testing.mdx
+++ b/site/src/content/docs/es/operations/docker-testing.mdx
@@ -6,7 +6,7 @@ faq:
   - q: "¿Cómo ejecuto la suite E2E contra una instancia efímera de GitLab?"
     a: "Ejecuta `make test-e2e-docker`. Ese objetivo orquesta el stack Docker, espera a GitLab, configura el usuario y el runner de CI de pruebas, ejecuta la suite E2E de Go con el build tag `e2e` y escribe reportes JUnit y JSON. La ruta por defecto usa GitLab CE y crea datos temporales que se eliminan al desmontar el stack, de modo que obtienes validación de alta confianza sin depender de una instancia real configurada en `.env`."
   - q: "¿Cómo ejecuto la cobertura Enterprise/Premium de E2E con Docker?"
-    a: "Define `ENTERPRISE_LICENSE` en `.env` o en la shell y ejecuta `make test-e2e-docker-enterprise`. Ese objetivo usa la imagen GitLab EE más los build tags `e2e enterprise`, así que se compilan y ejecutan los archivos comunes de harness y los tests Enterprise/Premium de `test/e2e/suite/*_ee_test.go`. Cuando `ENTERPRISE_LICENSE` contiene un activation code de 24 caracteres, la primera ejecución correcta exporta una licencia reutilizable a `test/e2e/.enterprise-license`, de modo que las siguientes ejecuciones la instalan mediante la License API en lugar de consumir otra vez el activation code."
+    a: "Define `ENTERPRISE_LICENSE` en `.env` o en la shell y ejecuta `make test-e2e-ee` (`make test-e2e-docker-enterprise` es el mismo objetivo con su nombre anterior). Usa la imagen GitLab EE y ejecuta los paquetes `common` y `ee` de la suite reconstruida bajo `test/e2e/gitlab` contra el binario real del servidor; no existe un build tag Enterprise, el paquete decide el runtime. Cuando `ENTERPRISE_LICENSE` contiene un activation code de 24 caracteres, la primera ejecución correcta exporta una licencia reutilizable a `test/e2e/.enterprise-license`, de modo que las siguientes ejecuciones la instalan mediante la License API en lugar de consumir otra vez el activation code."
   - q: "¿Cuándo debería usar el modo E2E con Docker en lugar de tests unitarios?"
     a: "Usa E2E con Docker al cambiar el registro de herramientas, la proyección del catálogo o los schemas; al cambiar el comportamiento de pipelines, jobs, webhooks, emoji personalizados o mirrors; y al verificar release candidates antes de publicar binarios. Normalmente no hace falta para editar una página Markdown estrecha o depurar un test unitario fallando con respuestas mock de GitLab. E2E con Docker es más lento que los tests unitarios pero es la ruta de validación preferida para migraciones de arquitectura porque ejercita la API real de GitLab junto con el transporte MCP."
   - q: "¿Cómo limpio los datos de prueba de E2E con Docker?"
@@ -39,10 +39,10 @@ Ese objetivo orquesta el stack Docker, espera a GitLab, configura el usuario y e
 Para ejecutar la cobertura Enterprise/Premium contra GitLab EE, define `ENTERPRISE_LICENSE` en `.env` o en la shell y usa:
 
 ```bash
-make test-e2e-docker-enterprise
+make test-e2e-ee    # o su nombre anterior, make test-e2e-docker-enterprise
 ```
 
-Ese objetivo se ejecuta con los build tags `e2e enterprise`, así que compila los archivos comunes de harness y los tests Enterprise/Premium de `test/e2e/suite/*_ee_test.go`. Los tests solo CE viven en `test/e2e/suite/*_ce_test.go` y quedan en `make test-e2e-docker`, mientras las fixtures Enterprise pueden ajustarse de forma independiente.
+Ese objetivo ejecuta los paquetes `common` y `ee` de la suite reconstruida bajo `test/e2e/gitlab` contra el binario real del servidor sobre stdio. No existe un build tag Enterprise: cada archivo lleva solo `e2e`, y el paquete decide el runtime, así que `ee` rechaza una instancia sin licencia antes de escribir nada mientras `common` ejecuta también sus acciones Free sobre el catálogo con licencia. La suite bajo `test/e2e/suite` sigue en `make test-e2e-docker` hasta que se porte su mitad CE.
 
 Cuando `ENTERPRISE_LICENSE` contiene un activation code de 24 caracteres, la primera ejecución correcta exporta la licencia reutilizable generada a `test/e2e/.enterprise-license`. Las siguientes ejecuciones Enterprise prefieren ese cache local ignorado por Git y lo instalan mediante la License API, así no consumen otra vez el activation code.
 

--- a/site/src/content/docs/operations/docker-testing.mdx
+++ b/site/src/content/docs/operations/docker-testing.mdx
@@ -6,7 +6,7 @@ faq:
   - q: "How do I run the E2E suite against an ephemeral GitLab?"
     a: "Run `make test-e2e-docker`. That target orchestrates the Docker stack, waits for GitLab, configures the test user and CI runner, runs the Go E2E suite with the `e2e` build tag, and writes JUnit plus JSON reports. The default path uses GitLab CE and creates temporary GitLab data that is removed when the stack is torn down, so you get high-confidence validation without relying on a real `.env` GitLab instance."
   - q: "How do I run Enterprise/Premium Docker E2E coverage?"
-    a: "Set `ENTERPRISE_LICENSE` in `.env` or your shell and run `make test-e2e-docker-enterprise`. That target uses the GitLab EE image plus the `e2e enterprise` build tags, so the common harness files and the `test/e2e/suite/*_ee_test.go` Enterprise/Premium tests are compiled and executed. When `ENTERPRISE_LICENSE` holds a 24-character activation code, the first successful run exports a reusable license key to `test/e2e/.enterprise-license`, so later runs install it through the License API instead of spending the activation code again."
+    a: "Set `ENTERPRISE_LICENSE` in `.env` or your shell and run `make test-e2e-ee` (`make test-e2e-docker-enterprise` is the same target under its older name). It uses the GitLab EE image and runs the `common` and `ee` packages of the rebuilt suite under `test/e2e/gitlab` against the real server binary; there is no Enterprise build tag, the package decides the runtime. When `ENTERPRISE_LICENSE` holds a 24-character activation code, the first successful run exports a reusable license key to `test/e2e/.enterprise-license`, so later runs install it through the License API instead of spending the activation code again."
   - q: "When should I use Docker E2E mode instead of unit tests?"
     a: "Use Docker E2E when changing tool registration, catalog projection, or schemas; when changing pipeline, job, webhook, custom emoji, or mirror behavior; and when verifying release candidates before publishing binaries. It is usually unnecessary for editing a narrow Markdown page or debugging a failing unit test with mocked GitLab responses. Docker E2E is slower than unit tests but is the preferred validation path for architecture migrations because it exercises the real GitLab API together with the MCP transport."
   - q: "How do I clean up Docker E2E test data?"
@@ -39,10 +39,10 @@ That target orchestrates the Docker stack, waits for GitLab, configures the test
 To run the Enterprise/Premium coverage against GitLab EE, set `ENTERPRISE_LICENSE` in `.env` or your shell and use:
 
 ```bash
-make test-e2e-docker-enterprise
+make test-e2e-ee    # or its older name, make test-e2e-docker-enterprise
 ```
 
-That target runs with the `e2e enterprise` build tags, so common harness files plus `test/e2e/suite/*_ee_test.go` Enterprise/Premium tests are compiled and executed. CE-only tests live in `test/e2e/suite/*_ce_test.go` and stay in `make test-e2e-docker`, while Enterprise fixtures can be tuned independently.
+That target runs the `common` and `ee` packages of the rebuilt suite under `test/e2e/gitlab` against the real server binary over stdio. There is no Enterprise build tag: every file carries `e2e` alone, and the package decides the runtime, so `ee` refuses an unlicensed instance before it writes anything while `common` runs its Free actions on the licensed catalog too. The suite under `test/e2e/suite` stays with `make test-e2e-docker` until its CE half is ported.
 
 When `ENTERPRISE_LICENSE` contains a 24-character activation code, the first successful run exports the generated reusable license key to `test/e2e/.enterprise-license`. Later Enterprise runs prefer that ignored local cache and install it through the License API, so they do not need to spend the activation code again.
 

--- a/site/src/data/stats.json
+++ b/site/src/data/stats.json
@@ -1,7 +1,7 @@
 {
   "version": "3.0.0",
   "tools": {
-    "free": 866,
+    "free": 865,
     "premium": 1019,
     "ultimate_self_managed": 1085,
     "gitlab_com": 1091
@@ -13,7 +13,7 @@
   },
   "dynamic": 2,
   "catalog_actions": {
-    "free": 870,
+    "free": 869,
     "self_managed_enterprise": 1089,
     "gitlab_com": 1095
   },

--- a/site/src/data/token-footprint.json
+++ b/site/src/data/token-footprint.json
@@ -10,18 +10,18 @@
   },
   "individual": {
     "free": {
-      "visible_tools": 866,
-      "tool_schema_tokens": 537551,
+      "visible_tools": 865,
+      "tool_schema_tokens": 537351,
       "reduction_factor_vs_dynamic": 353
     },
     "premium": {
       "visible_tools": 1019,
-      "tool_schema_tokens": 646650,
+      "tool_schema_tokens": 646632,
       "reduction_factor_vs_dynamic": 424
     },
     "ultimate": {
       "visible_tools": 1085,
-      "tool_schema_tokens": 680607,
+      "tool_schema_tokens": 680589,
       "reduction_factor_vs_dynamic": 447
     }
   }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,7 +15,7 @@ There are six modules, answering different questions:
 
 Each tag has to be listed in `GO_ANALYSIS_TAGS` in the Makefile and in `e2eTags` in `cmd/gen_testing_docs`, or the module is invisible to `go vet`, to `golangci-lint` and to the generated test metrics. A file behind a tag nothing names is analysed by nothing.
 
-`enterprise` is the one tag that is not a module's. It switches `test/e2e/suite` between two halves that exclude each other: every `*_ce_test.go` carries `e2e && !enterprise` and every `*_ee_test.go` carries `e2e && enterprise`, so a single analysis run sees one half and never the other, and putting the tag in the list above would trade the 128 CE files for the 41 EE ones. It therefore has an analysis pass of its own (`GO_ANALYSIS_ENTERPRISE_TAGS`, scoped to the suite, run by `make golangci-lint`) and a compile step of its own in CI, and it stays out of `e2eTags` because the generated metrics read each directory and already count both halves. Until issue 570 nothing compiled the EE half outside a manual `make test-e2e-docker-enterprise`, which is how nineteen helpers and four constants used only by CE tests came to sit unused under that tag in files both halves share; they now live in `assert_helpers_ce_test.go` and `network_endpoints_ce_test.go`, behind the constraint of the tests that use them.
+Those five tags are the whole list. Every file under `test/e2e/suite`, `test/e2e/gitlab` and `test/e2e/internal` carries `e2e` alone, so one compile and one analysis run see all of them, and the runtime a test needs is decided by the package it is in rather than by a tag. `test/e2e/suite` used to be two halves behind a second tag that excluded each other, which meant a single run could only see one half and the Enterprise one needed a compile step and an analysis pass of its own; that half was ported to `test/e2e/gitlab/ee` and deleted, and both passes went with it.
 
 ## HTTP transport module
 
@@ -136,7 +136,7 @@ DOCKER_HOST=ssh://truenas \
 E2E_DOCKER_GITLAB_URL=http://192.168.0.40:8929 \
 E2E_DOCKER_BITBUCKET_URL=http://192.168.0.40:7990 \
 E2E_BITBUCKET_BIND=0.0.0.0 \
-make test-e2e-docker          # or test-e2e-docker-enterprise
+make test-e2e-docker          # or test-e2e-ce, test-e2e-ee
 ```
 
 `E2E_DOCKER_GITLAB_URL` is also handed to the container as its `external_url`
@@ -151,11 +151,14 @@ that host's network: use it on a LAN you trust.
 Enterprise mode uses the same Docker topology with the EE image and a local
 Ultimate subscription. Store a 24-character activation code in `.env` as
 `ENTERPRISE_LICENSE` or `GITLAB_ACTIVATION_CODE`, or export it in the shell; the
-Docker target passes activation codes to the GitLab EE container during startup.
-`make test-e2e-docker-enterprise` runs with the `e2e enterprise` build tags, so
-common harness files plus `test/e2e/suite/*_ee_test.go` Enterprise/Premium tests
-are compiled and executed. CE-only tests live in `test/e2e/suite/*_ce_test.go`
-and remain in `make test-e2e-docker`.
+lifecycle script passes it to the GitLab EE container during startup.
+`make test-e2e-ee` is the licensed run, and `make test-e2e-docker-enterprise`
+is the same target under its older name. It runs the `common` and `ee`
+packages of the rebuilt suite against the real binary: there is no Enterprise
+build tag, and the package decides the runtime, so `ee` refuses an unlicensed
+instance before it writes anything while `common` runs its Free actions on
+the licensed catalog too. The old suite under `test/e2e/suite` stays with
+`make test-e2e-docker` until its CE half is ported.
 After a successful activation-code run, the setup script exports the generated
 license key to `test/e2e/.enterprise-license` with owner-only permissions. Future
 runs prefer that ignored local cache and install it through the License API, so
@@ -166,10 +169,12 @@ setup script installs those through the License API without writing the secret
 into `test/e2e/.env.docker`.
 
 ```bash
-make test-e2e-docker-enterprise
+make test-e2e-ee
 ```
 
-Equivalent manual setup:
+Equivalent manual setup, which is what `test/e2e/scripts/run-docker-e2e.sh ee`
+does; in Docker mode the harness reads `test/e2e/.env.docker` itself, and
+builds `cmd/server` once per process unless `E2E_SERVER_BINARY` names a build:
 
 ```bash
 GITLAB_ACTIVATION_CODE="$ENTERPRISE_LICENSE" env GITLAB_IMAGE=gitlab/gitlab-ee:latest docker compose -f test/e2e/docker-compose.yml up -d
@@ -177,11 +182,15 @@ GITLAB_ACTIVATION_CODE="$ENTERPRISE_LICENSE" env GITLAB_IMAGE=gitlab/gitlab-ee:l
 GITLAB_ENTERPRISE=true ./test/e2e/scripts/setup-gitlab.sh
 ./test/e2e/scripts/register-runner.sh
 
-set -a && source test/e2e/.env.docker && set +a
-go test -v -tags e2e -timeout 600s ./test/e2e/suite/
+E2E_MODE=docker go test -v -tags e2e -p 1 -count=1 -timeout 3600s ./test/e2e/gitlab/common/ ./test/e2e/gitlab/ee/
 
 env GITLAB_IMAGE=gitlab/gitlab-ee:latest docker compose -f test/e2e/docker-compose.yml down -v
 ```
+
+The old suite runs against the same licensed stack with its usual line,
+`set -a && source test/e2e/.env.docker && set +a` and then
+`go test -v -tags e2e -timeout 600s ./test/e2e/suite/`; a Premium scenario a
+CE file still holds runs there rather than skipping.
 
 Docker mode enables pipeline and job tests that require a CI runner, and starts an internal fixture service used by webhook and custom emoji tests. The setup script also writes `E2E_FIXTURE_URL` and `E2E_GITLAB_INTERNAL_URL` into `.env.docker` so CI runs all non-EE tests without public Internet dependencies.
 

--- a/test/e2e/gitlab/ee/auditevents_test.go
+++ b/test/e2e/gitlab/ee/auditevents_test.go
@@ -88,12 +88,28 @@ func TestAuditEvents_EachScope_ListsAndGetsWhatTheFixtureCaused(t *testing.T) {
 			e.T.Errorf("get_group answered event %d, want the listed %d", groupEvent.ID, groupEvents.AuditEvents[0].ID)
 		}
 
+		// The instance listing holds every event the instance ever recorded,
+		// so a non-empty answer proves nothing about this fixture: wait until
+		// it carries one of the two events found above, and read that one.
+		wanted := map[int64]bool{projectEvents.AuditEvents[0].ID: true, groupEvents.AuditEvents[0].ID: true}
+		fixtureEventIn := func(out auditevents.ListOutput) (int64, bool) {
+			for _, event := range out.AuditEvents {
+				if wanted[event.ID] {
+					return event.ID, true
+				}
+			}
+			return 0, false
+		}
 		instanceEvents := harness.Eventually(s, actionAuditEventListInstance,
-			map[string]any{"per_page": 20}, auditEventInterval, auditEventWait, hasAuditEvents)
+			map[string]any{"per_page": 100}, auditEventInterval, auditEventWait, func(out auditevents.ListOutput) bool {
+				_, found := fixtureEventIn(out)
+				return found
+			})
+		fixtureEventID, _ := fixtureEventIn(instanceEvents)
 		instanceEvent := harness.Do[auditevents.Output](s, actionAuditEventGetInstance,
-			map[string]any{"event_id": instanceEvents.AuditEvents[0].ID})
-		if instanceEvent.ID != instanceEvents.AuditEvents[0].ID {
-			e.T.Errorf("get_instance answered event %d, want the listed %d", instanceEvent.ID, instanceEvents.AuditEvents[0].ID)
+			map[string]any{"event_id": fixtureEventID})
+		if instanceEvent.ID != fixtureEventID {
+			e.T.Errorf("get_instance answered event %d, want the fixture's %d", instanceEvent.ID, fixtureEventID)
 		}
 	})
 }

--- a/test/e2e/gitlab/ee/externalstatuschecks_test.go
+++ b/test/e2e/gitlab/ee/externalstatuschecks_test.go
@@ -60,8 +60,13 @@ func TestExternalStatusChecks_Lifecycle_CreatesSetsRetriesAndDeletes(t *testing.
 		s := e.On(surface)
 		project := f.project.IDParam()
 
+		// The project is this scenario's own, so the deprecated listing has
+		// nothing to show before the create; an item here is a decoder or an
+		// endpoint answering for somebody else.
 		deprecated := harness.Do[externalstatuschecks.ListProjectStatusCheckOutput](s, actionStatusCheckListProjectChecks, map[string]any{"project_id": project})
-		e.T.Logf("the deprecated project listing holds %d check(s) before the create", len(deprecated.Items))
+		if len(deprecated.Items) != 0 {
+			e.T.Errorf("a fresh project lists %d external status check(s) before the create: %+v", len(deprecated.Items), deprecated.Items)
+		}
 
 		name := e.Name("check")
 		created := harness.Do[externalstatuschecks.ProjectStatusCheckOutput](s, actionStatusCheckCreateProject, map[string]any{

--- a/test/e2e/gitlab/ee/integrations_test.go
+++ b/test/e2e/gitlab/ee/integrations_test.go
@@ -6,10 +6,11 @@
 // before GitLab is asked.
 //
 // The key is a placeholder of the shape GitLab validates and nothing ever
-// sends to Datadog: the integration is created inactive, since GitLab
-// cannot verify the key, and it is deleted in the same test. The endpoint is
-// licensed although the catalog lists the actions as Free, which is why the
-// scenario lives here rather than in the common package.
+// sends to Datadog: GitLab stores it without contacting Datadog, so the set
+// leaves the integration active, which is what the read asserts, and the
+// delete in the same test turns it off. The endpoint is licensed although
+// the catalog lists the actions as Free, which is why the scenario lives
+// here rather than in the common package.
 
 package ee
 

--- a/test/e2e/gitlab/ee/issues_test.go
+++ b/test/e2e/gitlab/ee/issues_test.go
@@ -70,20 +70,23 @@ func TestIssueWeightEvents_TwoChanges_ListTheFinalWeight(t *testing.T) {
 	harness.SurfacesWith(e, buildWeightFixture, func(e *harness.Env, surface harness.Surface, f weightFixture) {
 		s := e.On(surface)
 
+		// The events are written asynchronously and one at a time, so the
+		// wait is for the final weight to appear, not for the first event:
+		// a listing that holds only the first change is still on its way.
 		events := harness.Eventually(s, actionIssueWeightEventList,
 			map[string]any{"project_id": f.project.IDParam(), "issue_iid": f.issue.IID}, resourceEventInterval, resourceEventWait,
-			func(out resourceevents.ListWeightEventsOutput) bool { return len(out.Events) > 0 })
-		sawFinal := false
+			func(out resourceevents.ListWeightEventsOutput) bool {
+				for _, event := range out.Events {
+					if event.Weight == finalWeight {
+						return true
+					}
+				}
+				return false
+			})
 		for _, event := range events.Events {
 			if event.ID == 0 {
 				e.T.Errorf("a weight event has no ID: %+v", event)
 			}
-			if event.Weight == finalWeight {
-				sawFinal = true
-			}
-		}
-		if !sawFinal {
-			e.T.Errorf("no weight event records the final weight %d among %d event(s): %+v", finalWeight, len(events.Events), events.Events)
 		}
 	})
 }

--- a/test/e2e/gitlab/ee/mergetrains_test.go
+++ b/test/e2e/gitlab/ee/mergetrains_test.go
@@ -26,21 +26,20 @@ import (
 // mergeTrainFixture is a group-scoped project with merge trains enabled.
 type mergeTrainFixture struct {
 	project fixture.Project
-	// enabled is whether GitLab kept both switches, which decides whether
-	// the add is refused for want of a pipeline or for want of a train.
-	enabled bool
 }
 
 // buildMergeTrainFixture creates the group, the project in it, and turns
-// the trains on.
+// the trains on. The project lives in a group so that GitLab keeps both
+// switches; a project whose switches did not stick would make the scenario
+// assert the refusals of a project without a train, which is not what it
+// claims to cover, so that is a failure rather than a note.
 func buildMergeTrainFixture(e *harness.Env) mergeTrainFixture {
 	group := fixture.NewGroup(e, fixture.WithGroupNamePrefix("mt"))
 	project := fixture.NewProject(e, fixture.WithNamePrefix("mt"), fixture.InGroup(group))
-	enabled := fixture.EnableMergeTrains(e, project)
-	if !enabled {
-		e.T.Logf("GitLab did not keep merge trains enabled on %s; the add and the entry read assert the refusals a project without a train gives", project.Path)
+	if !fixture.EnableMergeTrains(e, project) {
+		e.T.Fatalf("GitLab did not keep merge trains enabled on %s, which is a group project on a licensed instance", project.Path)
 	}
-	return mergeTrainFixture{project: project, enabled: enabled}
+	return mergeTrainFixture{project: project}
 }
 
 // TestMergeTrains_ProjectInGroup_ListsAndRefusesAnUnpipelinedRequest lists

--- a/test/e2e/gitlab/ee/protectedenvs_test.go
+++ b/test/e2e/gitlab/ee/protectedenvs_test.go
@@ -131,9 +131,13 @@ func TestDeploymentApproval_ProtectedEnvironment_RefusesTheDeployer(t *testing.T
 			e.T.Fatalf("deployment_create answered %+v, want a deployment with an ID", deployed)
 		}
 
+		// The wording is GitLab's own, from ee/app/services/deployments/
+		// approval_service.rb: it names self-approval, which is the one
+		// refusal this scenario is about, where "deployment" alone would
+		// also accept an environment that is not protected or has no rule.
 		refused := harness.ExpectToolError(s, actionDeploymentApproveOrReject, map[string]any{
 			"project_id": project.IDParam(), "deployment_id": deployed.ID, "status": "approved", "comment": "e2e deployment approval",
 		}, "deployment")
-		e.T.Logf("approving deployment %d (%s) as its deployer is refused: %s", deployed.ID, deployed.Status, firstLine(refused))
+		assertMentions(e, "the self-approval refusal", refused, "cannot approve your own deployment")
 	})
 }

--- a/test/e2e/gitlab/ee/securityattributes_test.go
+++ b/test/e2e/gitlab/ee/securityattributes_test.go
@@ -10,6 +10,7 @@ package ee
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/securityattributes"
@@ -21,6 +22,12 @@ import (
 const (
 	attributeColor        = "#FF0000"
 	attributeUpdatedColor = "#00FF00"
+)
+
+// The wait for the bulk update's background job to assign the attribute.
+const (
+	bulkUpdateInterval = 2 * time.Second
+	bulkUpdateWait     = 60 * time.Second
 )
 
 // classificationFixture is a top-level group with a project in it, which is
@@ -81,6 +88,16 @@ func TestSecurityAttributes_Lifecycle_AssignsToAProjectAndDeletes(t *testing.T) 
 		if added.AddedCount < 1 {
 			e.T.Errorf("the project update added %d attributes, want at least the one", added.AddedCount)
 		}
+		// Take the attribute off again before the bulk add, so that the bulk
+		// add has something to do: on a project that already carries it a
+		// bulk update answering success proves nothing, and the removal at
+		// the end would pass on the direct add alone.
+		cleared := harness.Do[securityattributes.ProjectUpdateOutput](s, actionSecurityAttributeProjectUpdate, map[string]any{
+			"project_id": f.project.ID, "remove_attribute_ids": []int64{attribute.ID},
+		})
+		if cleared.RemovedCount < 1 {
+			e.T.Errorf("the project update removed %d attributes before the bulk add, want at least the one", cleared.RemovedCount)
+		}
 
 		bulk := harness.Do[securityattributes.BulkUpdateOutput](s, actionSecurityAttributeBulkUpdate, map[string]any{
 			"project_ids": []int64{f.project.ID}, "attribute_ids": []int64{attribute.ID}, "mode": securityattributes.BulkUpdateModeAdd,
@@ -89,11 +106,16 @@ func TestSecurityAttributes_Lifecycle_AssignsToAProjectAndDeletes(t *testing.T) 
 			e.T.Errorf("the bulk update answered status %q, want success: %+v", bulk.Status, bulk)
 		}
 
-		removed := harness.Do[securityattributes.ProjectUpdateOutput](s, actionSecurityAttributeProjectUpdate, map[string]any{
+		// The bulk update is a background job: GitLab's BulkUpdateService
+		// enqueues a scheduler worker and answers "initiated", so the
+		// assignment lands later. No action reads a project's attributes,
+		// so the removal is what observes it: retried until it finds the
+		// one the bulk add assigned, which is what proves the bulk add did.
+		removed := harness.Eventually(s, actionSecurityAttributeProjectUpdate, map[string]any{
 			"project_id": f.project.ID, "remove_attribute_ids": []int64{attribute.ID},
-		})
+		}, bulkUpdateInterval, bulkUpdateWait, func(out securityattributes.ProjectUpdateOutput) bool { return out.RemovedCount >= 1 })
 		if removed.RemovedCount < 1 {
-			e.T.Errorf("the project update removed %d attributes, want at least the one", removed.RemovedCount)
+			e.T.Errorf("the project update removed %d attributes after the bulk add, want the one the bulk add assigned", removed.RemovedCount)
 		}
 
 		harness.DoVoid(s, actionSecurityAttributeDelete, map[string]any{"attribute_id": attribute.ID})

--- a/test/e2e/gitlab/ee/securityscanprofiles_test.go
+++ b/test/e2e/gitlab/ee/securityscanprofiles_test.go
@@ -27,6 +27,12 @@ import (
 // attaches, and the one the provisioning script's feature flags enable.
 const dependencyScanning = "dependency_scanning"
 
+// scanProfileNotConfigured is the status GitLab lists a profile with while
+// no project holds it attached: the listing enumerates every profile of the
+// scan types the project can hold, so a detach shows as this status and
+// never as an absence.
+const scanProfileNotConfigured = "NOT_CONFIGURED"
+
 // TestSecurityScanProfiles_ProjectInGroup_AttachesListsAndDetaches walks
 // the lifecycle once per surface on a project of its own, since a profile
 // attached by one surface would already be present for the next.
@@ -56,14 +62,20 @@ func TestSecurityScanProfiles_ProjectInGroup_AttachesListsAndDetaches(t *testing
 		if statuses.ProjectFullPath != project.Path {
 			e.T.Errorf("the status listing echoes %q, want %q", statuses.ProjectFullPath, project.Path)
 		}
-		var profileID string
+		// The listing names every profile of the scan types the project can
+		// hold, attached or not, with a status per profile; what the attach
+		// changes is the status, which is what the detach below reverts.
+		var profileID, attachedStatus string
 		for _, status := range statuses.Statuses {
 			if strings.EqualFold(status.ScanProfile.ScanType, dependencyScanning) {
-				profileID = status.ScanProfile.ID
+				profileID, attachedStatus = status.ScanProfile.ID, status.Status
 			}
 		}
 		if profileID == "" {
 			e.T.Fatalf("the attached %s profile is not among the project's statuses: %+v", dependencyScanning, statuses.Statuses)
+		}
+		if attachedStatus == scanProfileNotConfigured {
+			e.T.Errorf("the attached %s profile is still %s in the project's statuses: %+v", dependencyScanning, attachedStatus, statuses.Statuses)
 		}
 
 		detached := harness.Do[securityscanprofiles.MutationOutput](s, actionScanProfileDetach, map[string]any{
@@ -71,6 +83,21 @@ func TestSecurityScanProfiles_ProjectInGroup_AttachesListsAndDetaches(t *testing
 		})
 		if detached.Status != "success" {
 			e.T.Errorf("detach answered status %q, want success: %+v", detached.Status, detached)
+		}
+		// A success answer is the mutation's word; the listing is GitLab's,
+		// and a detached profile stays listed with its status back to not
+		// configured.
+		after := harness.Do[securityscanprofiles.ListProjectStatusesOutput](s, actionScanProfileListProjectStatuses,
+			map[string]any{"project_full_path": project.Path})
+		detachedStatus := ""
+		for _, status := range after.Statuses {
+			if status.ScanProfile.ID == profileID {
+				detachedStatus = status.Status
+			}
+		}
+		if detachedStatus != scanProfileNotConfigured {
+			e.T.Errorf("the detached profile %s reads %q in the project's statuses, want %s (was %s while attached): %+v",
+				profileID, detachedStatus, scanProfileNotConfigured, attachedStatus, after.Statuses)
 		}
 	})
 }

--- a/test/e2e/gitlab/ee/vulnerabilities_test.go
+++ b/test/e2e/gitlab/ee/vulnerabilities_test.go
@@ -285,15 +285,25 @@ func assertSASTFindings(e *harness.Env, scope string, out securityfindings.ListO
 		if finding.Severity != "CRITICAL" {
 			e.T.Errorf("%s: finding %s is %s, want CRITICAL", scope, finding.UUID, finding.Severity)
 		}
+		// Exactly one of the report's identifiers per finding: a global
+		// count alone would accept a finding carrying none beside one
+		// carrying two, which is the shape a malformed decode takes.
+		var expected []string
 		for _, identifier := range finding.Identifiers {
 			if !slices.Contains(sastIdentifiers, identifier.Name) {
 				e.T.Errorf("%s: finding %s carries %s, which the report never published", scope, finding.UUID, identifier.Name)
+				continue
 			}
-			if slices.Contains(seen, identifier.Name) {
-				e.T.Errorf("%s: two findings carry %s", scope, identifier.Name)
-			}
-			seen = append(seen, identifier.Name)
+			expected = append(expected, identifier.Name)
 		}
+		if len(expected) != 1 {
+			e.T.Errorf("%s: finding %s carries %d of the report's identifiers %v, want exactly one", scope, finding.UUID, len(expected), expected)
+			continue
+		}
+		if slices.Contains(seen, expected[0]) {
+			e.T.Errorf("%s: two findings carry %s", scope, expected[0])
+		}
+		seen = append(seen, expected[0])
 	}
 	if len(seen) != want {
 		e.T.Errorf("%s: the findings carry %v, want %d distinct identifiers", scope, seen, want)

--- a/test/e2e/internal/fixture/iteration.go
+++ b/test/e2e/internal/fixture/iteration.go
@@ -97,9 +97,12 @@ func NewIteration(e *harness.Env, group Group) Iteration {
 			Errors []string `json:"errors"`
 		} `json:"iterationCadenceCreate"`
 	}
+	// A transport, document or decoding error is a broken endpoint and fails
+	// the test; only GitLab's own refusal in the payload, which is how an
+	// instance without the feature answers, is a reason to skip.
 	err := mutate(e, cadenceMutation, map[string]any{"groupPath": group.Path, "title": e.Name("cadence")}, &cadence)
 	if err != nil {
-		e.Skipf("creating an iteration cadence in group %s: %v", group.Path, err)
+		e.T.Fatalf("creating an iteration cadence in group %s: %v", group.Path, err)
 	}
 	if errs := cadence.IterationCadenceCreate.Errors; len(errs) > 0 {
 		e.Skipf("GitLab refused an iteration cadence in group %s: %s", group.Path, strings.Join(errs, "; "))

--- a/test/e2e/internal/fixture/license.go
+++ b/test/e2e/internal/fixture/license.go
@@ -40,8 +40,14 @@ func CachedEnterpriseLicense(e *harness.Env) string {
 
 	path := licenseCachePath(e.Setting(SettingEnterpriseLicenseFile), e.RepoRoot())
 	key, err := readCachedLicense(path)
-	if err != nil {
+	if errors.Is(err, errNoLicenseCached) {
 		e.Skipf("reading the cached Enterprise license: %v (provision one with test/e2e/scripts/setup-gitlab.sh, or name it with %s)", err, SettingEnterpriseLicenseFile)
+	}
+	if err != nil {
+		// A cache that is there and cannot be read (a directory, a
+		// permission) is a broken checkout, not an unlicensed run, and a
+		// skip would take the license lifecycle out of the suite silently.
+		e.T.Fatalf("reading the cached Enterprise license: %v", err)
 	}
 	return key
 }
@@ -60,11 +66,15 @@ func licenseCachePath(configured, root string) string {
 }
 
 // readCachedLicense reads the key out of one cache file, refusing an empty
-// one the same way as a missing one.
+// one the same way as a missing one; any other read failure is reported as
+// itself, since it says the cache is broken rather than absent.
 func readCachedLicense(path string) (string, error) {
 	data, err := os.ReadFile(path)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("%w at %s: %w", errNoLicenseCached, path, err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
 	}
 	key := strings.TrimSpace(string(data))
 	if key == "" {

--- a/test/e2e/internal/fixture/license_test.go
+++ b/test/e2e/internal/fixture/license_test.go
@@ -57,22 +57,32 @@ func TestReadCachedLicense_Files_AreReadTrimmedOrRefused(t *testing.T) {
 		path    string
 		want    string
 		refused bool
+		broken  bool
 	}{
 		{name: "present", path: present, want: "dGVzdA=="},
 		{name: "empty", path: empty, refused: true},
 		{name: "missing", path: filepath.Join(dir, "missing"), refused: true},
+		// A directory where the file should be opens and cannot be read: a
+		// broken cache, which is reported as itself and never as absent, so
+		// that the caller fails rather than skips.
+		{name: "directory", path: dir, broken: true},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
 			got, err := readCachedLicense(testCase.path)
-			if testCase.refused {
+			switch {
+			case testCase.refused:
 				if !errors.Is(err, errNoLicenseCached) {
 					t.Errorf("readCachedLicense(%s) error = %v, want %v", testCase.name, err, errNoLicenseCached)
 				}
-				return
-			}
-			if err != nil || got != testCase.want {
-				t.Errorf("readCachedLicense(%s) = (%q, %v), want (%q, nil)", testCase.name, got, err, testCase.want)
+			case testCase.broken:
+				if err == nil || errors.Is(err, errNoLicenseCached) {
+					t.Errorf("readCachedLicense(%s) error = %v, want a read error that is not %v", testCase.name, err, errNoLicenseCached)
+				}
+			default:
+				if err != nil || got != testCase.want {
+					t.Errorf("readCachedLicense(%s) = (%q, %v), want (%q, nil)", testCase.name, got, err, testCase.want)
+				}
 			}
 		})
 	}

--- a/test/e2e/suite/access_extras2_ce_test.go
+++ b/test/e2e/suite/access_extras2_ce_test.go
@@ -15,7 +15,7 @@
 // through the admin API and must never run against a real instance or touch
 // the suite's own credentials.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -67,7 +67,7 @@ func accessExtrasCreatePAT(ctx context.Context, t *testing.T, userID int64, pref
 // suite user (owner) then lists the group requests and approves the first
 // user while denying the second on both scopes.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_AccessRequests(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -212,7 +212,7 @@ func TestIndividual_AccessRequests(t *testing.T) {
 // new token ID and invalidates the old one), and revokes the rotated
 // generation. The suite's own credential is never involved.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_PersonalAccessTokenAdminOps(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -275,7 +275,7 @@ func TestIndividual_PersonalAccessTokenAdminOps(t *testing.T) {
 // self-revokes it — rotate first, revoke last, because each step kills the
 // credential it ran on.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_PersonalAccessTokenSelfOps(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -332,7 +332,7 @@ func TestIndividual_PersonalAccessTokenSelfOps(t *testing.T) {
 // remains on the disposable Docker instance — which is exactly why the test
 // is Docker-gated.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_InstanceDeployKeyAdd(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/access_extras_ce_test.go
+++ b/test/e2e/suite/access_extras_ce_test.go
@@ -12,7 +12,7 @@
 // the call, so this file also provides the shared helper that spins up an
 // extra in-process MCP session bound to an arbitrary token.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -82,7 +82,7 @@ func accessExtrasExpiry() gl.ISOTime {
 // deletes it. The token value is only returned at creation time, which the
 // create subtest asserts.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_GroupDeployTokens(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -154,7 +154,7 @@ func TestIndividual_GroupDeployTokens(t *testing.T) {
 // the group's invitation listing. The invitation disappears with the group
 // fixture cleanup.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_GroupInvitations(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -211,7 +211,7 @@ func TestIndividual_GroupInvitations(t *testing.T) {
 // generation is revoked during cleanup so the bot membership never outlives
 // the group fixture.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_GroupAccessTokens(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -301,7 +301,7 @@ func TestIndividual_GroupAccessTokens(t *testing.T) {
 // rotated generation is revoked during cleanup; the project fixture cleanup
 // removes the bot membership regardless.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_ProjectAccessTokenRotateSelf(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/access_meta_ce_test.go
+++ b/test/e2e/suite/access_meta_ce_test.go
@@ -5,7 +5,7 @@
 // access tokens, personal tokens, deploy tokens, deploy keys, access
 // requests, and invitations.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -31,7 +31,7 @@ import (
 // without error. The created project is auto-deleted by the fixture's
 // per-test resource ledger.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AccessTokensProject(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -121,7 +121,7 @@ func TestMeta_AccessTokensProject(t *testing.T) {
 // for visibility; it does not mutate personal tokens because the E2E token is
 // the active credential for the test run.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AccessTokensPersonal(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -149,7 +149,7 @@ func TestMeta_AccessTokensPersonal(t *testing.T) {
 // and defers deletion via deploy_token_delete_project. Each subtest asserts
 // the expected ID and that the meta-tool returns a structured output.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AccessDeployTokens(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -232,7 +232,7 @@ func TestMeta_AccessDeployTokens(t *testing.T) {
 // enable step. The parallel flag is dropped in Enterprise mode because
 // shared GitLab state is touched across both fixtures.
 //
-// Build tag: e2e && !enterprise. Mode: CE/EE. Surface: meta.
+// Build tag: e2e. Mode: CE/EE. Surface: meta.
 func TestMeta_DeployKeysExtended(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()
@@ -323,7 +323,7 @@ func TestMeta_DeployKeysExtended(t *testing.T) {
 // well-formed even when no requests are pending, asserting that the meta-tool
 // returns a structured empty slice rather than an error.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AccessRequests(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -354,7 +354,7 @@ func TestMeta_AccessRequests(t *testing.T) {
 // returned invitation status is one of the GitLab-recognized states
 // (accepted, pending, expired).
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Invitations(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/accesstokens_ce_test.go
+++ b/test/e2e/suite/accesstokens_ce_test.go
@@ -4,7 +4,7 @@
 // live GitLab instance using both individual tools and the gitlab_access
 // meta-tool. Exercises the full token lifecycle: create → get → list → revoke.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -29,7 +29,7 @@ func expiresAtNextYear() string {
 // Revoke runs last and confirms the tool returns no error for a valid ID.
 // The created project is auto-deleted by [createProject]'s ledger entry.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_AccessTokens(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -92,7 +92,7 @@ func TestIndividual_AccessTokens(t *testing.T) {
 // asserting the same create → get → list → revoke outcome and verifying the
 // tool name stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AccessTokens(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/admin_ce_test.go
+++ b/test/e2e/suite/admin_ce_test.go
@@ -4,7 +4,7 @@
 // a live GitLab instance. Covers topic listing, settings retrieval via
 // gitlab_admin, and job token scope via gitlab_job.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -25,7 +25,7 @@ import (
 // admin settings through settings_get and asserts the returned map has at
 // least one key. Neither subtest mutates GitLab state.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Admin(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -59,7 +59,7 @@ func TestMeta_Admin(t *testing.T) {
 // through token_scope_get and asserts the response carries an inbound_enabled
 // flag.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_JobTokens(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/admin_extras2_ce_test.go
+++ b/test/e2e/suite/admin_extras2_ce_test.go
@@ -8,7 +8,7 @@
 // bulk_import_entity_list, bulk_import_entity_get,
 // bulk_import_entity_failures, and bulk_import_cancel.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -125,7 +125,7 @@ func admBulkWaitTerminal(ctx context.Context, t *testing.T, importID int64) stri
 // started and canceled immediately, asserting the canceled status
 // round-trips. Both destination groups are registered for deletion.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminBulkImports(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/admin_extras_ce_test.go
+++ b/test/e2e/suite/admin_extras_ce_test.go
@@ -13,7 +13,7 @@
 // fixtures only the disposable Docker instance can provide) and require an
 // admin token.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -158,7 +158,7 @@ func admExtrasCreateAlert(ctx context.Context, t *testing.T, projectPath string)
 // asserts a new non-empty secret different from the original is returned,
 // and defers deletion of the application.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminApplicationRenewSecret(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -209,7 +209,7 @@ func TestMeta_AdminApplicationRenewSecret(t *testing.T) {
 // reflected in the action output, and restores the original value with a
 // deferred SDK call so the instance-wide limit never drifts.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminPlanLimitsChange(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -260,7 +260,7 @@ func TestMeta_AdminPlanLimitsChange(t *testing.T) {
 // secure file (base64 content), lists and fetches it back asserting the name
 // and checksum round-trip, and deletes it asserting the list is empty again.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminSecureFiles(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -351,7 +351,7 @@ func TestMeta_AdminSecureFiles(t *testing.T) {
 // variable, verifies the variable key is reported by system_hook_get, and
 // deletes the variable. The hook itself is deleted via a deferred call.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminSystemHookEditURLVariables(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -449,7 +449,7 @@ func TestMeta_AdminSystemHookEditURLVariables(t *testing.T) {
 // its feature flag enabled (verified by live probing), so a clean 404 is the
 // deterministic outcome; a future GitLab that serves it passes too.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminUsageData(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -561,7 +561,7 @@ func TestMeta_AdminUsageData(t *testing.T) {
 // The test performs the real call and asserts that clean error path, which
 // validates routing and error wrapping for the action without a license.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminLicenseGetCE(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -596,7 +596,7 @@ func TestMeta_AdminLicenseGetCE(t *testing.T) {
 // be 2), locks and unlocks it, deletes the non-latest version (the API
 // refuses to delete the latest), and finally deletes the whole state.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminTerraformStates(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -729,7 +729,7 @@ func TestMeta_AdminTerraformStates(t *testing.T) {
 // error_tracking_delete — works regardless of the settings record and is
 // asserted strictly.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminErrorTracking(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -826,7 +826,7 @@ func TestMeta_AdminErrorTracking(t *testing.T) {
 // payload at its notify URL (which synchronously returns the alert IID), and
 // then walks the metric image lifecycle against that alert with a real PNG.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminAlertMetricImages(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -916,7 +916,7 @@ func TestMeta_AdminAlertMetricImages(t *testing.T) {
 // probing on a fresh group), so the call is asserted to succeed against a
 // disposable group fixture.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_AdminDependencyProxyPurge(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -1034,7 +1034,7 @@ func adminExtrasImportGists(ctx context.Context, t *testing.T, ghToken string) {
 // writes them to .env.docker, so the subtest runs for real; elsewhere it
 // skips unless the operator points it at a reachable Bitbucket Server.
 //
-// Build tag: e2e && !enterprise. Mode: any (credential-gated). Surface: meta.
+// Build tag: e2e. Mode: any (credential-gated). Surface: meta.
 func TestMeta_AdminExternalImporters(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -1147,7 +1147,7 @@ func TestMeta_AdminExternalImporters(t *testing.T) {
 // it automatically in Docker mode by deleting the newest Rails-resolvable
 // schema_migrations row; the mark call here re-inserts it.
 //
-// Build tag: e2e && !enterprise. Mode: any (error path) / Docker with
+// Build tag: e2e. Mode: any (error path) / Docker with
 // E2E_DB_MIGRATION_VERSION (mutating path). Surface: meta.
 func TestMeta_AdminDBMigrationMark(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/suite/admin_meta_ce_test.go
+++ b/test/e2e/suite/admin_meta_ce_test.go
@@ -5,7 +5,7 @@
 // settings, appearance, broadcast messages, feature flags, system hooks,
 // Sidekiq metrics, plan limits, metadata, applications, and custom attributes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -36,7 +36,7 @@ import (
 // topic, fetches it, and updates its description. Cleanup deletes the topic
 // via a deferred call so the instance stays clean even when subtests fail.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminTopics(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -106,7 +106,7 @@ func TestMeta_AdminTopics(t *testing.T) {
 // changes only the default branch name to "main" — and runs in isolation
 // because instance-global state is touched.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminSettingsAppearance(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -160,7 +160,7 @@ func TestMeta_AdminSettingsAppearance(t *testing.T) {
 // stays clean. Each subtest asserts the expected ID round-trips and the
 // operation reports no error.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminBroadcast(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -235,7 +235,7 @@ func TestMeta_AdminBroadcast(t *testing.T) {
 // true, and then deletes it. The feature name is suffixed with the current
 // millisecond timestamp so parallel runs cannot collide on the same flag.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminFeatures(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -300,7 +300,7 @@ func TestMeta_AdminFeatures(t *testing.T) {
 // The test event is allowed to fail silently on isolated networks because
 // the example.com URL will not deliver; the deletion still runs.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminSystemHooks(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -372,7 +372,7 @@ func TestMeta_AdminSystemHooks(t *testing.T) {
 // is mutated, so the test can run in parallel with other admin-only tests
 // that touch different instance endpoints.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminSidekiqMetrics(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -426,7 +426,7 @@ func TestMeta_AdminSidekiqMetrics(t *testing.T) {
 // call asserts that the GitLab version is non-empty so an empty response
 // (proxy misroute) is caught early.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminPlanLimitsMetadata(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -482,7 +482,7 @@ func TestMeta_AdminPlanLimitsMetadata(t *testing.T) {
 // intentionally non-deliverable so the application cannot be exercised
 // against a real callback endpoint.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminApplications(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -537,7 +537,7 @@ func TestMeta_AdminApplications(t *testing.T) {
 // Cleanup deletes the attribute via a deferred call so the user is restored
 // even when subtests fail.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AdminCustomAttributes(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/annotations_ce_test.go
+++ b/test/e2e/suite/annotations_ce_test.go
@@ -5,7 +5,7 @@
 // destructive detection): it calls tools/list on both individual and meta
 // sessions and verifies that destructiveHint is consistent with tool semantics.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (

--- a/test/e2e/suite/assert_helpers_ce_test.go
+++ b/test/e2e/suite/assert_helpers_ce_test.go
@@ -1,18 +1,18 @@
 //go:build e2e
 
 // assert_helpers_ce_test.go holds the listing projections only the Community
-// Edition suites read, split from assert_helpers_test.go so that they live
-// behind the constraint of the tests that use them.
+// Edition suites read, split from assert_helpers_test.go when the suite was
+// still two halves behind two build tags, so that they lived behind the
+// constraint of the tests that use them.
 //
-// They used to sit in the shared file, which both halves of the suite compile,
-// and were therefore unused under the Enterprise tag: every *_ce_test.go
-// carries `e2e && !enterprise`, so an Enterprise compile drops the only callers
-// and keeps the helpers. Nothing noticed for as long as nothing compiled that
-// half outside a manual run, which is what issue 570 changed. A projection an
-// Enterprise suite also needs belongs in assert_helpers_test.go, as
-// groupBoardIDs does.
+// They used to sit in the shared file, which both halves compiled, and were
+// therefore unused under the Enterprise tag: the CE files were excluded from
+// an Enterprise compile, which dropped the only callers and kept the helpers.
+// Nothing noticed for as long as nothing compiled that half outside a manual
+// run, which is what issue 570 changed. The split is history now, since every
+// file carries `e2e` alone, and the file keeps its name until the suite goes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (

--- a/test/e2e/suite/award_emoji_ce_test.go
+++ b/test/e2e/suite/award_emoji_ce_test.go
@@ -4,7 +4,7 @@
 // instance using both individual tools and the gitlab_issue meta-tool.
 // Exercises the full emoji lifecycle on issues: create → list → get → delete.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // asserts the expected ID round-trips through get and that the list
 // contains at least the created emoji.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_AwardEmoji(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -91,7 +91,7 @@ func TestIndividual_AwardEmoji(t *testing.T) {
 // emoji_issue_delete. Each subtest asserts the same outcome and verifies
 // the tool name stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_AwardEmoji(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/badges_ce_test.go
+++ b/test/e2e/suite/badges_ce_test.go
@@ -4,7 +4,7 @@
 // instance using both individual tools and the gitlab_project meta-tool.
 // Exercises the full badge lifecycle: create → get → list → update → delete.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // updates its link URL, and finally deletes it. Each subtest asserts the
 // expected ID or URL round-trips and that the list contains the badge.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Badges(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -104,7 +104,7 @@ func TestIndividual_Badges(t *testing.T) {
 // test skips the explicit get subtest because the meta-tool routes through
 // the same GitLab endpoint and the list subtest confirms identity.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Badges(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/boards_ce_test.go
+++ b/test/e2e/suite/boards_ce_test.go
@@ -4,7 +4,7 @@
 // meta-tool against a live GitLab instance. Exercises the full board
 // lifecycle: create → list → get → delete.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // Cleanup relies on the explicit delete subtest; project removal is
 // handled by the per-test resource ledger.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Boards(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/branches_ce_test.go
+++ b/test/e2e/suite/branches_ce_test.go
@@ -4,7 +4,7 @@
 // Each top-level test function creates its own project fixture and runs all
 // subtests independently of any other domain test file.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // Each subtest asserts the expected branch name, commit SHA, or
 // protection level round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Branches(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -168,7 +168,7 @@ func TestIndividual_Branches(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Branches(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/ci_lint_ce_test.go
+++ b/test/e2e/suite/ci_lint_ce_test.go
@@ -4,7 +4,7 @@
 // using both individual tools and the gitlab_template meta-tool. Validates
 // CI configuration content and project-level linting.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // asserts Valid=false. Together they exercise both inline content and
 // repository-backed lint paths.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_CILint(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()
@@ -65,7 +65,7 @@ func TestIndividual_CILint(t *testing.T) {
 // tool, using lint and lint_project. Each subtest asserts the same
 // Valid / Invalid outcome and verifies the tool name stays constant.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CILint(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/ci_variables_ce_test.go
+++ b/test/e2e/suite/ci_variables_ce_test.go
@@ -5,7 +5,7 @@
 // meta-tool. Exercises the full variable lifecycle: create → get → list →
 // update → delete.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // subtest asserts the returned key/value round-trips through the GitLab
 // API and that list contains the created variable.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_CIVariables(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -101,7 +101,7 @@ func TestIndividual_CIVariables(t *testing.T) {
 // tool, using create, get, list, update, and delete. Each subtest asserts
 // the same outcome and verifies the tool name stays constant.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CIVariables(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/ci_variables_meta_ce_test.go
+++ b/test/e2e/suite/ci_variables_meta_ce_test.go
@@ -4,7 +4,7 @@
 // the gitlab_ci_variable meta-tool against a live GitLab instance.
 // Exercises the group variable lifecycle: list → create → get → update.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -27,7 +27,7 @@ import (
 // deletes both the variable and the group via deferred calls so the
 // GitLab instance stays clean even when subtests fail.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CIVariablesGroup(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/cluster_agents_ce_test.go
+++ b/test/e2e/suite/cluster_agents_ce_test.go
@@ -5,7 +5,7 @@
 // list tokens → get token → revoke token → delete agent, using both individual
 // tools and the gitlab_admin meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -25,7 +25,7 @@ import (
 // token ID round-trips through the GitLab API. The project itself is
 // removed by the per-test resource ledger at test exit.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_ClusterAgents(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -151,7 +151,7 @@ func TestIndividual_ClusterAgents(t *testing.T) {
 // expected ID or token ID round-trips and verifies the tool name stays
 // constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ClusterAgents(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/commits_ce_test.go
+++ b/test/e2e/suite/commits_ce_test.go
@@ -4,7 +4,7 @@
 // instance using both individual tools and the gitlab_repository meta-tool.
 // Exercises: commit list, get, diff, and file retrieval.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -26,7 +26,7 @@ import (
 // from the default branch. Each subtest asserts the expected ID, SHA, or
 // filename round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Commits(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -94,7 +94,7 @@ func TestIndividual_Commits(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Commits(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/confirm_guard_ce_test.go
+++ b/test/e2e/suite/confirm_guard_ce_test.go
@@ -45,7 +45,7 @@ func guardResultText(result *mcp.CallToolResult) string {
 // silently: the call is blocked with a confirm=true instruction, nothing is
 // deleted, and the explicit confirm=true retry executes the deletion.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual (no elicitation).
+// Build tag: e2e. Mode: CE. Surface: individual (no elicitation).
 func TestDestructiveConfirmGuard_NoElicitationClient(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/test/e2e/suite/custom_emoji_ce_test.go
+++ b/test/e2e/suite/custom_emoji_ce_test.go
@@ -4,7 +4,7 @@
 // GitLab instance using both individual tools and the gitlab_custom_emoji
 // meta-tool. Exercises custom emoji create → list → delete lifecycle.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -25,7 +25,7 @@ import (
 // created emoji. Each subtest asserts the expected name or ID round-trips
 // and that the list contains the created emoji.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_CustomEmoji(t *testing.T) {
 	t.Parallel()
 
@@ -89,7 +89,7 @@ func TestIndividual_CustomEmoji(t *testing.T) {
 // gitlab_custom_emoji tool. The temporary group fixture is cleaned up via
 // t.Cleanup so the GitLab instance stays clean even when subtests fail.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CustomEmoji(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/suite/deploy_keys_ce_test.go
+++ b/test/e2e/suite/deploy_keys_ce_test.go
@@ -3,7 +3,7 @@
 // deploy_keys_ce_test.go tests the deploy key MCP tools against a live GitLab instance.
 // Covers add, get, list, update, and delete for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -41,7 +41,7 @@ func generateTestSSHKey(t *testing.T) string {
 // title round-trips through the GitLab API. Cleanup relies on the
 // explicit delete subtest plus the per-test project cleanup.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_DeployKeys(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -115,7 +115,7 @@ func TestIndividual_DeployKeys(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_DeployKeys(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/deploy_tokens_ce_test.go
+++ b/test/e2e/suite/deploy_tokens_ce_test.go
@@ -3,7 +3,7 @@
 // deploy_tokens_ce_test.go tests the deploy token MCP tools against a live GitLab instance.
 // Exercises create, list, get, and delete via the gitlab_access meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // subtest asserts the expected ID round-trips through the GitLab API and
 // that the list contains the created token.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_DeployTokens(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/deployments_meta_ce_test.go
+++ b/test/e2e/suite/deployments_meta_ce_test.go
@@ -3,7 +3,7 @@
 // deployments_meta_ce_test.go tests the deployment MCP tools against a live GitLab instance.
 // Exercises get, update, and delete via the gitlab_environment meta-tool (deployment_* actions).
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // Each subtest asserts the expected ID round-trips through the GitLab
 // API and verifies the tool name stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_DeploymentsGetUpdateDelete(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/doc.go
+++ b/test/e2e/suite/doc.go
@@ -9,14 +9,14 @@
 // # Editions and Modes
 //
 // Every file carries the one build constraint `e2e`. The suite used to be
-// split by edition, with the `_ce_test.go` files behind `e2e && !enterprise`
-// and an `_ee_test.go` half behind `e2e && enterprise` for the features that
-// need a GitLab Enterprise license (epics, group protected branches,
-// iterations, SAML/SCIM, compliance frameworks, security policies). That
-// half was ported to test/e2e/gitlab/ee and deleted, and the `_ce_test.go`
-// files kept their suffix and lost the constraint; what remains runs on
-// either edition, and a Premium scenario a CE file still holds skips when
-// the running GitLab reports Free.
+// split by edition behind a second build tag that excluded one half from the
+// other: the `_ce_test.go` files on one side and an `_ee_test.go` half on the
+// other for the features that need a GitLab Enterprise license (epics, group
+// protected branches, iterations, SAML/SCIM, compliance frameworks, security
+// policies). That half was ported to test/e2e/gitlab/ee and deleted, the tag
+// with it, and the `_ce_test.go` files kept their suffix and lost the
+// constraint; what remains runs on either edition, and a Premium scenario a
+// CE file still holds skips when the running GitLab reports Free.
 //
 // Each domain is exercised under multiple MCP surfaces where applicable:
 //

--- a/test/e2e/suite/elicitation_ce_test.go
+++ b/test/e2e/suite/elicitation_ce_test.go
@@ -3,7 +3,7 @@
 // elicitation_ce_test.go tests the MCP elicitation capability against a live GitLab instance.
 // Uses the elicitation-enabled session with an auto-accept mock handler.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // accepts with plausible field values and the test asserts the resulting
 // issue IID is positive.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: elicitation.
+// Build tag: e2e. Mode: CE. Surface: elicitation.
 func TestElicitation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/enterprise_ce_test.go
+++ b/test/e2e/suite/enterprise_ce_test.go
@@ -2,7 +2,7 @@
 
 // enterprise_ce_test.go verifies CE catalog behavior for Enterprise-only tools.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -21,7 +21,7 @@ import (
 // _classifications) appear in the catalog. This is a structural check:
 // exposing EE tools on CE would leak Premium/Ultimate endpoints.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: catalog.
+// Build tag: e2e. Mode: CE. Surface: catalog.
 func TestEnterpriseSecurityTools_NotRegisteredOnCE(t *testing.T) {
 	t.Parallel()
 	if sess.enterprise {

--- a/test/e2e/suite/environments_ce_test.go
+++ b/test/e2e/suite/environments_ce_test.go
@@ -3,7 +3,7 @@
 // environments_ce_test.go tests the environment MCP tools against a live GitLab instance.
 // Covers create, get, list, update, stop, and delete for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // environment, and gitlab_delete_environment tools. Each subtest asserts
 // the expected ID or name round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Environments(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()
@@ -117,7 +117,7 @@ func TestIndividual_Environments(t *testing.T) {
 // gitlab_environment tool. Each subtest asserts the same outcome and
 // verifies the tool name stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Environments(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/environments_meta_ce_test.go
+++ b/test/e2e/suite/environments_meta_ce_test.go
@@ -3,7 +3,7 @@
 // environments_meta_ce_test.go tests environment-related meta-tool actions against a live
 // GitLab instance, including protected environments, freeze periods, and deployment CRUD.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -25,7 +25,7 @@ import (
 // actions through the catalog-backed meta-tool, asserting each step's
 // expected ID round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: EE. Surface: meta.
+// Build tag: e2e. Mode: EE. Surface: meta.
 func TestMeta_EnvironmentsProtected(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -109,7 +109,7 @@ func TestMeta_EnvironmentsProtected(t *testing.T) {
 // catalog-backed gitlab_environment tool. Each subtest asserts the
 // expected ID or schedule round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_EnvironmentsFreeze(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -195,7 +195,7 @@ func TestMeta_EnvironmentsFreeze(t *testing.T) {
 // subtest asserts the expected ID or environment name round-trips
 // through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_DeploymentsExtended(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/feature_flag_extras_ce_test.go
+++ b/test/e2e/suite/feature_flag_extras_ce_test.go
@@ -4,7 +4,7 @@
 // and delete MCP tools against a live GitLab instance. Flag creation is
 // already exercised elsewhere and is reused here only as fixture setup.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // verifies a follow-up get fails. A best-effort cleanup removes the flag if
 // the delete subtest never ran.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_FeatureFlagExtras(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/freeze_periods_ce_test.go
+++ b/test/e2e/suite/freeze_periods_ce_test.go
@@ -3,7 +3,7 @@
 // freeze_periods_ce_test.go tests the freeze period MCP tools against a live GitLab instance.
 // Exercises create, list, get, update, and delete via the gitlab_environment meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -22,7 +22,7 @@ import (
 // freeze_period_update, and freeze_period_delete actions. Each subtest
 // asserts the expected ID round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_FreezePeriods(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/group_extras2_ce_test.go
+++ b/test/e2e/suite/group_extras2_ce_test.go
@@ -7,7 +7,7 @@
 // provisioning a group issue board via API is a Premium capability, so the
 // coverage is enterprise-gated like the other EE tests.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -42,7 +42,7 @@ import (
 // empty and that both delete actions surface their documented 404 error
 // paths instead.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupMarkdownUploads(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -174,7 +174,7 @@ func runGroupExtrasUploadUnavailablePath(t *testing.T, ctx context.Context, grp 
 // assertion stands and the download/import subtests skip with the reason.
 // The imported group is deleted once GitLab finishes materializing it.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupExportImport(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -258,7 +258,7 @@ func TestMeta_GroupExportImport(t *testing.T) {
 // the schedule confirmation already proves the export pipeline accepted the
 // request; the poll outcome is logged either way.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupRelationsExport(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -337,7 +337,7 @@ func TestMeta_GroupRelationsExport(t *testing.T) {
 // hard-deleted afterwards. Docker-gated because service-account creation is
 // an instance-admin operation on self-managed GitLab.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta.
 // Admin token required.
 func TestMeta_GroupServiceAccountPATRotate(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/suite/group_extras_ce_test.go
+++ b/test/e2e/suite/group_extras_ce_test.go
@@ -8,7 +8,7 @@
 // sub-operations (custom headers, URL variables, test triggers, and event
 // resends).
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -48,7 +48,7 @@ const (
 // and lists it via shared_projects, transfers the project into the parent
 // group, and finally moves the child group under the parent.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupExtrasLifecycle(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -201,7 +201,7 @@ func runGroupExtrasTransferOps(t *testing.T, ctx context.Context, e2e *E2EContex
 // documents that behavior with a skip instead of failing. When delayed
 // deletion applies, the restore must return the original group ID.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupRestore(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -253,7 +253,7 @@ func TestMeta_GroupRestore(t *testing.T) {
 // group_member_unshare). Each unshare runs before the next share so the pair
 // never holds two overlapping invitations.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupToGroupSharing(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -337,7 +337,7 @@ func TestMeta_GroupToGroupSharing(t *testing.T) {
 // fresh group as Developer, promotes it to Maintainer, and removes it. Each
 // step asserts the member payload round-trips the user ID and access level.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta.
 // Admin token required.
 func TestMeta_GroupMemberLifecycle(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/suite/group_labels_ce_test.go
+++ b/test/e2e/suite/group_labels_ce_test.go
@@ -3,7 +3,7 @@
 // group_labels_ce_test.go tests the group label MCP tools against a live GitLab instance.
 // Exercises create, list, and delete via the gitlab_group meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -26,7 +26,7 @@ import (
 // gitlab_group meta-tool. Cleanup deletes the group via a deferred call
 // so the GitLab instance stays clean even when subtests fail.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupLabels(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/test/e2e/suite/group_milestones_ce_test.go
+++ b/test/e2e/suite/group_milestones_ce_test.go
@@ -3,7 +3,7 @@
 // group_milestones_ce_test.go tests the group milestone MCP tools against a live GitLab instance.
 // Exercises create, list, get, and delete via the gitlab_group meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -27,7 +27,7 @@ import (
 // deletes the group via a deferred call so the GitLab instance stays
 // clean even when subtests fail.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupMilestones(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/test/e2e/suite/group_variables_ce_test.go
+++ b/test/e2e/suite/group_variables_ce_test.go
@@ -3,7 +3,7 @@
 // group_variables_ce_test.go tests the group CI variable MCP tools against a live GitLab instance.
 // Exercises create, list, get, update, and delete via the gitlab_ci_variable meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -27,7 +27,7 @@ import (
 // subtest asserts the expected key or value round-trips through the
 // GitLab API. Cleanup deletes the group via a deferred call.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupVariables(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/groups_ce_test.go
+++ b/test/e2e/suite/groups_ce_test.go
@@ -3,7 +3,7 @@
 // groups_ce_test.go tests the group MCP tools against a live GitLab instance.
 // Covers create, list, get, members, subgroups, and delete for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -26,7 +26,7 @@ import (
 // gitlab_group_* tools. Each subtest asserts the expected ID or name
 // round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Groups(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -170,7 +170,7 @@ func TestIndividual_Groups(t *testing.T) {
 // the unique-project-download-limit cluster) are intentionally not set here so
 // the test stays green on a CE instance.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_GroupNewV241Fields(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -221,7 +221,7 @@ func TestIndividual_GroupNewV241Fields(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Groups(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/groups_meta_ce_test.go
+++ b/test/e2e/suite/groups_meta_ce_test.go
@@ -3,7 +3,7 @@
 // groups_meta_ce_test.go tests advanced CE/common gitlab_group meta-tool actions
 // against a live GitLab instance.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // Each subtest asserts the expected ID or path round-trips through the
 // GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_GroupDeep(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/import_service_ce_test.go
+++ b/test/e2e/suite/import_service_ce_test.go
@@ -14,7 +14,7 @@
 //
 // The field wiring itself is covered exhaustively by the importservice unit tests.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 package suite
 
 import (

--- a/test/e2e/suite/instance_variables_ce_test.go
+++ b/test/e2e/suite/instance_variables_ce_test.go
@@ -3,7 +3,7 @@
 // instance_variables_ce_test.go tests the instance-level CI variable MCP tools against a live
 // GitLab instance. Exercises create, list, get, update, and delete via the gitlab_ci_variable meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -22,7 +22,7 @@ import (
 // instance_update, and instance_delete. Each subtest asserts the expected
 // key or value round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CIVariablesInstance(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/issue_discussions_ce_test.go
+++ b/test/e2e/suite/issue_discussions_ce_test.go
@@ -4,7 +4,7 @@
 // GitLab instance. Covers threaded discussion create, list, get, add note,
 // update note, and delete note for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // threaded discussion. Each subtest asserts the expected discussion ID,
 // note ID, or body round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_IssueDiscussions(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -122,7 +122,7 @@ func TestIndividual_IssueDiscussions(t *testing.T) {
 // gitlab_issue tool. Each subtest asserts the same outcome and verifies
 // the tool name stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_IssueDiscussions(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/issue_links_ce_test.go
+++ b/test/e2e/suite/issue_links_ce_test.go
@@ -4,7 +4,7 @@
 // instance. Covers link create, list, get, and delete between two issues
 // for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // the link by ID, and finally deletes it. Each subtest asserts the expected
 // link ID or source/target IID round-trips through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_IssueLinks(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -92,7 +92,7 @@ func TestIndividual_IssueLinks(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_IssueLinks(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/issue_notes_ce_test.go
+++ b/test/e2e/suite/issue_notes_ce_test.go
@@ -4,7 +4,7 @@
 // instance. Covers note create, list, get, update, and delete for both
 // individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // subtest asserts the expected note ID or body round-trips through the
 // GitLab API. The project is removed by the per-test resource ledger.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_IssueNotes(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -99,7 +99,7 @@ func TestIndividual_IssueNotes(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_IssueNotes(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/issues_ce_test.go
+++ b/test/e2e/suite/issues_ce_test.go
@@ -4,7 +4,7 @@
 // instance. Covers create, get, list, update, note create/list, and delete
 // for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -27,7 +27,7 @@ import (
 // the expected IID, title, or note ID round-trips through the GitLab API.
 // The project is removed by the per-test resource ledger at test exit.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Issues(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -179,7 +179,7 @@ func TestIndividual_Issues(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Issues(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/job_extras_ce_test.go
+++ b/test/e2e/suite/job_extras_ce_test.go
@@ -7,7 +7,7 @@
 // job.delete_artifacts, job.erase, job.retry, job.cancel, job.play, and
 // job.list_bridges through the individual tool surface.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -90,7 +90,7 @@ trigger-child:
 // Outside Docker mode the test skips when no runner picks up the pipeline's
 // jobs within the pickup budget.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_JobExtras(t *testing.T) {
 	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(_ *E2EContext) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)

--- a/test/e2e/suite/jobs_meta_ce_test.go
+++ b/test/e2e/suite/jobs_meta_ce_test.go
@@ -5,7 +5,7 @@
 // and extended job actions (list bridges, delete project artifacts) via the
 // gitlab_job meta-tool.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -146,7 +146,7 @@ func TestMeta_JobTokenScope(t *testing.T) {
 // artifact delete, and other extended actions. Each subtest asserts the
 // expected outcome and verifies the tool name stays constant.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_JobsExtended(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/labels_ce_test.go
+++ b/test/e2e/suite/labels_ce_test.go
@@ -4,7 +4,7 @@
 // instance. Covers label create, list, update, and delete for both individual
 // and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -25,7 +25,7 @@ import (
 // ID, name, or color round-trips through the GitLab API. The project is
 // removed by the per-test resource ledger at test exit.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Labels(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -93,7 +93,7 @@ func TestIndividual_Labels(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Labels(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/markdown_ce_test.go
+++ b/test/e2e/suite/markdown_ce_test.go
@@ -4,7 +4,7 @@
 // GitLab instance. Covers basic markdown-to-HTML rendering and GitLab Flavored
 // Markdown (GFM) rendering with project context.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // expected tags. Each subtest runs without a project fixture so the
 // render endpoint stays stateless.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_MarkdownRender(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/members_ce_test.go
+++ b/test/e2e/suite/members_ce_test.go
@@ -4,7 +4,7 @@
 // instance. Covers member listing and retrieval of the project owner for both
 // individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -24,7 +24,7 @@ import (
 // project owner, who is always present). The second fetches that owner by
 // member ID and asserts the round-trip.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Members(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -72,7 +72,7 @@ func TestIndividual_Members(t *testing.T) {
 // tool. Each subtest asserts the same outcome and verifies the tool name
 // stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Members(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/merge_requests_ce_test.go
+++ b/test/e2e/suite/merge_requests_ce_test.go
@@ -4,7 +4,7 @@
 // live GitLab instance. Covers create, get, list, update, commits, participants,
 // and delete for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -59,7 +59,7 @@ func setupMRProjectMeta(ctx context.Context, t *testing.T, session *mcp.ClientSe
 // the GitLab API. The test waits for MR readiness before checking
 // commits so the assertions do not race with the sidekiq diff job.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_MergeRequests(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()
@@ -170,7 +170,7 @@ func TestIndividual_MergeRequests(t *testing.T) {
 // gitlab_merge_request tool. Each subtest asserts the same outcome and
 // verifies the tool name stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_MergeRequests(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/milestones_ce_test.go
+++ b/test/e2e/suite/milestones_ce_test.go
@@ -4,7 +4,7 @@
 // GitLab instance. Covers milestone create, get, update (with close), and
 // delete for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -23,7 +23,7 @@ import (
 // asserts the expected IID, title, or state round-trips through the
 // GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Milestones(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -94,7 +94,7 @@ func TestIndividual_Milestones(t *testing.T) {
 // gitlab_project tool. Each subtest asserts the same outcome and
 // verifies the tool name stays constant across the lifecycle.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Milestones(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/misc_extras_ce_test.go
+++ b/test/e2e/suite/misc_extras_ce_test.go
@@ -5,7 +5,7 @@
 // catalog resource get, deployment merge requests, and the GraphQL work item
 // type listing.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -36,7 +36,7 @@ import (
 // latest release and asserts the tag name round-trips. The fetch is retried
 // because a just-created release can lag behind the latest-release endpoint.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_ReleaseGetLatest(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -85,7 +85,7 @@ func TestIndividual_ReleaseGetLatest(t *testing.T) {
 // diff is non-empty (diff computation is asynchronous). It asserts the diff
 // mentions the file committed to the feature branch.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_MRRawDiffs(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -134,7 +134,7 @@ func TestIndividual_MRRawDiffs(t *testing.T) {
 // full path. Marking is version- and instance-policy-dependent, so mutation
 // failures skip the test with the reported reason rather than failing it.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_CICatalogGet(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -315,7 +315,7 @@ component-job:
 // range behind it, so an empty list is the expected well-formed response;
 // the assertion targets the successful listing shape.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_DeploymentMergeRequests(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -363,7 +363,7 @@ func TestIndividual_DeploymentMergeRequests(t *testing.T) {
 // and asserts the system-defined Issue type is present with a populated GID,
 // which validates the GraphQL round-trip end to end on CE.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_WorkItemTypes(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/misc_meta_ce_test.go
+++ b/test/e2e/suite/misc_meta_ce_test.go
@@ -4,7 +4,7 @@
 // Covers feature flags, feature flag user lists, branch rules (GraphQL), CI/CD catalog (GraphQL),
 // deployments, and user SSH/GPG key listing for both individual and meta-tool modes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -29,7 +29,7 @@ import (
 // treats errors as fatal because the meta-tool requires the feature
 // flag API to be available in the running GitLab edition.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_FeatureFlags(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -55,7 +55,7 @@ func TestMeta_FeatureFlags(t *testing.T) {
 // have been defined; the assertion checks the call succeeds and logs
 // the count for visibility.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_BranchRules(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -101,7 +101,7 @@ func TestMeta_BranchRules(t *testing.T) {
 // have been published; the assertion checks the call succeeds and logs the
 // count for visibility.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CICatalog(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -124,7 +124,7 @@ func TestMeta_CICatalog(t *testing.T) {
 // triggered; the assertion checks the call succeeds and logs the count
 // for visibility.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Deployments(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -151,7 +151,7 @@ func TestMeta_Deployments(t *testing.T) {
 // purpose is to verify the meta-tool route works against the live
 // GitLab instance.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_UserKeys(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -182,7 +182,7 @@ func TestMeta_UserKeys(t *testing.T) {
 // rules. The list may be empty when no branch rules have been defined;
 // the assertion checks the call succeeds and logs the count.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_BranchRules(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/modes_ce_test.go
+++ b/test/e2e/suite/modes_ce_test.go
@@ -64,7 +64,7 @@ func modeSafePreview(text string) (tools.SafeModePreview, bool) {
 // operation, and the issue count taken afterwards through the unrestricted
 // session proves nothing was written.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: read-only.
+// Build tag: e2e. Mode: CE. Surface: read-only.
 func TestReadOnlyMode(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -160,7 +160,7 @@ func TestReadOnlyMode(t *testing.T) {
 // actions routed through the same gitlab_execute_action tool must execute
 // normally, and the project must be left untouched.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: dynamic safe-mode.
+// Build tag: e2e. Mode: CE. Surface: dynamic safe-mode.
 func TestSafeModeDynamicSurface(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/test/e2e/suite/mr_extras_ce_test.go
+++ b/test/e2e/suite/mr_extras_ce_test.go
@@ -4,7 +4,7 @@
 // GitLab instance: context commits (create/delete), to-do creation, related
 // issues, blocking dependencies listing, and MR pipeline creation.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -40,7 +40,7 @@ const mrExtrasCIYAML = `mr-check:
 // dependencies, and finally commits a merge-request-only CI configuration to
 // the source branch and triggers a detached MR pipeline.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_MRExtras(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/network_endpoints_ce_test.go
+++ b/test/e2e/suite/network_endpoints_ce_test.go
@@ -1,13 +1,15 @@
 //go:build e2e
 
 // network_endpoints_ce_test.go holds the Docker-network URL helper only the
-// Community Edition mirror suites read. It is split from
-// network_endpoints_test.go, which both halves of the suite compile, so that it
-// lives behind the constraint of its callers: under the Enterprise tag every
-// *_ce_test.go drops out and the helper was left unused, which nothing noticed
-// while nothing compiled that half outside a manual run (issue 570).
+// Community Edition mirror suites read. It was split from
+// network_endpoints_test.go when the suite was still two halves behind two
+// build tags, so that it lived behind the constraint of its callers: an
+// Enterprise compile dropped every *_ce_test.go and left the helper unused,
+// which nothing noticed while nothing compiled that half outside a manual run
+// (issue 570). Every file carries `e2e` alone now, and the file keeps its name
+// until the suite goes.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (

--- a/test/e2e/suite/package_extras_ce_test.go
+++ b/test/e2e/suite/package_extras_ce_test.go
@@ -6,7 +6,7 @@
 // publish-directory composite tools, and container registry protection rule
 // updates.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -81,7 +81,7 @@ func pkgExtrasCreateGroupProject(ctx context.Context, t *testing.T) (groups.Deta
 // registry listing asserts a successful (typically empty) response; it skips
 // gracefully when the instance has the container registry disabled.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_PackageGroupExtras(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()
@@ -163,7 +163,7 @@ func TestIndividual_PackageGroupExtras(t *testing.T) {
 // asserting per-file results and totals. Both tools run against the
 // in-process MCP server, so local temp paths are directly readable.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_PackagePublishComposite(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()
@@ -234,7 +234,7 @@ func TestIndividual_PackagePublishComposite(t *testing.T) {
 // pushed container image and therefore stay uncovered until the Wave-4 image
 // push enabler lands.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_PackageRegistryRules(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/package_registry_images_ce_test.go
+++ b/test/e2e/suite/package_registry_images_ce_test.go
@@ -12,7 +12,7 @@
 // empty-tar gzip layer through the registry v2 blob upload protocol, and
 // PUTs one manifest per tag.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -190,7 +190,7 @@ func pkgImgPushImage(ctx context.Context, t *testing.T, registryURL, repository,
 // tag, and finally registry_delete for the whole repository. The repository
 // ID is discovered through the already-covered registry_list_project action.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only, needs :5050 registry). Surface: meta.
+// Build tag: e2e. Mode: CE (Docker only, needs :5050 registry). Surface: meta.
 func TestMeta_PackageRegistryImages(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/pipeline_extras_ce_test.go
+++ b/test/e2e/suite/pipeline_extras_ce_test.go
@@ -6,7 +6,7 @@
 // pipeline creation succeeds with jobs left pending, which is enough for the
 // resource group to materialize and for the trigger run to return a pipeline.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -57,7 +57,7 @@ func pipelineExtrasSetupProject(ctx context.Context, t *testing.T) ProjectFixtur
 // exist, and the upcoming jobs listing is asserted only for shape since the
 // queue content depends on runner activity.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_PipelineResourceGroups(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -124,7 +124,7 @@ func TestIndividual_PipelineResourceGroups(t *testing.T) {
 // triggered pipeline is left pending (no runner needed) and is removed with
 // the project fixture.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_PipelineTriggerRun(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/project_extras2_ce_test.go
+++ b/test/e2e/suite/project_extras2_ce_test.go
@@ -5,7 +5,7 @@
 // group integration configuration (including Jira and group Datadog), and
 // the Pages write actions (settings update, custom domains, unpublish).
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -66,7 +66,7 @@ func projectExtrasSkipIfPagesDisabled(t *testing.T, err error, action string) {
 // and re-imports it as a new project via import_from_file. The imported
 // project is registered for permanent deletion in the per-test ledger.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectExportDownloadImport(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -189,7 +189,7 @@ func TestMeta_ProjectExportDownloadImport(t *testing.T) {
 // removes both integrations via integration_delete. Assertions check the
 // integration slug round-trips and reads report an active integration.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectIntegrationConfig(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -292,7 +292,7 @@ func TestMeta_ProjectIntegrationConfig(t *testing.T) {
 // exercised against the fresh group where no Datadog integration exists, so
 // both are asserted to return the documented not-configured error.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectGroupIntegrations(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -426,7 +426,7 @@ func projectExtrasDeployPages(ctx context.Context, t *testing.T, proj ProjectFix
 // and unpublish are asserted strictly. On self-hosted instances without
 // Pages each call site converts the rejection into a documented skip.
 //
-// Build tag: e2e && !enterprise. Mode: CE (full assertions need the Docker
+// Build tag: e2e. Mode: CE (full assertions need the Docker
 // runner). Surface: meta.
 func TestMeta_ProjectPagesWrite(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/suite/project_extras_ce_test.go
+++ b/test/e2e/suite/project_extras_ce_test.go
@@ -5,7 +5,7 @@
 // sharing, avatar upload/download, restore, transfer, create-for-user, fork
 // relations, markdown upload deletion, and forced push-mirror sync.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -113,7 +113,7 @@ func projectExtrasUploadRef(t *testing.T, uploadURL string) (string, string) {
 // member_edit (raise to Maintainer), and member_delete. Each subtest asserts
 // the returned membership carries the expected user ID and access level.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta.
 func TestMeta_ProjectMemberLifecycle(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -188,7 +188,7 @@ func TestMeta_ProjectMemberLifecycle(t *testing.T) {
 // delete_shared_group. Assertions check the share echoes the group ID and
 // that the invited-groups list contains the helper group.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectGroupSharing(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -264,7 +264,7 @@ func TestMeta_ProjectGroupSharing(t *testing.T) {
 // the upload round-trips to the same project and the downloaded image is
 // non-empty base64 content.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectAvatar(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -313,7 +313,7 @@ func TestMeta_ProjectAvatar(t *testing.T) {
 // delayed-deletion window), the restore call returns 404 and the test skips
 // with a documented reason instead of failing.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectRestore(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -370,7 +370,7 @@ func TestMeta_ProjectRestore(t *testing.T) {
 // group, then transfers it back to the personal namespace so the fixture
 // cleanup path stays valid.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectTransfer(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -423,7 +423,7 @@ func TestMeta_ProjectTransfer(t *testing.T) {
 // and asserts the resulting project lives in the target user's namespace.
 // The project and user are cleaned up through the per-test ledger.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta. Admin token required.
 func TestMeta_ProjectCreateForUser(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -462,7 +462,7 @@ func TestMeta_ProjectCreateForUser(t *testing.T) {
 // endpoint answers with names the expected upstream, then removes the
 // relationship via delete_fork_relation.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectForkRelations(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -522,7 +522,7 @@ func TestMeta_ProjectForkRelations(t *testing.T) {
 // subtest skips on instances older than GitLab 17.3, which do not return
 // upload IDs.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectUploadDeletes(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -611,7 +611,7 @@ func TestMeta_ProjectUploadDeletes(t *testing.T) {
 // mode only: the mirror target URL is a Docker network address that GitLab
 // cannot resolve in self-hosted runs.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: meta.
+// Build tag: e2e. Mode: CE (Docker only). Surface: meta.
 func TestMeta_ProjectMirrorForcePush(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/project_mirrors_ce_test.go
+++ b/test/e2e/suite/project_mirrors_ce_test.go
@@ -24,7 +24,7 @@ import (
 //
 // Remote mirrors are a Free-tier feature (push mirrors).
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectRemoteMirrors(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/suite/projects_meta_ce_test.go
+++ b/test/e2e/suite/projects_meta_ce_test.go
@@ -32,7 +32,7 @@ import (
 // documented action returns the expected payload and that mutations are
 // observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectCore(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -238,7 +238,7 @@ func TestMeta_ProjectCore(t *testing.T) {
 // returns the expected webhook metadata and that mutations are observable
 // through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectHooks(t *testing.T) {
 	t.Parallel()
 
@@ -434,7 +434,7 @@ func TestMeta_ProjectHooks(t *testing.T) {
 // meta-tool returns the expected payload and that subscription/promotion
 // mutations are observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectLabelsDeep(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -543,7 +543,7 @@ func TestMeta_ProjectLabelsDeep(t *testing.T) {
 // expected payload and that filtering by milestone ID produces non-empty
 // result sets.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectMilestonesDeep(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -617,7 +617,7 @@ func TestMeta_ProjectMilestonesDeep(t *testing.T) {
 // returns the expected membership payload and that mutations are
 // observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectMembersDeep(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -651,7 +651,7 @@ func TestMeta_ProjectMembersDeep(t *testing.T) {
 // catalog-backed tool. Each subtest asserts the meta-tool returns the
 // expected payload with non-empty badge metadata and rendered SVG content.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectBadgesDeep(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -722,7 +722,7 @@ func TestMeta_ProjectBadgesDeep(t *testing.T) {
 // subtest asserts the meta-tool returns the expected board payload and that
 // mutations are observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectBoardsDeep(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -877,7 +877,7 @@ func TestMeta_ProjectBoardsDeep(t *testing.T) {
 // meta-tool returns the expected approval payload and that mutations are
 // observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectApprovals(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -1023,7 +1023,7 @@ func TestMeta_ProjectApprovals(t *testing.T) {
 // map to the documented meta-tool routes and that the export payload matches
 // the requested export options.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectExport(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -1077,7 +1077,7 @@ func TestMeta_ProjectExport(t *testing.T) {
 // step asserts the meta-tool returns the expected integration metadata and
 // that mutations are observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectIntegrations(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -1107,7 +1107,7 @@ func TestMeta_ProjectIntegrations(t *testing.T) {
 // Pages metadata. Assertions cover the project ID round-trip and the presence
 // of the documented Pages fields in the response payload.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProjectPages(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/protected_tags_ce_test.go
+++ b/test/e2e/suite/protected_tags_ce_test.go
@@ -20,7 +20,7 @@ import (
 // action returns the expected payload and that the tag name round-trips
 // through GitLab correctly.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ProtectedTags(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/releases_ce_test.go
+++ b/test/e2e/suite/releases_ce_test.go
@@ -24,7 +24,7 @@ import (
 // verify the release name, tag name, and link URLs round-trip through the
 // GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Releases(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -160,7 +160,7 @@ func TestIndividual_Releases(t *testing.T) {
 // Subtests cover create, list, get, update, and delete, then exercise the
 // link create, list, get, update, and delete actions.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Releases(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/releases_meta_ce_test.go
+++ b/test/e2e/suite/releases_meta_ce_test.go
@@ -23,7 +23,7 @@ import (
 // meta-tool returns the expected link payload and that mutations are
 // observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_ReleaseLinksExtended(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/repository_ce_test.go
+++ b/test/e2e/suite/repository_ce_test.go
@@ -20,7 +20,7 @@ import (
 // tool surface. Each subtest asserts the expected payload shape and that
 // the file paths and commit SHAs round-trip through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Repository(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -82,7 +82,7 @@ func TestIndividual_Repository(t *testing.T) {
 // catalog-backed tool. Assertions cover the file paths, commit SHAs, and
 // diff entries returned by the meta-tool for the documented routes.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Repository(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/repository_extras_ce_test.go
+++ b/test/e2e/suite/repository_extras_ce_test.go
@@ -6,7 +6,7 @@
 // commit, changelog generation and committing, and submodule listing plus the
 // submodule file read path.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -47,7 +47,7 @@ func repoExtrasBlobSHA(ctx context.Context, t *testing.T, proj ProjectFixture, f
 // asserts the SHA round-trips and the decoded text content matches what was
 // committed.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_RepositoryBlobs(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -94,7 +94,7 @@ func TestIndividual_RepositoryBlobs(t *testing.T) {
 // the branches diverge, and asserts the reported merge base equals the commit
 // the branch was created from.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_RepositoryMergeBase(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -131,7 +131,7 @@ func TestIndividual_RepositoryMergeBase(t *testing.T) {
 // check runs before the revert so the MR diff is still non-empty when GitLab
 // computes it.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_CommitRevertMergeRequests(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -206,7 +206,7 @@ func TestIndividual_CommitRevertMergeRequests(t *testing.T) {
 // fixture project has no previous semver tag for GitLab to infer the range
 // start from.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_RepositoryChangelog(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -264,7 +264,7 @@ func TestIndividual_RepositoryChangelog(t *testing.T) {
 // exists. A positive read requires a repository with a real submodule, which
 // cannot be provisioned through the available tools.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_RepositorySubmodules(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/repository_meta_ce_test.go
+++ b/test/e2e/suite/repository_meta_ce_test.go
@@ -30,7 +30,7 @@ import (
 // meta-tool returns the expected file payload and that mutations are
 // observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_RepositoryFiles(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -141,7 +141,7 @@ func TestMeta_RepositoryFiles(t *testing.T) {
 // asserts the meta-tool returns the expected payload with non-empty
 // contributor and snapshot metadata.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_RepositoryExplore(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -185,7 +185,7 @@ func TestMeta_RepositoryExplore(t *testing.T) {
 // subtest asserts the meta-tool returns the expected payload and that
 // mutations are observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CommitExtended(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -331,7 +331,7 @@ func TestMeta_CommitExtended(t *testing.T) {
 // action returns the expected discussion metadata and that the resolved flag
 // is observed by a follow-up read.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_CommitDiscussions(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -444,7 +444,7 @@ const InvalidCommitSHA = "0000000000000000000000000000000000000000"
 // rather than crashing, validating the action spec wiring for the
 // submodule_update route.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_SubmoduleUpdate(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/runner_extras_ce_test.go
+++ b/test/e2e/suite/runner_extras_ce_test.go
@@ -9,7 +9,7 @@
 // Throwaway runners are registered paused and tagged so they can never pick
 // up suite jobs, and the shared compose runner is never touched.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -37,7 +37,7 @@ const runnerExtrasToolRegister = "gitlab_runner_register"
 // legacy flow the affected subtests skip with a documented reason instead of
 // failing.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_RunnerExtras(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()
@@ -82,7 +82,7 @@ func TestIndividual_RunnerExtras(t *testing.T) {
 // token. Rotating the token is safe there because already-registered runners
 // authenticate with their own auth tokens, not the registration token.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_RunnerExtrasInstanceRegToken(t *testing.T) {
 	if sess.individual == nil {
 		t.Skip("individual session not configured")

--- a/test/e2e/suite/runner_meta_ce_test.go
+++ b/test/e2e/suite/runner_meta_ce_test.go
@@ -27,7 +27,7 @@ import (
 // expected runner payload and that mutations are observable through
 // subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Runner(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")

--- a/test/e2e/suite/safe_mode_ce_test.go
+++ b/test/e2e/suite/safe_mode_ce_test.go
@@ -23,7 +23,7 @@ import (
 // executing it; read-only calls must pass through and return the
 // expected payload.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: safe-mode.
+// Build tag: e2e. Mode: CE. Surface: safe-mode.
 func TestSafeMode(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/test/e2e/suite/schema_compliance_ce_test.go
+++ b/test/e2e/suite/schema_compliance_ce_test.go
@@ -21,7 +21,7 @@ import (
 // lockdown. This prevents LLMs from silently passing unknown arguments
 // that would otherwise round-trip silently through the GitLab API.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual, meta.
+// Build tag: e2e. Mode: CE. Surface: individual, meta.
 func TestSchema_AdditionalPropertiesFalse(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -88,7 +88,7 @@ func TestSchema_AdditionalPropertiesFalse(t *testing.T) {
 // action spec catalog. This guards against regressions where a meta-tool
 // is registered without a matching output schema.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestSchema_MetaToolsHaveOutputSchema(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -121,7 +121,7 @@ func TestSchema_MetaToolsHaveOutputSchema(t *testing.T) {
 // the pagination output enrichment pipeline that exposes a uniform
 // pagination contract across every list tool.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestSchema_PaginationHasMore(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil && sess.meta == nil {

--- a/test/e2e/suite/scope_filter_ce_test.go
+++ b/test/e2e/suite/scope_filter_ce_test.go
@@ -33,7 +33,7 @@ import (
 // Assertions check that admin-only meta-tools are removed, regular
 // meta-tools are still present, and the read_api scope is observed.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestScopeFilter_NonAdminToken(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not available")
@@ -170,7 +170,7 @@ func TestScopeFilter_NonAdminToken(t *testing.T) {
 // names keeps the test tier-independent: a group absent on this runtime is
 // absent from both sides.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE. Surface: meta. Admin token required.
 func TestScopeFilter_AdminToken(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not available")

--- a/test/e2e/suite/search_ce_test.go
+++ b/test/e2e/suite/search_ce_test.go
@@ -21,7 +21,7 @@ import (
 // surface. Each subtest asserts the expected payload shape with non-empty
 // results matching the unique content marker.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Search(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -67,7 +67,7 @@ func TestIndividual_Search(t *testing.T) {
 // meta-tool returns consistent payloads with non-empty results matching
 // the unique content marker.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Search(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/search_meta_ce_test.go
+++ b/test/e2e/suite/search_meta_ce_test.go
@@ -26,7 +26,7 @@ import (
 // notes, snippets, global, and commits. Each subtest asserts the action
 // returns successfully with the expected payload shape.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_SearchExtended(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/search_type_ce_test.go
+++ b/test/e2e/suite/search_type_ce_test.go
@@ -27,7 +27,7 @@ import (
 // the search returns the expected payload and that the basic search type
 // does not produce validation errors.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual, meta.
+// Build tag: e2e. Mode: CE. Surface: individual, meta.
 func TestSearchType_BasicSearchWorks(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -80,7 +80,7 @@ func TestSearchType_BasicSearchWorks(t *testing.T) {
 // through to the GitLab API. The same checks run for the catalog-backed
 // meta-tool search action.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual, meta.
+// Build tag: e2e. Mode: CE. Surface: individual, meta.
 func TestSearchType_InvalidValueFails(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -122,7 +122,7 @@ func TestSearchType_InvalidValueFails(t *testing.T) {
 // against accidental schema regressions that would weaken input
 // validation for both surfaces.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual, meta.
+// Build tag: e2e. Mode: CE. Surface: individual, meta.
 func TestSearchType_SchemasExposeEnum(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/snippets_ce_test.go
+++ b/test/e2e/suite/snippets_ce_test.go
@@ -20,7 +20,7 @@ import (
 // round-trip through the GitLab API. Cleanup removes the snippet when the
 // test exits, even on failure.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Snippets(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -103,7 +103,7 @@ func TestIndividual_Snippets(t *testing.T) {
 // cover create, get, content, list, update, and delete, verifying the
 // meta-tool returns consistent payloads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Snippets(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/snippets_meta_ce_test.go
+++ b/test/e2e/suite/snippets_meta_ce_test.go
@@ -26,7 +26,7 @@ import (
 // the expected snippet metadata and that mutations are observable through
 // subsequent reads. Cleanup removes the snippet when the test exits.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_SnippetsPersonal(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -106,7 +106,7 @@ func TestMeta_SnippetsPersonal(t *testing.T) {
 // subtest asserts the meta-tool returns the expected snippet metadata and
 // that the file content round-trips correctly.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_SnippetsProject(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -205,7 +205,7 @@ func TestMeta_SnippetsProject(t *testing.T) {
 // meta-tool returns the expected discussion metadata and that the resolved
 // flag is observable through a follow-up read.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_SnippetDiscussions(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -337,7 +337,7 @@ func TestMeta_SnippetDiscussions(t *testing.T) {
 // meta-tool returns the expected note metadata and that mutations are
 // observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_SnippetNotes(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -448,7 +448,7 @@ func TestMeta_SnippetNotes(t *testing.T) {
 // asserts the meta-tool returns the expected emoji metadata and that
 // removal is observed through a follow-up list call.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_SnippetEmoji(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/state_events_ce_test.go
+++ b/test/e2e/suite/state_events_ce_test.go
@@ -22,7 +22,7 @@ import (
 // event listing. Each subtest asserts the meta-tool returns the expected
 // state event payload with the documented action types.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_StateEvents(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/tags_ce_test.go
+++ b/test/e2e/suite/tags_ce_test.go
@@ -21,7 +21,7 @@ import (
 // Each subtest asserts the tag name and target SHA round-trip through the
 // GitLab API, and cleanup removes the tag and release on test exit.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Tags(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -101,7 +101,7 @@ func TestIndividual_Tags(t *testing.T) {
 // Subtests cover create, list, get, update, delete, and release_create off
 // the resulting tag, verifying the meta-tool returns consistent payloads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Tags(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/tags_meta_ce_test.go
+++ b/test/e2e/suite/tags_meta_ce_test.go
@@ -22,7 +22,7 @@ import (
 // asserts the meta-tool returns the expected protected-tag payload and
 // that protection mutations are observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_TagsProtected(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/templates_ce_test.go
+++ b/test/e2e/suite/templates_ce_test.go
@@ -23,7 +23,7 @@ import (
 // returns the expected template payload and that get operations return
 // non-empty template content.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Templates(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -57,7 +57,7 @@ func TestMeta_Templates(t *testing.T) {
 // the rendered headings and links from the input. The test does not create
 // any GitLab resources and runs without a project fixture.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_MarkdownRender(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/templates_meta_ce_test.go
+++ b/test/e2e/suite/templates_meta_ce_test.go
@@ -26,7 +26,7 @@ import (
 // asserts the meta-tool returns the expected template payload and that the
 // fetched template content is non-empty.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_TemplatesCIYml(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -66,7 +66,7 @@ func TestMeta_TemplatesCIYml(t *testing.T) {
 // subtest asserts the meta-tool returns the expected template payload and
 // that the fetched Dockerfile content is non-empty.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_TemplatesDockerfile(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -105,7 +105,7 @@ func TestMeta_TemplatesDockerfile(t *testing.T) {
 // subtest asserts the meta-tool returns the expected template payload and
 // that the fetched gitignore content is non-empty.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_TemplatesGitignore(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -144,7 +144,7 @@ func TestMeta_TemplatesGitignore(t *testing.T) {
 // Each subtest asserts the meta-tool returns the expected template payload
 // and that the fetched license content is non-empty.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_TemplatesLicense(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -188,7 +188,7 @@ const templatePageBudget = 10
 // meta-tool returns the expected template payload. Get actions verify the
 // fetched project template content is non-empty.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_TemplatesProject(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/todos_ce_test.go
+++ b/test/e2e/suite/todos_ce_test.go
@@ -23,7 +23,7 @@ import (
 // asserts the todo payload shape and that mark_all_done clears pending
 // todos in a follow-up list call.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Todos(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -56,7 +56,7 @@ func TestIndividual_Todos(t *testing.T) {
 // returns consistent todo payloads and that mark_all_done clears pending
 // todos in a follow-up list call.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Todos(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/uploads_ce_test.go
+++ b/test/e2e/suite/uploads_ce_test.go
@@ -7,7 +7,7 @@
 // gitlab_upload_get, gitlab_upload_list) and the catalog-backed
 // gitlab_project meta-tool surface for upload actions.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -28,7 +28,7 @@ import (
 // subtest asserts the expected upload payload shape with non-empty name
 // and URL.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Uploads(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -72,7 +72,7 @@ func TestIndividual_Uploads(t *testing.T) {
 // content, verifying the meta-tool returns consistent upload payloads
 // with non-empty name and URL.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Uploads(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/user_extras2_ce_test.go
+++ b/test/e2e/suite/user_extras2_ce_test.go
@@ -11,7 +11,7 @@
 // All tests here need an admin token and mutate instance-level state, so
 // they are gated to Docker mode where the GitLab instance is disposable.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -97,7 +97,7 @@ func userExtrasCreateUser(ctx context.Context, t *testing.T, prefix string, muta
 // embedded GPG fixture key to it, reads the key back, and deletes it. All
 // three actions require an admin token.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_UserGPGKeysForUser(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -156,7 +156,7 @@ func TestIndividual_UserGPGKeysForUser(t *testing.T) {
 // seed an identity without a real OAuth flow), then deletes that identity
 // via MCP and asserts the confirmation payload.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_UserDeleteIdentity(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -196,7 +196,7 @@ func TestIndividual_UserDeleteIdentity(t *testing.T) {
 // via the raw admin API so the fixture runner of the Docker compose stack is
 // never touched.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_UserCreateRunner(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -233,7 +233,7 @@ func TestIndividual_UserCreateRunner(t *testing.T) {
 // deletes its user and the approved user is removed in cleanup. Docker mode
 // only: the seeded fixtures exist only on the disposable instance.
 //
-// Build tag: e2e && !enterprise. Mode: Docker. Surface: individual.
+// Build tag: e2e. Mode: Docker. Surface: individual.
 func TestIndividual_UserApproveReject(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -294,7 +294,7 @@ func TestIndividual_UserApproveReject(t *testing.T) {
 // user", HTTP 400) instead of a transport failure. This exercises the full
 // MCP round-trip for the action with the only state reachable in E2E.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual. Admin token required.
 func TestIndividual_UserDisableTwoFactor(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/user_extras_ce_test.go
+++ b/test/e2e/suite/user_extras_ce_test.go
@@ -7,7 +7,7 @@
 // (user.key_get_by_fingerprint), avatar upload (user.upload_avatar), and
 // marking a single todo done (user.todo_mark_done).
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -86,7 +86,7 @@ func userExtrasSSHKey(t *testing.T) (string, string) {
 // deferred best-effort delete guards against leftovers if the delete subtest
 // never runs.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_UserEmails(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -143,7 +143,7 @@ func TestIndividual_UserEmails(t *testing.T) {
 // runs in Docker mode only where the whole instance is disposable and a
 // crashed previous run cannot leave a colliding fingerprint behind.
 //
-// Build tag: e2e && !enterprise. Mode: CE (Docker only). Surface: individual.
+// Build tag: e2e. Mode: CE (Docker only). Surface: individual.
 func TestIndividual_UserGPGKeys(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -203,7 +203,7 @@ func TestIndividual_UserGPGKeys(t *testing.T) {
 // the admin-only fingerprint lookup endpoint, asserting the IDs match. The
 // key is removed via a deferred delete.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE. Surface: individual. Admin token required.
 func TestIndividual_UserKeyByFingerprint(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -241,7 +241,7 @@ func TestIndividual_UserKeyByFingerprint(t *testing.T) {
 // avatar URL. GitLab keeps exactly one avatar per user, so no cleanup is
 // needed beyond the upload replacing whatever was there.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_UserAvatarUpload(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -272,7 +272,7 @@ func TestIndividual_UserAvatarUpload(t *testing.T) {
 // setup), then marks that todo done via MCP and asserts the confirmation
 // echoes the todo ID.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_UserTodoMarkDone(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {

--- a/test/e2e/suite/user_projects_ce_test.go
+++ b/test/e2e/suite/user_projects_ce_test.go
@@ -20,7 +20,7 @@ import (
 // each tool returns the expected payload shape. The test does not create
 // any GitLab resources and runs without a project fixture.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_UserProjects(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -51,7 +51,7 @@ func TestIndividual_UserProjects(t *testing.T) {
 // catalog-backed tool. Each subtest asserts the meta-tool returns the
 // expected payload shape.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_UserProjects(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/e2e/suite/users_ce_test.go
+++ b/test/e2e/suite/users_ce_test.go
@@ -9,7 +9,7 @@
 // surface. Also validates catalog-projected tool registration through
 // the individual session.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (
@@ -30,7 +30,7 @@ import (
 // individual tool surface returns consistent user metadata. The test
 // does not create any resources.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Users(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -76,7 +76,7 @@ func TestIndividual_Users(t *testing.T) {
 // tool surface. Each subtest asserts the meta-tool returns the expected
 // user payload and that mutations are observable through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE. Surface: individual. Admin token required.
 func TestIndividual_UserManagement(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -161,7 +161,7 @@ func TestIndividual_UserManagement(t *testing.T) {
 // registered with the expected destructiveHint/readOnlyHint annotations
 // and JSON-schema-derived input/output schemas.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual. Admin token required.
+// Build tag: e2e. Mode: CE. Surface: individual. Admin token required.
 func TestIndividual_UserManagementCatalogProjection(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -219,7 +219,7 @@ func assertUserToolProjection(t *testing.T, tools []*mcp.Tool, name string, requ
 // returns consistent user metadata for the current user and the listed
 // users. The test does not create any resources.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Users(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/users_meta_ce_test.go
+++ b/test/e2e/suite/users_meta_ce_test.go
@@ -34,7 +34,7 @@ import (
 // get_status, emails, contribution_events, associations_count, memberships,
 // and avatar_get, asserting each action returns the expected payload shape.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_UserSelf(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -166,7 +166,7 @@ func TestMeta_UserSelf(t *testing.T) {
 // and event_list_project to verify those actions return consistent payloads.
 // Cleanup removes the project and the lingering todos when the test exits.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_UserTodosEvents(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -225,7 +225,7 @@ func TestMeta_UserTodosEvents(t *testing.T) {
 // sub-actions, then confirms the original global notification level survives
 // every change by re-reading it after each mutating step.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_UserNamespacesNotifications(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -389,7 +389,7 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 // asserting the registered key shows up in the listing and disappears after
 // deletion. Cleanup removes the key when the test exits, even on failure.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_UserSSHKeyLifecycle(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {
@@ -454,7 +454,7 @@ func TestMeta_UserSSHKeyLifecycle(t *testing.T) {
 //
 // Cleanup unblocks and deletes the user when the test exits, even on failure.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta. Admin token required.
+// Build tag: e2e. Mode: CE. Surface: meta. Admin token required.
 //
 //nolint:maintidx // Ordered admin E2E workflow keeps one created user lifecycle visible through cleanup.
 func TestMeta_UserAdmin(t *testing.T) {
@@ -789,7 +789,7 @@ func TestMeta_UserAdmin(t *testing.T) {
 // The PAT subtest runs on every tier and confirms the issued token resolves
 // to the expected user and expires in the future.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_UserServiceAccounts(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/wait_ce_test.go
+++ b/test/e2e/suite/wait_ce_test.go
@@ -33,7 +33,7 @@ wait-job:
 // helper) to validate the MCP server wrapping. It exercises both the
 // individual session and the catalog-backed meta-tool session.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual, meta.
+// Build tag: e2e. Mode: CE. Surface: individual, meta.
 func TestWaitTools(t *testing.T) {
 	if !sess.enterprise {
 		t.Parallel()

--- a/test/e2e/suite/wikis_ce_test.go
+++ b/test/e2e/suite/wikis_ce_test.go
@@ -21,7 +21,7 @@ import (
 // slug and content round-trip through the GitLab API. Cleanup removes the
 // page (and its project fixture) when the test exits.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: individual.
+// Build tag: e2e. Mode: CE. Surface: individual.
 func TestIndividual_Wikis(t *testing.T) {
 	t.Parallel()
 	if sess.individual == nil {
@@ -102,7 +102,7 @@ func TestIndividual_Wikis(t *testing.T) {
 // meta-tool returns consistent payloads and that mutations are observable
 // through subsequent reads.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_Wikis(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/wikis_meta_ce_test.go
+++ b/test/e2e/suite/wikis_meta_ce_test.go
@@ -23,7 +23,7 @@ import (
 // non-empty file name and path. This complements the CRUD coverage in the
 // wikis test.
 //
-// Build tag: e2e && !enterprise. Mode: CE. Surface: meta.
+// Build tag: e2e. Mode: CE. Surface: meta.
 func TestMeta_WikiUploadAttachment(t *testing.T) {
 	t.Parallel()
 	if sess.meta == nil {

--- a/test/e2e/suite/work_item_saved_views_ce_test.go
+++ b/test/e2e/suite/work_item_saved_views_ce_test.go
@@ -9,7 +9,7 @@
 // doubles as the availability probe: when it fails, the test skips rather than
 // failing an otherwise healthy suite on an older instance.
 //
-// Build tag: e2e && !enterprise.
+// Build tag: e2e.
 package suite
 
 import (


### PR DESCRIPTION
Step S16 of the e2e rebuild (issue 704): the enterprise analysis pass and every mention of the tag are gone, so one compile and one analysis run see every file under `test/e2e`.

Makefile: `GO_ANALYSIS_ENTERPRISE_TAGS`, `GO_ANALYSIS_ENTERPRISE_PKGS` and their comment deleted, the second `golangci-lint run` deleted from the lint target, the enterprise step deleted from `analyze` and the remaining steps renumbered 1 to 15 (with the six citations of those numbers in `docs/development/cmd-utilities.md` following), and `E2E_DOCKER_ENTERPRISE_TIMEOUT` and `E2E_GITLAB_TIMEOUT` documented as applying per package binary. CI: the second compile under `e2e enterprise` deleted, the remaining one saying why it suffices. `cmd/gen_testing_docs` loses its enterprise paragraph. The documents that described the tag are rewritten around `make test-e2e-ee` and the `common` and `ee` packages: `static-analysis.md`, `enterprise-schema-checks.md`, `test/e2e/README.md`, the prose of `testing.md`, `CLAUDE.md`, and the English and Spanish `docker-testing.mdx` pages of the site. The 296 `// Build tag: e2e && !enterprise.` doc-comment lines of the old CE files, which S15's constraint change had left stale, now read `e2e`.

One match of the verification pattern stays on purpose: `test/e2e/internal/harness/sources_test.go` carries `//go:build e2e && enterprise` as the fixture of the static gate's wrong-tag case, which is the regression guard against the tag coming back.

Verified: the pattern sweep finds that one line only; `make golangci-lint` runs one pass, clean; `make analyze` counts 15 steps; `go test ./cmd/gen_testing_docs/` passes; markdownlint on every changed page and the site's full lint set (i18n, format, chips, facts, llms, contrast, eslint, astro check) all pass.

The generated counts are refreshed here, at the top of the stack: the golden individual snapshot carries the approval rule schemas and the Premium mark on the group board delete, and the llms files, the token footprint, the README and site stats, the testing reference and the prose that counted 866 Free tools follow.
